### PR TITLE
Install to internal storage - calling armbian-install script

### DIFF
--- a/lib/armbian-configng/config.ng.jobs.json
+++ b/lib/armbian-configng/config.ng.jobs.json
@@ -74,7 +74,7 @@
                     "doc_link": "https://github.com/armbian/config/wiki#System",
                     "src_reference": "",
                     "author": "https://github.com/igorpecovnik",
-                    "condition": ""
+                    "condition": "[[ -n $(ls /sbin/armbian-install) ]]"
                 }
 
             ]

--- a/lib/armbian-configng/config.ng.jobs.json
+++ b/lib/armbian-configng/config.ng.jobs.json
@@ -63,7 +63,20 @@
                     "src_reference": "https://github.com/armbian/config/blob/master/debian-config-jobs#L160",
                     "author": "https://github.com/Tearran",
                     "condition": "are_headers_installed"
+                },
+                {
+                    "id": "S06",
+                    "description": "Install to internal storage",
+                    "command": [
+                        "armbian-install"
+                    ],
+                    "status": "Pending Review",
+                    "doc_link": "https://github.com/armbian/config/wiki#System",
+                    "src_reference": "",
+                    "author": "https://github.com/igorpecovnik",
+                    "condition": ""
                 }
+
             ]
         },
         {


### PR DESCRIPTION
# Description

As title says.

# Implementation Details

Simple command execution. armbian-install is a part of BSP. Must be present ... do we need to check for presence?

# Testing Procedure

- [x] It opens and returns to armbian-config as expected

# Checklist

- [x] My code follows the style guidelines of this project
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
