### PR TITLE
make Tooglerepo avalible to --api

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ sudo armbian-config
   - **S07** - Manage SSH login options
   - **S08** - Change shell system wide to BASH
   - **S09** - Change shell system wide to ZSH
+  - **S10** - Switch to rolling release
+  - **S11** - Switch to stable release
 
 
 - ## **Network** 
@@ -96,6 +98,8 @@ Usage:  armbian-configng [option] [arguments]
     --cli S07  -  Manage SSH login options
     --cli S08  -  Change shell system wide to BASH
     --cli S09  -  Change shell system wide to ZSH
+    --cli S10  -  Switch to rolling release
+    --cli S11  -  Switch to stable release
     --cli N00  -  Install Bluetooth support
     --cli N01  -  Remove Bluetooth support
     --cli N02  -  Bluetooth Discover

--- a/lib/armbian-configng/config.ng.jobs.json
+++ b/lib/armbian-configng/config.ng.jobs.json
@@ -249,6 +249,32 @@
                     "src_reference": "",
                     "author": "https://github.com/igorpecovnik",
                     "condition": "[[ $(cat /etc/passwd | grep \"^root:\" | rev | cut -d\":\" -f1 | cut -d\"/\" -f1| rev) == \"bash\" ]]"
+                },
+                {
+                    "id": "S10",
+                    "description": "Switch to rolling release",
+                    "command": [
+                        "get_user_continue \"This will switch to rolling releases\n\nwould you like to continue?\" process_input",
+                        "sed -i \"s\/http:\\/\\/[^ ]*\/http:\\/\\/beta.armbian.com/\" /etc/apt/sources.list.d/armbian.list"
+                    ],
+                    "status": "Active",
+                    "doc_link": "",
+                    "src_reference": "https://github.com/armbian/config/blob/master/debian-config-jobs#L1446",
+                    "author": "Igor Pecovnik",
+                    "condition": "grep -q 'apt.armbian.com' /etc/apt/sources.list.d/armbian.list"
+                },
+                {
+                    "id": "S11",
+                    "description": "Switch to stable release",
+                    "command": [
+                        "get_user_continue \"This will switch to stable releases\n\nwould you like to continue?\" process_input",
+                        "sed -i \"s\/http:\\/\\/[^ ]*\/http:\\/\\/apt.armbian.com/\" /etc/apt/sources.list.d/armbian.list"
+                    ],
+                    "status": "Active",
+                    "doc_link": "",
+                    "src_reference": "https://github.com/armbian/config/blob/master/debian-config-jobs#L1446",
+                    "author": "Igor Pecovnik",
+                    "condition": "grep -q 'beta.armbian.com' /etc/apt/sources.list.d/armbian.list"
                 }
 
             ]

--- a/lib/armbian-configng/config.ng.jobs.json
+++ b/lib/armbian-configng/config.ng.jobs.json
@@ -255,7 +255,7 @@
                     "description": "Switch to rolling release",
                     "command": [
                         "get_user_continue \"This will switch to rolling releases\n\nwould you like to continue?\" process_input",
-                        "sed -i \"s\/http:\\/\\/[^ ]*\/http:\\/\\/beta.armbian.com/\" /etc/apt/sources.list.d/armbian.list"
+                        "set_rolling"
                     ],
                     "status": "Active",
                     "doc_link": "",
@@ -268,7 +268,7 @@
                     "description": "Switch to stable release",
                     "command": [
                         "get_user_continue \"This will switch to stable releases\n\nwould you like to continue?\" process_input",
-                        "sed -i \"s\/http:\\/\\/[^ ]*\/http:\\/\\/apt.armbian.com/\" /etc/apt/sources.list.d/armbian.list"
+                        "set_stable"
                     ],
                     "status": "Active",
                     "doc_link": "",

--- a/lib/armbian-configng/config.ng.system.sh
+++ b/lib/armbian-configng/config.ng.system.sh
@@ -52,3 +52,30 @@ function qr_code (){
 	read -n 1 -s -r -p "Press any key to continue"
 
 }
+
+function set_rolling () {
+
+        # Set rolling release if not already set
+        if ! grep -q 'beta.armbian.com' /etc/apt/sources.list.d/armbian.list; then
+            sed -i "s/http:\/\/[^ ]*/http:\/\/beta.armbian.com/" /etc/apt/sources.list.d/armbian.list
+        fi
+}
+
+module_options+=(
+["set_stable,author"]="Igor Pecovnik"
+["set_stable,ref_link"]=""
+["set_stable,feature"]="set_stable"
+["set_stable,desc"]="Set Armbian to stable release"
+["set_stable,example"]="set_stable"
+["set_stable,status"]="Active"
+)
+#
+# @description Set Armbian to stable release
+#
+function set_stable () {
+
+if ! grep -q 'beta.armbian.com' /etc/apt/sources.list.d/armbian.list; then
+    sed -i "s/http:\/\/[^ ]*/http:\/\/apt.armbian.com/" /etc/apt/sources.list.d/armbian.list
+fi
+
+}

--- a/lib/armbian-configng/config.ng.system.sh
+++ b/lib/armbian-configng/config.ng.system.sh
@@ -53,17 +53,10 @@ function qr_code (){
 
 }
 
-function set_rolling () {
-
-        # Set rolling release if not already set
-        if ! grep -q 'beta.armbian.com' /etc/apt/sources.list.d/armbian.list; then
-            sed -i "s/http:\/\/[^ ]*/http:\/\/beta.armbian.com/" /etc/apt/sources.list.d/armbian.list
-        fi
-}
 
 module_options+=(
-["set_stable,author"]="Igor Pecovnik"
-["set_stable,ref_link"]=""
+["set_stable,author"]="Tearran"
+["set_stable,ref_link"]="https://github.com/armbian/config/blob/master/debian-config-jobs#L1446"
 ["set_stable,feature"]="set_stable"
 ["set_stable,desc"]="Set Armbian to stable release"
 ["set_stable,example"]="set_stable"
@@ -74,8 +67,25 @@ module_options+=(
 #
 function set_stable () {
 
-if ! grep -q 'beta.armbian.com' /etc/apt/sources.list.d/armbian.list; then
+if ! grep -q 'apt.armbian.com' /etc/apt/sources.list.d/armbian.list; then
     sed -i "s/http:\/\/[^ ]*/http:\/\/apt.armbian.com/" /etc/apt/sources.list.d/armbian.list
 fi
+}
 
+module_options+=(
+["set_rolling,author"]="Tearran"
+["set_rolling,ref_link"]="https://github.com/armbian/config/blob/master/debian-config-jobs#L1446"
+["set_rolling,feature"]="set_rolling"
+["set_rolling,desc"]="Set Armbian to rolling release"
+["set_rolling,example"]="set_rolling"
+["set_rolling,status"]="Active"
+)
+#
+# @description Set Armbian to rolling release
+#
+function set_rolling () {
+
+if ! grep -q 'beta.armbian.com' /etc/apt/sources.list.d/armbian.list; then
+	sed -i "s/http:\/\/[^ ]*/http:\/\/beta.armbian.com/" /etc/apt/sources.list.d/armbian.list
+fi
 }


### PR DESCRIPTION
With this change to  pull request #54 
The feature becomes accessible to the --api flag 

```
sudo "/home/tearran/configng/bin/armbian-configng" --api set_rolling

```

and 
```
sudo "/home/tearran/configng/bin/armbian-configng" --api set_stable

```