### PR TITLE
Refactoring network configuration

### DIFF
--- a/lib/armbian-configng/config.ng.functions.sh
+++ b/lib/armbian-configng/config.ng.functions.sh
@@ -540,7 +540,14 @@ module_options+=(
 #
 function execute_command() {
     local id=$1
-    local commands=$(jq -r --arg id "$id" '.menu[] | .. | objects | select(.id==$id) | .command[]' "$json_file")
+    #local commands=$(jq -r --arg id "$id" '.menu[] | .. | objects | select(.id==$id) | .command[]' "$json_file")
+    local commands=$(jq -r --arg id "$id" '
+  .menu[] | 
+  .. | 
+  objects | 
+  select(.id == $id) | 
+  .command[]?' "$json_file")
+    
     for command in "${commands[@]}"; do
         # Check if the command is not in the list of restricted commands       
             [[ -n "$debug" ]] && echo "$command"

--- a/lib/armbian-configng/config.ng.jobs.json
+++ b/lib/armbian-configng/config.ng.jobs.json
@@ -287,47 +287,59 @@
                     "description": "Configure network interfaces",
                     "sub": [
                             {
-                                "id": "N03",
+                                "id": "N02",
                                 "description": "Wired",
                                 "sub": [
                                     {
-                                        "id": "N04",
-                                        "description": "Show configuration",                                    
-                                        "command": [ "show_message <<< \"$(sudo netplan get ethernets)\"" ],
-                                        "condition": "[ -f /etc/netplan/30-*static-interfaces.yaml ] || [ -f /etc/netplan/10-dhcp-all-interfaces.yaml ]",
+                                        "id": "N06",
+                                        "description": "Show configuration",
+                                        "command": [ "netplan_wrapper \"show_message\" \"\" \"\" \"ethernets\"" ],
                                         "status": "Active",
-                                        "author": "Igor Pecovnik"
+                                        "doc_link": "",
+                                        "src_reference": "",
+                                        "author": "Igor Pecovnik",
+                                        "condition": "[ -f /etc/netplan/30-*static-interfaces.yaml ] || [ -f /etc/netplan/10-dhcp-all-interfaces.yaml ]"
                                     },
                                     {
-                                        "id": "N05",
+                                        "id": "N07",
                                         "description": "Enable DHCP on all interfaces",
-                                        "command": [
-                                                    "rm -f /etc/netplan/30-*-static-interfaces.yaml",
-                                                    "netplan set --origin-hint 10-dhcp-all-interfaces renderer=networkd",
-                                                    "netplan set --origin-hint 10-dhcp-all-interfaces ethernets.all-eth-interfaces.dhcp4=true",
-                                                    "netplan set --origin-hint 10-dhcp-all-interfaces ethernets.all-eth-interfaces.dhcp6=true",
-                                                    "netplan set --origin-hint 10-dhcp-all-interfaces ethernets.all-eth-interfaces.match.name=e*",
-                                                    "show_message <<< \"$(sudo netplan get ethernets)\""
-                                                ],
+                                        "command": [ "netplan_wrapper \"dhcp_all_wired_interfaces\" \"false\" \"10-dhcp-all-interfaces\" \"ethernets\" \"networkd\"" ],
                                         "status": "Active",
                                         "author": "Igor Pecovnik",
                                         "condition": "[ ! -f /etc/netplan/10-dhcp-all-interfaces.yaml ]"
                                     },
                                     {
-                                        "id": "N06",
+                                        "id": "N08",
                                         "description": "Set fixed IP address",
-                                        "command": [
-                                                        "choose_adapter \"e\"",
-                                                        "[[ -n \"$IP_ADDRESS\" ]] && netplan_wrapper \"10-dhcp-all-interfaces\" \"ethernets\" \"networkd\" \"${SELECTED_ADAPTER}\" \"$IP_ADDRESS\""
-                                                   ],
+                                        "command": [" netplan_wrapper \"set_ip\" \"true\" \"10-dhcp-all-interfaces\" \"ethernets\" \"networkd\""],
                                         "status": "Active",
                                         "doc_link": "",
                                         "src_reference": "",
                                         "author": "Igor Pecovnik",
-                                        "condition": "[ -f /etc/netplan/10-dhcp-all-interfaces.yaml ] || true"
+                                        "condition": ""
                                     },
                                     {
-                                        "id": "N07",
+                                        "id": "N09",
+                                        "description": "Disable IPV6",
+                                        "command": [" netplan_wrapper \"disable_ipv6\" \"false\" \"10-dhcp-all-interfaces\" \"ethernets\" \"networkd\""],
+                                        "status": "Pending Review",
+                                        "doc_link": "",
+                                        "src_reference": "",
+                                        "author": "Igor Pecovnik",
+                                        "condition": "[ -f /etc/netplan/30-*static-interfaces.yaml ] || [ -f /etc/netplan/10-dhcp-all-interfaces.yaml ]"
+                                    },
+                                    {
+                                        "id": "N10",
+                                        "description": "Enable IPV6",
+                                        "command": [" netplan_wrapper \"enable_ipv6\" \"false\" \"10-dhcp-all-interfaces\" \"ethernets\" \"networkd\""],
+                                        "status": "Pending Review",
+                                        "doc_link": "",
+                                        "src_reference": "",
+                                        "author": "Igor Pecovnik",
+                                        "condition": "[ -f /etc/netplan/30-*static-interfaces.yaml ] || [ -f /etc/netplan/10-dhcp-all-interfaces.yaml ]"
+                                    },
+                                    {
+                                        "id": "N11",
                                         "description": "Disable wired networking",                                    
                                         "command": [ "rm -f /etc/netplan/10-dhcp-all-interfaces.yaml /etc/netplan/30-*static-interfaces.yaml" ],
                                         "condition": "[ -f /etc/netplan/30-*static-interfaces.yaml ] || [ -f /etc/netplan/10-dhcp-all-interfaces.yaml ]",
@@ -337,19 +349,19 @@
                                 ]
                             },
                             {
-                                "id": "N08",
+                                "id": "N03",
                                 "description": "Wireless",
                                 "sub": [
                                     {
-                                        "id": "N09",
-                                        "description": "Show configuration",                                    
-                                        "command": [ "show_message <<< \"$(sudo netplan get wifis)\"" ],
+                                        "id": "N25",
+                                        "description": "Show configuration",
+                                        "command": [ "netplan_wrapper \"show_message\" \"\" \"\" \"wifis\"" ],
                                         "condition": "[ -f /etc/netplan/20-dhcp-wlan-interface.yaml ]",
                                         "status": "Active",
                                         "author": "Igor Pecovnik"
                                     },
                                     {
-                                        "id": "N10",
+                                        "id": "N26",
                                         "description": "Disable wireless networking",
                                         "command": [ "rm -f /etc/netplan/20-dhcp-wlan-interface.yaml" ],
                                         "condition": "[ -f /etc/netplan/20-dhcp-wlan-interface.yaml ]",
@@ -357,19 +369,23 @@
                                         "author": "Igor Pecovnik"
                                     },
                                     {
-                                        "id": "N11",
-                                        "description": "Disable IPV6 in wireless configuration",
-                                        "command": [ 
-                                                        "wifi_index=$(netplan get wifis | head -1 | cut -d\":\" -f1)",
-                                                        "netplan set --origin-hint 20-dhcp-wlan-interface wifis.$wifi_index.dhcp6=false",
-                                                        "show_message <<< \"$(sudo netplan get wifis)\""
-                                                    ],
+                                        "id": "N27",
+                                        "description": "Disable IPV6",
+                                        "command": [" netplan_wrapper \"disable_ipv6\" \"false\" \"20-dhcp-wlan-interface\" \"wifis\" \"networkd\""],
                                         "condition": "[ -f /etc/netplan/20-dhcp-wlan-interface.yaml ]",
                                         "status": "Active",
                                         "author": "Igor Pecovnik"
                                     },
                                     {
-                                        "id": "N12",
+                                        "id": "N28",
+                                        "description": "Enable IPV6",
+                                        "command": [" netplan_wrapper \"enable_ipv6\" \"false\" \"20-dhcp-wlan-interface\" \"wifis\" \"networkd\""],
+                                        "condition": "[ -f /etc/netplan/20-dhcp-wlan-interface.yaml ]",
+                                        "status": "Active",
+                                        "author": "Igor Pecovnik"
+                                    },
+                                    {
+                                        "id": "N29",
                                         "description": "Enable DHCP on wireless network interface",
                                         "command": [
                                                     "wifi_connect"
@@ -381,16 +397,26 @@
                                 ]
                             },
                             {
-                                "id": "N02",
-                                "description": "Apply configs",
+                                "id": "N04",
+                                "description": "Show common configs",
+                                "command": [ "show_message <<< \"$(sudo netplan get all)\"" ],
+                                "status": "Active",
+                                "doc_link": "",
+                                "src_reference": "",
+                                "author": "Igor Pecovnik",
+                                "condition": ""
+                            },
+                            {
+                                "id": "N05",
+                                "description": "Apply common configs",
                                 "command": [                                    
-                                    "get_user_continue \"This will apply new network configuration\n\nwould you like to continue?\" process_input",
-                                    "netplan apply"
+                                                "get_user_continue \"This will apply new network configuration\n\nwould you like to continue?\" process_input",
+                                                "netplan apply"
                                     ],
                                 "status": "Active",
                                 "doc_link": "",
                                 "src_reference": "",
-                                "author": "https://github.com/igorpecovnik",
+                                "author": "Igor Pecovnik",
                                 "condition": ""
                             }
                             ]

--- a/lib/armbian-configng/config.ng.jobs.json
+++ b/lib/armbian-configng/config.ng.jobs.json
@@ -258,11 +258,11 @@
             "description": "Fixed and wireless network settings",
             "sub": [
                 {
-                    "id": "NP00",
+                    "id": "N01",
                     "description": "Configure network interfaces",
                     "sub": [
                             {
-                                "id": "LAN00",
+                                "id": "N02",
                                 "description": "Apply configuration",
                                 "command": [
                                     "netplan apply"
@@ -270,15 +270,15 @@
                                 "status": "Active",
                                 "doc_link": "",
                                 "src_reference": "",
-                                "author": "",
+                                "author": "https://github.com/igorpecovnik",
                                 "condition": ""
                             },
                             {
-                                "id": "LAN01",
+                                "id": "N03",
                                 "description": "Wired",
                                 "sub": [
                                     {
-                                        "id": "LAN02",
+                                        "id": "N04",
                                         "description": "Show configuration",                                    
                                         "command": [ "show_message <<< \"$(sudo netplan get ethernets)\"" ],
                                         "condition": "[ -f /etc/netplan/30-*static-interfaces.yaml ] || [ -f /etc/netplan/10-dhcp-all-interfaces.yaml ]",
@@ -286,7 +286,7 @@
                                         "author": "Igor Pecovnik"
                                     },
                                     {
-                                        "id": "LAN03",
+                                        "id": "N05",
                                         "description": "Enable DHCP on all interfaces",
                                         "command": [
                                                     "rm -f /etc/netplan/30-*-static-interfaces.yaml",
@@ -301,7 +301,7 @@
                                         "condition": "[ ! -f /etc/netplan/10-dhcp-all-interfaces.yaml ]"
                                     },
                                     {
-                                        "id": "LAN04",
+                                        "id": "N06",
                                         "description": "Set fixed IP address",
                                         "command": [
                                             "rm -f /etc/netplan/10-dhcp-all-interfaces.yaml",
@@ -318,7 +318,7 @@
                                         "condition": "[ -f /etc/netplan/10-dhcp-all-interfaces.yaml ] || true"
                                     },
                                     {
-                                        "id": "LAN05",
+                                        "id": "N07",
                                         "description": "Disable wired networking",                                    
                                         "command": [ "rm -f /etc/netplan/10-dhcp-all-interfaces.yaml /etc/netplan/30-*static-interfaces.yaml" ],
                                         "condition": "[ -f /etc/netplan/30-*static-interfaces.yaml ] || [ -f /etc/netplan/10-dhcp-all-interfaces.yaml ]",
@@ -328,11 +328,11 @@
                                 ]
                             },
                             {
-                                "id": "WLAN01",
+                                "id": "N08",
                                 "description": "Wireless",
                                 "sub": [
                                     {
-                                        "id": "WLAN02",
+                                        "id": "N09",
                                         "description": "Show configuration",                                    
                                         "command": [ "show_message <<< \"$(sudo netplan get wifis)\"" ],
                                         "condition": "[ -f /etc/netplan/20-dhcp-wlan-interface.yaml ]",
@@ -340,7 +340,7 @@
                                         "author": "Igor Pecovnik"
                                     },
                                     {
-                                        "id": "WLAN03",
+                                        "id": "N10",
                                         "description": "Disable wireless networking",
                                         "command": [ "rm -f /etc/netplan/20-dhcp-wlan-interface.yaml" ],
                                         "condition": "[ -f /etc/netplan/20-dhcp-wlan-interface.yaml ]",
@@ -348,7 +348,7 @@
                                         "author": "Igor Pecovnik"
                                     },
                                     {
-                                        "id": "WLAN04",
+                                        "id": "N11",
                                         "description": "Disable IPV6 in wireless configuration",
                                         "command": [ 
                                                         "wifi_index=$(netplan get wifis | head -1 | cut -d\":\" -f1)",
@@ -360,7 +360,7 @@
                                         "author": "Igor Pecovnik"
                                     },
                                     {
-                                        "id": "WLAN05",
+                                        "id": "N12",
                                         "description": "Enable DHCP on wireless network interface",
                                         "command": [
                                                     "wifi_index=\"wlx44334c47dec3\"",
@@ -382,7 +382,7 @@
                             ]
                 },
                 {
-                    "id": "N00",
+                    "id": "N13",
                     "description": "Install Bluetooth support",
                     "command": [
                         "see_current_apt ",
@@ -396,7 +396,7 @@
                     "condition": "! check_if_installed bluetooth && ! check_if_installed bluez && ! check_if_installed bluez-tools"
                 },
                 {
-                    "id": "N01",
+                    "id": "N14",
                     "description": "Remove Bluetooth support",
                     "command": [
                         "see_current_apt ",
@@ -411,7 +411,7 @@
                     "condition": "check_if_installed bluetooth || check_if_installed bluez || check_if_installed bluez-tools"
                 },
                 {
-                    "id": "N02",
+                    "id": "N15",
                     "description": "Bluetooth Discover",
                     "command": [
 						"get_user_continue \"Verify that your Bluetooth device is discoverable!\" process_input ; connect_bt_interface"
@@ -424,68 +424,7 @@
                     "condition": "check_if_installed bluetooth || check_if_installed bluez || check_if_installed bluez-tools"
                 },
                 {
-                    "id": "N03",
-                    "description": "Install Infrared support",
-                    "command": [
-                        "see_current_apt; debconf-apt-progress -- apt-get -y --no-install-recommends install lirc"
-                    ],
-                    "status": "Testing",
-                    "doc_link": "",
-                    "src_reference": "",
-                    "author": "",
-                    "condition": "! check_if_installed lirc"
-                },
-                {
-                    "id": "N04",
-                    "description": "Uninstall Infrared support",
-                    "command": [
-                        "see_current_apt; debconf-apt-progress -- apt-get -y --no-install-recommends install lirc"
-                    ],
-                    "status": "Testing",
-                    "doc_link": "",
-                    "src_reference": "",
-                    "author": "",
-                    "condition": "check_if_installed lirc"
-                },
-                {
-                    "id": "N05",
-                    "description": "Manage wifi network connections",
-                    "command": [
-                        "nmtui connect"
-                    ],
-                    "status": "Active",
-                    "doc_link": "",
-                    "src_reference": "",
-                    "author": ""
-                },
-                {
-                    "id": "N06",
-                    "description": "Advanced Edit /etc/network/interface",
-                    "command": [
-                        "get_user_continue \"This will open interface file to edit\nCTRL+S to save\nCTLR+X to exit\nwould you like to continue?\" process_input",
-                        "nano /etc/network/interfaces"
-                    ],
-                    "status": "Active",
-                    "doc_link": "",
-                    "src_reference": "",
-                    "author": "",
-                    "condition": "[ -f /etc/network/interface ]"
-                },
-                {
-                    "id": "N07",
-                    "description": "Disconnect and forget all wifi connections (Advanced)",
-                    "command": [
-                        "get_user_continue \"Disconnect and forget all wifi connections\nWould you like to continue?\" process_input",
-                        "LC_ALL=C nmcli --fields UUID,TIMESTAMP-REAL,TYPE con show | grep wifi |  awk '{print $1}' | while read line; \\ ",
-						"do nmcli con delete uuid  $line; done > /dev/null"
-                    ],
-                    "status": "Active",
-                    "doc_link": "",
-                    "src_reference": "",
-                    "author": ""
-                },
-                {
-                    "id": "N08",
+                    "id": "N16",
                     "description": "Toggle system IPv6/IPv4 internet protocol",
                     "command": [
                         "get_user_continue \"This will toggle your internet protocol\nWould you like to continue?\" process_input",
@@ -497,20 +436,7 @@
                     "author": ""
                 },
                 {
-                    "id": "N09",
-                    "description": "(WIP) Setup Hotspot/Access point",
-                    "command": [
-                        "get_user_continue \"This operation will install necessary software and add configuration files.\nDo you wish to continue?\" process_input",
-                        "hotspot_setup"
-                    ],
-                    "disabled": true,
-                    "status": "WIP",
-                    "doc_link": "",
-                    "src_reference": "",
-                    "author": ""
-                },
-                {
-                    "id": "N10",
+                    "id": "N17",
                     "description": "Announce system in the network (Avahi)",
                     "command": [
                         "get_user_continue \"This operation will install avahi-daemon and add configuration files.\nDo you wish to continue?\" process_input",
@@ -527,7 +453,7 @@
                     "condition": "! check_if_installed avahi-daemon"
                 },
                 {
-                    "id": "N11",
+                    "id": "N18",
                     "description": "Disable system announce in the network (Avahi)",
                     "command": [
                         "get_user_continue \"This operation will purge avahi-daemon \nDo you wish to continue?\" process_input",

--- a/lib/armbian-configng/config.ng.jobs.json
+++ b/lib/armbian-configng/config.ng.jobs.json
@@ -255,8 +255,132 @@
         },
         {
             "id": "Network",
-            "description": "Wireless, Ethernet, and Network settings",
+            "description": "Fixed and wireless network settings",
             "sub": [
+                {
+                    "id": "NP00",
+                    "description": "Configure network interfaces",
+                    "sub": [
+                            {
+                                "id": "LAN00",
+                                "description": "Apply configuration",
+                                "command": [
+                                    "netplan apply"
+                                    ],
+                                "status": "Active",
+                                "doc_link": "",
+                                "src_reference": "",
+                                "author": "",
+                                "condition": ""
+                            },
+                            {
+                                "id": "LAN01",
+                                "description": "Wired",
+                                "sub": [
+                                    {
+                                        "id": "LAN02",
+                                        "description": "Show configuration",                                    
+                                        "command": [ "show_message <<< \"$(sudo netplan get ethernets)\"" ],
+                                        "condition": "[ -f /etc/netplan/30-*static-interfaces.yaml ] || [ -f /etc/netplan/10-dhcp-all-interfaces.yaml ]",
+                                        "status": "Active",
+                                        "author": "Igor Pecovnik"
+                                    },
+                                    {
+                                        "id": "LAN03",
+                                        "description": "Enable DHCP on all interfaces",
+                                        "command": [
+                                                    "rm -f /etc/netplan/30-*-static-interfaces.yaml",
+                                                    "netplan set --origin-hint 10-dhcp-all-interfaces renderer=networkd",
+                                                    "netplan set --origin-hint 10-dhcp-all-interfaces ethernets.all-eth-interfaces.dhcp4=true",
+                                                    "netplan set --origin-hint 10-dhcp-all-interfaces ethernets.all-eth-interfaces.dhcp6=true",
+                                                    "netplan set --origin-hint 10-dhcp-all-interfaces ethernets.all-eth-interfaces.match.name=e*",
+                                                    "show_message <<< \"$(sudo netplan get ethernets)\""
+                                                ],
+                                        "status": "Active",
+                                        "author": "Igor Pecovnik",
+                                        "condition": "[ ! -f /etc/netplan/10-dhcp-all-interfaces.yaml ]"
+                                    },
+                                    {
+                                        "id": "LAN04",
+                                        "description": "Set fixed IP address",
+                                        "command": [
+                                            "rm -f /etc/netplan/10-dhcp-all-interfaces.yaml",
+                                            "eth_index=\"eth0\"",
+                                            "eth_ip=\"10.0.10.199/24\"",
+                                            "netplan set --origin-hint 30-eth0-static-interfaces renderer=networkd",
+                                            "netplan set --origin-hint 30-eth0-static-interfaces ethernets.${eth_index}.addresses=[$eth_ip]",
+                                            "show_message <<< \"$(sudo netplan get ethernets)\""
+                                                   ],
+                                        "status": "Active",
+                                        "doc_link": "",
+                                        "src_reference": "",
+                                        "author": "Igor Pecovnik",
+                                        "condition": "[ -f /etc/netplan/10-dhcp-all-interfaces.yaml ] || true"
+                                    },
+                                    {
+                                        "id": "LAN05",
+                                        "description": "Disable wired networking",                                    
+                                        "command": [ "rm -f /etc/netplan/10-dhcp-all-interfaces.yaml /etc/netplan/30-*static-interfaces.yaml" ],
+                                        "condition": "[ -f /etc/netplan/30-*static-interfaces.yaml ] || [ -f /etc/netplan/10-dhcp-all-interfaces.yaml ]",
+                                        "status": "Active",
+                                        "author": "Igor Pecovnik"
+                                    }
+                                ]
+                            },
+                            {
+                                "id": "WLAN01",
+                                "description": "Wireless",
+                                "sub": [
+                                    {
+                                        "id": "WLAN02",
+                                        "description": "Show configuration",                                    
+                                        "command": [ "show_message <<< \"$(sudo netplan get wifis)\"" ],
+                                        "condition": "[ -f /etc/netplan/20-dhcp-wlan-interface.yaml ]",
+                                        "status": "Active",
+                                        "author": "Igor Pecovnik"
+                                    },
+                                    {
+                                        "id": "WLAN03",
+                                        "description": "Disable wireless networking",
+                                        "command": [ "rm -f /etc/netplan/20-dhcp-wlan-interface.yaml" ],
+                                        "condition": "[ -f /etc/netplan/20-dhcp-wlan-interface.yaml ]",
+                                        "status": "Active",
+                                        "author": "Igor Pecovnik"
+                                    },
+                                    {
+                                        "id": "WLAN04",
+                                        "description": "Disable IPV6 in wireless configuration",
+                                        "command": [ 
+                                                        "wifi_index=$(netplan get wifis | head -1 | cut -d\":\" -f1)",
+                                                        "netplan set --origin-hint 20-dhcp-wlan-interface wifis.$wifi_index.dhcp6=false",
+                                                        "show_message <<< \"$(sudo netplan get wifis)\""
+                                                    ],
+                                        "condition": "[ -f /etc/netplan/20-dhcp-wlan-interface.yaml ]",
+                                        "status": "Active",
+                                        "author": "Igor Pecovnik"
+                                    },
+                                    {
+                                        "id": "WLAN05",
+                                        "description": "Enable DHCP on wireless network interface",
+                                        "command": [
+                                                    "wifi_index=\"wlx44334c47dec3\"",
+                                                    "SSID=GOSTJE24",
+                                                    "PASSWORD=password",
+                                                    "rm -f /etc/netplan/20-dhcp-wlan-interface",
+                                                    "netplan set --origin-hint 20-dhcp-wlan-interface renderer=networkd",
+                                                    "netplan set --origin-hint 20-dhcp-wlan-interface wifis.$wifi_index.access-points.\"${SSID}\".${PASSWORD}=password",
+                                                    "netplan set --origin-hint 20-dhcp-wlan-interface wifis.$wifi_index.dhcp4=true",
+                                                    "netplan set --origin-hint 20-dhcp-wlan-interface wifis.$wifi_index.dhcp6=true",
+                                                    "show_message <<< \"$(sudo netplan get wifis)\""
+                                                ],
+                                        "status": "Active",
+                                        "author": "Igor Pecovnik",
+                                        "condition": "[ ! -f /etc/netplan/20-dhcp-wlan-interface.yaml ]"
+                                    }
+                                ]
+                            }
+                            ]
+                },
                 {
                     "id": "N00",
                     "description": "Install Bluetooth support",

--- a/lib/armbian-configng/config.ng.jobs.json
+++ b/lib/armbian-configng/config.ng.jobs.json
@@ -288,18 +288,6 @@
                     "description": "Configure network interfaces",
                     "sub": [
                             {
-                                "id": "N02",
-                                "description": "Apply configuration",
-                                "command": [
-                                    "netplan apply"
-                                    ],
-                                "status": "Active",
-                                "doc_link": "",
-                                "src_reference": "",
-                                "author": "https://github.com/igorpecovnik",
-                                "condition": ""
-                            },
-                            {
                                 "id": "N03",
                                 "description": "Wired",
                                 "sub": [
@@ -330,12 +318,8 @@
                                         "id": "N06",
                                         "description": "Set fixed IP address",
                                         "command": [
-                                            "rm -f /etc/netplan/10-dhcp-all-interfaces.yaml",
-                                            "eth_index=\"eth0\"",
-                                            "eth_ip=\"10.0.10.199/24\"",
-                                            "netplan set --origin-hint 30-eth0-static-interfaces renderer=networkd",
-                                            "netplan set --origin-hint 30-eth0-static-interfaces ethernets.${eth_index}.addresses=[$eth_ip]",
-                                            "show_message <<< \"$(sudo netplan get ethernets)\""
+                                                        "choose_adapter \"e\"",
+                                                        "[[ -n \"$IP_ADDRESS\" ]] && netplan_wrapper \"10-dhcp-all-interfaces\" \"ethernets\" \"networkd\" \"${SELECTED_ADAPTER}\" \"$IP_ADDRESS\""
                                                    ],
                                         "status": "Active",
                                         "doc_link": "",
@@ -389,21 +373,26 @@
                                         "id": "N12",
                                         "description": "Enable DHCP on wireless network interface",
                                         "command": [
-                                                    "wifi_index=\"wlx44334c47dec3\"",
-                                                    "SSID=GOSTJE24",
-                                                    "PASSWORD=password",
-                                                    "rm -f /etc/netplan/20-dhcp-wlan-interface",
-                                                    "netplan set --origin-hint 20-dhcp-wlan-interface renderer=networkd",
-                                                    "netplan set --origin-hint 20-dhcp-wlan-interface wifis.$wifi_index.access-points.\"${SSID}\".${PASSWORD}=password",
-                                                    "netplan set --origin-hint 20-dhcp-wlan-interface wifis.$wifi_index.dhcp4=true",
-                                                    "netplan set --origin-hint 20-dhcp-wlan-interface wifis.$wifi_index.dhcp6=true",
-                                                    "show_message <<< \"$(sudo netplan get wifis)\""
+                                                    "wifi_connect"
                                                 ],
                                         "status": "Active",
                                         "author": "Igor Pecovnik",
                                         "condition": "[ ! -f /etc/netplan/20-dhcp-wlan-interface.yaml ]"
                                     }
                                 ]
+                            },
+                            {
+                                "id": "N02",
+                                "description": "Apply configs",
+                                "command": [                                    
+                                    "get_user_continue \"This will apply new network configuration\n\nwould you like to continue?\" process_input",
+                                    "netplan apply"
+                                    ],
+                                "status": "Active",
+                                "doc_link": "",
+                                "src_reference": "",
+                                "author": "https://github.com/igorpecovnik",
+                                "condition": ""
                             }
                             ]
                 },


### PR DESCRIPTION
# Description

As we recently switched one level higher to defining network configuration via Netplan, all existing routines become deprecated. This commit adds initial support for handling wired and wireless networking. 

Problems - doesn't list sub routines:
`sudo bin/armbian-configng --cli N01`

jq: error (at bin/../lib/armbian-configng/config.ng.jobs.json:584): Cannot iterate over null (null)

Question:

What is simplest way to:

- pick and pass parameters further - IP, password
- collect users input via GUI  (reading IP, password, ...)

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have ensured that my changes do not introduce new warnings or errors
- [ ] No new external dependencies are included
- [ ] Changes have been tested and verified
- [ ] I have included necessary metadata in the code, including associative arrays
