### PR TITLE
network configuration

### DIFF
--- a/bin/armbian-configng
+++ b/bin/armbian-configng
@@ -93,8 +93,8 @@ case "$1" in
           fi
           option="$1"
           shift
-          args=$(sanitize_input "$@")
-          # echo -e "\"$option\" \"$args\""
+          args="$@"
+          
           "$option" "$args"
           exit 0
           ;;

--- a/bin/armbian-configng
+++ b/bin/armbian-configng
@@ -82,19 +82,20 @@ case "$1" in
           exit 0
           ;;
      "--api")
+          
           if [[ $EUID != 0 ]]; then
                echo "Error: The --api option requires root privileges. Please run as root or use sudo."
                exit 1
-          fi
+          fi   
+ 
           shift
-          if [[ -z "$1" ]]; then
-               echo "Error: Missing option for --api."
+          if [[ -z "$1" || "$1" == "help" ]]; then
+              see_use;
                exit 1
           fi
           option="$1"
           shift
           args="$@"
-          
           "$option" "$args"
           exit 0
           ;;

--- a/bin/armbian-configng
+++ b/bin/armbian-configng
@@ -72,6 +72,7 @@ case "$1" in
           fi
           ;; 
      "--cli")
+          INPUTMODE="cli"
           if [[ $EUID != 0 ]]; then
                echo "Error: The --cli option requires root privileges. Please run as root or use sudo."
                exit 1

--- a/lib/armbian-configng/config.ng.docs.sh
+++ b/lib/armbian-configng/config.ng.docs.sh
@@ -488,10 +488,11 @@ EOF
     # TODO: Migrate More features. 
     #echo " main=help   -  Display Legacy cli commands."
     jq -r --arg script_name "$script_name" '
-        .menu[] | 
-        .sub[] | 
-        select(.id | startswith("H") | not) |
-       "    --cli " + .id + "  -  " + .description
+        def process_item(item):
+	    "    --cli " + item.id + "  -  " + item.description,
+	    (item.sub[]? | process_item(.));
+	    .menu[] |
+	    .sub[]? | process_item(.)
     ' $json_file
 }
 

--- a/lib/armbian-configng/config.ng.functions.sh
+++ b/lib/armbian-configng/config.ng.functions.sh
@@ -564,7 +564,43 @@ module_options+=(
 #
 # Function to execute the command
 #
+
 function execute_command() {
+    local id=$1
+
+    # Extract commands
+    local commands=$(jq -r --arg id "$id" '
+      .menu[] | 
+      .. | 
+      objects | 
+      select(.id == $id) | 
+      .command[]?' "$json_file")
+
+    # Check if a prompt exists
+    local prompt=$(jq -r --arg id "$id" '
+      .menu[] | 
+      .. | 
+      objects | 
+      select(.id == $id) | 
+      .prompt?' "$json_file")
+
+    # If a prompt exists, display it and wait for user confirmation
+    if [[ "$prompt" != "null" && $INPUTMODE != "cli" ]]; then
+        get_user_continue "$prompt" process_input
+    fi
+
+    # Execute each command
+    for command in "${commands[@]}"; do
+        [[ -n "$debug" ]] && echo "$command"
+        eval "$command"
+    done
+}
+
+
+
+
+
+function execute_command_old() {
     local id=$1
     #local commands=$(jq -r --arg id "$id" '.menu[] | .. | objects | select(.id==$id) | .command[]' "$json_file")
     local commands=$(jq -r --arg id "$id" '

--- a/lib/armbian-configng/config.ng.functions.sh
+++ b/lib/armbian-configng/config.ng.functions.sh
@@ -566,7 +566,14 @@ module_options+=(
 #
 function execute_command() {
     local id=$1
-    local commands=$(jq -r --arg id "$id" '.menu[] | .. | objects | select(.id==$id) | .command[]' "$json_file")
+    #local commands=$(jq -r --arg id "$id" '.menu[] | .. | objects | select(.id==$id) | .command[]' "$json_file")
+    local commands=$(jq -r --arg id "$id" '
+  .menu[] | 
+  .. | 
+  objects | 
+  select(.id == $id) | 
+  .command[]?' "$json_file")
+    
     for command in "${commands[@]}"; do
         # Check if the command is not in the list of restricted commands       
             [[ -n "$debug" ]] && echo "$command"
@@ -940,4 +947,28 @@ sanitize_input() {
         fi
     done
     echo "${sanitized_input[@]}"
+}
+
+
+
+module_options+=(
+["get_user_input,author"]="tearran"
+["get_user_input,ref_link"]=""
+["get_user_input,feature"]="get_user_input"
+["get_user_input,desc"]="Get user input from a dialog input box"
+["get_user_input,example"]="get_user_input"
+["get_user_input,status"]="Pending Review"
+["get_user_input,doc_link"]=""
+)
+#
+# @description Get user input from a dialog input box
+function get_user_input() {
+      
+    local choice=$($DIALOG --backtitle "$(uname --all)" --title "$TITLE" --inputbox "$INSTUCTION" 10 50 "$default" 3>&1 1>&2 2>&3)
+
+    if [ $? -eq 0 ]; then
+        echo "$choice"
+    fi
+
+
 }

--- a/lib/armbian-configng/config.ng.jobs.json
+++ b/lib/armbian-configng/config.ng.jobs.json
@@ -283,46 +283,217 @@
             "description": "Wireless, Ethernet, and Network settings",
             "sub": [
                 {
-                    "id": "N00",
-                    "description": "Install Bluetooth support",
-                    "command": [
-                        "see_current_apt ",
-                        "debconf-apt-progress -- apt-get -y install bluetooth bluez bluez-tools",
-                        "check_if_installed xserver-xorg && debconf-apt-progress -- apt-get -y --no-install-recommends install pulseaudio-module-bluetooth blueman"
-                    ],
-                    "status": "Active",
-                    "doc_link": "",
-                    "src_reference": "",
-                    "author": "",
-                    "condition": "! check_if_installed bluetooth && ! check_if_installed bluez && ! check_if_installed bluez-tools"
-                },
-                {
-                    "id": "N01",
-                    "description": "Remove Bluetooth support",
-                    "command": [
-                        "see_current_apt ",
-						"debconf-apt-progress -- apt-get -y remove bluetooth bluez bluez-tools",
-						"check_if_installed xserver-xorg && debconf-apt-progress -- apt-get -y remove pulseaudio-module-bluetooth blueman",
-                        "debconf-apt-progress -- apt -y -qq autoremove"
+                    "id": "MN01",
+                    "description": "Manage Bluetooth",
+                    "sub": [
+                        {
+		                    "id": "SN00",
+		                    "description": "Install Bluetooth support",
+		                    "command": [
+		                        "see_current_apt ",
+		                        "debconf-apt-progress -- apt-get -y install bluetooth bluez bluez-tools",
+		                        "check_if_installed xserver-xorg && debconf-apt-progress -- apt-get -y --no-install-recommends install pulseaudio-module-bluetooth blueman"
+		                    ],
+		                    "status": "Pending Review",
+		                    "doc_link": "",
+		                    "src_reference": "",
+		                    "author": "",
+		                    "condition": "! check_if_installed bluetooth && ! check_if_installed bluez && ! check_if_installed bluez-tools"
+                		},
+                        {
+                            "id": "SN01",
+                            "description": "Remove Bluetooth support",
+                            "command": [
+                                "see_current_apt ",
+                                "debconf-apt-progress -- apt-get -y remove bluetooth bluez bluez-tools",
+                                "check_if_installed xserver-xorg && debconf-apt-progress -- apt-get -y remove pulseaudio-module-bluetooth blueman",
+                                "debconf-apt-progress -- apt -y -qq autoremove"
+                            ],
+                            "status": "Pending Review",
+                            "doc_link": "",
+                            "src_reference": "",
+                            "author": "",
+                            "condition": "check_if_installed bluetooth || check_if_installed bluez || check_if_installed bluez-tools"
+                        },
+                        {
+                            "id": "SN02",
+                            "description": "Bluetooth Discover",
+                            "command": [
+                                "get_user_continue \"Verify that your Bluetooth device is discoverable!\" process_input ",
+                                "connect_bt_interface"
+        
+                            ],
+                            "status": "Pending Review",
+                            "doc_link": "",
+                            "src_reference": "",
+                            "author": "",
+                            "condition": "check_if_installed bluetooth || check_if_installed bluez || check_if_installed bluez-tools"
+                        }
 		            ],
                     "status": "Active",
                     "doc_link": "",
                     "src_reference": "",
-                    "author": "",
-                    "condition": "check_if_installed bluetooth || check_if_installed bluez || check_if_installed bluez-tools"
+                    "author": ""
                 },
                 {
-                    "id": "N02",
-                    "description": "Bluetooth Discover",
-                    "command": [
-						"get_user_continue \"Verify that your Bluetooth device is discoverable!\" process_input ; connect_bt_interface"
-
+                    "id": "MN02",
+                    "description": "Configure network interfaces (NetworkManager)",
+                    "condition": "[[ -n $( grep -m1 'renderer: NetworkManager' /etc/netplan/*.yaml) ]]",
+                    "sub": [
+						{
+                            "id": "SN05",
+                            "description": "Select a Network Connection",
+                            "command": [
+                                "nmtui-connect"
+                            ],
+                            "status": "Pending Review",
+                            "doc_link": "",
+                            "src_reference": "",
+                            "author": ""
+                        },
+                        {
+                            "id": "SN06",
+                            "description": "Edit network IPv DNS and DHCP",
+                            "command": [
+                                "nmtui-edit"
+                            ],
+                            "status": "Pending Review",
+                            "doc_link": "",
+                            "src_reference": "",
+                            "author": ""
+                        },
+                        {
+                            "id": "SN07",
+                            "description": "Change HostName",
+                            "command": [
+                                "network_hostname"
+                            ],
+                            "status": "Pending Review",
+                            "doc_link": "",
+                            "src_reference": "",
+                            "author": ""
+                        }
                     ],
-                    "status": "Active",
+                    "status": "Pending Review",
                     "doc_link": "",
                     "src_reference": "",
-                    "author": "",
-                    "condition": "check_if_installed bluetooth || check_if_installed bluez || check_if_installed bluez-tools"
+                    "author": ""
+                },
+                {
+                    "id": "MN03",
+                    "description": "Configure network interfaces",
+                    "condition": "[[ -n $(command -v nmcli >) ]]",
+                    
+                    "disabled": true,
+                    "sub": [
+                            {
+                                "id": "N03",
+                                "description": "Wired",
+                                "sub": [
+                                    {
+                                        "id": "N04",
+                                        "description": "Show configuration",                                    
+                                        "command": [ "show_message <<< \"$(sudo netplan get ethernets)\"" ],
+                                        "condition": "[ -f /etc/netplan/30-*static-interfaces.yaml ] || [ -f /etc/netplan/10-dhcp-all-interfaces.yaml ]",
+                                        "status": "Active",
+                                        "author": "Igor Pecovnik"
+                                    },
+                                    {
+                                        "id": "N05",
+                                        "description": "Enable DHCP on all interfaces",
+                                        "command": [
+                                                    "rm -f /etc/netplan/30-*-static-interfaces.yaml",
+                                                    "netplan set --origin-hint 10-dhcp-all-interfaces renderer=networkd",
+                                                    "netplan set --origin-hint 10-dhcp-all-interfaces ethernets.all-eth-interfaces.dhcp4=true",
+                                                    "netplan set --origin-hint 10-dhcp-all-interfaces ethernets.all-eth-interfaces.dhcp6=true",
+                                                    "netplan set --origin-hint 10-dhcp-all-interfaces ethernets.all-eth-interfaces.match.name=e*",
+                                                    "show_message <<< \"$(sudo netplan get ethernets)\""
+                                                ],
+                                        "status": "Active",
+                                        "author": "Igor Pecovnik",
+                                        "condition": "[ ! -f /etc/netplan/10-dhcp-all-interfaces.yaml ]"
+                                    },
+                                    {
+                                        "id": "N06",
+                                        "description": "Set fixed IP address",
+                                        "command": [
+                                                        "choose_adapter \"e\"",
+                                                        "[[ -n \"$IP_ADDRESS\" ]] && netplan_wrapper \"10-dhcp-all-interfaces\" \"ethernets\" \"networkd\" \"${SELECTED_ADAPTER}\" \"$IP_ADDRESS\""
+                                                   ],
+                                        "status": "Active",
+                                        "doc_link": "",
+                                        "src_reference": "",
+                                        "author": "Igor Pecovnik",
+                                        "condition": "[ -f /etc/netplan/10-dhcp-all-interfaces.yaml ] || true"
+                                    },
+                                    {
+                                        "id": "N07",
+                                        "description": "Disable wired networking",                                    
+                                        "command": [ "rm -f /etc/netplan/10-dhcp-all-interfaces.yaml /etc/netplan/30-*static-interfaces.yaml" ],
+                                        "condition": "[ -f /etc/netplan/30-*static-interfaces.yaml ] || [ -f /etc/netplan/10-dhcp-all-interfaces.yaml ]",
+                                        "status": "Active",
+                                        "author": "Igor Pecovnik"
+                                    }
+                                ]
+                            },
+                            {
+                                "id": "N08",
+                                "description": "Wireless",
+                                "sub": [
+                                    {
+                                        "id": "N09",
+                                        "description": "Show configuration",                                    
+                                        "command": [ "show_message <<< \"$(sudo netplan get wifis)\"" ],
+                                        "condition": "[ -f /etc/netplan/20-dhcp-wlan-interface.yaml ]",
+                                        "status": "Active",
+                                        "author": "Igor Pecovnik"
+                                    },
+                                    {
+                                        "id": "N10",
+                                        "description": "Disable wireless networking",
+                                        "command": [ "rm -f /etc/netplan/20-dhcp-wlan-interface.yaml" ],
+                                        "condition": "[ -f /etc/netplan/20-dhcp-wlan-interface.yaml ]",
+                                        "status": "Active",
+                                        "author": "Igor Pecovnik"
+                                    },
+                                    {
+                                        "id": "N11",
+                                        "description": "Disable IPV6 in wireless configuration",
+                                        "command": [ 
+                                                        "wifi_index=$(netplan get wifis | head -1 | cut -d\":\" -f1)",
+                                                        "netplan set --origin-hint 20-dhcp-wlan-interface wifis.$wifi_index.dhcp6=false",
+                                                        "show_message <<< \"$(sudo netplan get wifis)\""
+                                                    ],
+                                        "condition": "[ -f /etc/netplan/20-dhcp-wlan-interface.yaml ]",
+                                        "status": "Active",
+                                        "author": "Igor Pecovnik"
+                                    },
+                                    {
+                                        "id": "N12",
+                                        "description": "Enable DHCP on wireless network interface",
+                                        "command": [
+                                                    "wifi_connect"
+                                                ],
+                                        "status": "Active",
+                                        "author": "Igor Pecovnik",
+                                        "condition": "[ ! -f /etc/netplan/20-dhcp-wlan-interface.yaml ]"
+                                    }
+                                ]
+                            },
+                            {
+                                "id": "N02",
+                                "description": "Apply configs",
+                                "command": [                                    
+                                    "get_user_continue \"This will apply new network configuration\n\nwould you like to continue?\" process_input",
+                                    "netplan apply"
+                                    ],
+                                "status": "Active",
+                                "doc_link": "",
+                                "src_reference": "",
+                                "author": "https://github.com/igorpecovnik",
+                                "condition": ""
+                            }
+                            ]
                 },
                 {
                     "id": "N03",
@@ -330,7 +501,7 @@
                     "command": [
                         "see_current_apt; debconf-apt-progress -- apt-get -y --no-install-recommends install lirc"
                     ],
-                    "status": "Testing",
+                    "status": "Active",
                     "doc_link": "",
                     "src_reference": "",
                     "author": "",
@@ -342,66 +513,16 @@
                     "command": [
                         "see_current_apt; debconf-apt-progress -- apt-get -y --no-install-recommends install lirc"
                     ],
-                    "status": "Testing",
+                    "status": "Active",
                     "doc_link": "",
                     "src_reference": "",
                     "author": "",
                     "condition": "check_if_installed lirc"
                 },
                 {
-                    "id": "N05",
-                    "description": "Manage wifi network connections",
-                    "command": [
-                        "nmtui connect"
-                    ],
-                    "status": "Active",
-                    "doc_link": "",
-                    "src_reference": "",
-                    "author": ""
-                },
-                {
-                    "id": "N06",
-                    "description": "Advanced Edit /etc/network/interface",
-                    "command": [
-                        "get_user_continue \"This will open interface file to edit\nCTRL+S to save\nCTLR+X to exit\nwould you like to continue?\" process_input",
-                        "nano /etc/network/interfaces"
-                    ],
-                    "status": "Active",
-                    "doc_link": "",
-                    "src_reference": "",
-                    "author": "",
-                    "condition": "[ -f /etc/network/interface ]"
-                },
-                {
-                    "id": "N07",
-                    "description": "Disconnect and forget all wifi connections (Advanced)",
-                    "command": [
-                        "get_user_continue \"Disconnect and forget all wifi connections\nWould you like to continue?\" process_input",
-                        "LC_ALL=C nmcli --fields UUID,TIMESTAMP-REAL,TYPE con show | grep wifi |  awk '{print $1}' | while read line; \\ ",
-						"do nmcli con delete uuid  $line; done > /dev/null"
-                    ],
-                    "status": "Active",
-                    "doc_link": "",
-                    "src_reference": "",
-                    "author": ""
-                },
-                {
-                    "id": "N08",
-                    "description": "Toggle system IPv6/IPv4 internet protocol",
-                    "command": [
-                        "get_user_continue \"This will toggle your internet protocol\nWould you like to continue?\" process_input",
-                        "toggle_ipv6 | show_infobox"
-                    ],
-                    "status": "Active",
-                    "doc_link": "",
-                    "src_reference": "",
-                    "author": ""
-                },
-                {
                     "id": "N09",
                     "description": "(WIP) Setup Hotspot/Access point",
                     "command": [
-                        "get_user_continue \"This operation will install necessary software and add configuration files.\nDo you wish to continue?\" process_input",
                         "hotspot_setup"
                     ],
                     "disabled": true,
@@ -414,7 +535,6 @@
                     "id": "N10",
                     "description": "Announce system in the network (Avahi)",
                     "command": [
-                        "get_user_continue \"This operation will install avahi-daemon and add configuration files.\nDo you wish to continue?\" process_input",
                         "check_if_installed avahi-daemon",
 						"debconf-apt-progress -- apt-get -y install avahi-daemon libnss-mdns",
 						"cp /usr/share/doc/avahi-daemon/examples/sftp-ssh.service /etc/avahi/services/",
@@ -431,7 +551,6 @@
                     "id": "N11",
                     "description": "Disable system announce in the network (Avahi)",
                     "command": [
-                        "get_user_continue \"This operation will purge avahi-daemon \nDo you wish to continue?\" process_input",
                         "check_if_installed avahi-daemon",
 						"systemctl stop avahi-daemon avahi-daemon.socket",
 						"debconf-apt-progress -- apt-get -y purge avahi-daemon"
@@ -477,7 +596,7 @@
                     "description": "Change Keyboard layout",
                     "command": [
 						"dpkg-reconfigure keyboard-configuration ; setupcon ",
-			    "update-initramfs -u"
+			            "update-initramfs -u"
                     ],
                     "status": "Active",
                     "doc_link": "",
@@ -506,8 +625,7 @@
                     "id": "I00",
                     "description": "Update Application Repository",
                     "command": [
-                        "get_user_continue \"This will update apt\" process_input",
-                        "debconf-apt-progress -- apt update"
+                       "debconf-apt-progress -- apt update"
                     ],
                     "status": "Active",
                     "doc_link": "",

--- a/lib/armbian-configng/config.ng.jobs.json
+++ b/lib/armbian-configng/config.ng.jobs.json
@@ -7,6 +7,7 @@
                 {
                     "id": "S01",
                     "description": "Enable Armbian kernel upgrades",
+                    "prompt": "TThis will Place a defreeze/unhold the firmware\nwould you like to continue?",
                     "command": [
                         "armbian_fw_manipulate unhold"
                     ],
@@ -19,6 +20,7 @@
                 {
                     "id": "S02",
                     "description": "Disable Armbian kernel upgrades",
+                    "prompt": "This will Place a freeze/hold on the firmware\nwould you like to continue?",
                     "command": [
                         "armbian_fw_manipulate hold"
                     ],
@@ -31,8 +33,8 @@
                 {
                     "id": "S03",
                     "description": "Edit the boot environment",
+                    "prompt": "This will open /boot/armbianEnv.txt file to edit\nCTRL+S to save\nCTLR+X to exit\nwould you like to continue?",
                     "command": [
-                        "get_user_continue \"This will open /boot/armbianEnv.txt file to edit\nCTRL+S to save\nCTLR+X to exit\nwould you like to continue?\" process_input",
                         "nano /boot/armbianEnv.txt"
                     ],
                     "status": "Active",
@@ -252,9 +254,9 @@
                 {
                     "id": "S10",
                     "description": "Switch to rolling release",
+                    "prompt": "This will switch to rolling releases\n\nwould you like to continue?",
                     "command": [
-                        "get_user_continue \"This will switch to rolling releases\n\nwould you like to continue?\" process_input",
-                        "set_rolling"
+                       "set_rolling"
                     ],
                     "status": "Active",
                     "doc_link": "",
@@ -265,8 +267,8 @@
                 {
                     "id": "S11",
                     "description": "Switch to stable release",
+                    "prompt": "This will switch to stable releases\n\nwould you like to continue?",
                     "command": [
-                        "get_user_continue \"This will switch to stable releases\n\nwould you like to continue?\" process_input",
                         "set_stable"
                     ],
                     "status": "Active",
@@ -318,8 +320,8 @@
                         {
                             "id": "SN02",
                             "description": "Bluetooth Discover",
+                            "prompt": "Verify that your Bluetooth device is discoverable!",
                             "command": [
-                                "get_user_continue \"Verify that your Bluetooth device is discoverable!\" process_input ",
                                 "connect_bt_interface"
         
                             ],
@@ -483,8 +485,8 @@
                             {
                                 "id": "N02",
                                 "description": "Apply configs",
+                                "prompt": "This will apply new network configuration\n\nwould you like to continue?",
                                 "command": [                                    
-                                    "get_user_continue \"This will apply new network configuration\n\nwould you like to continue?\" process_input",
                                     "netplan apply"
                                     ],
                                 "status": "Active",

--- a/lib/armbian-configng/config.ng.network.sh
+++ b/lib/armbian-configng/config.ng.network.sh
@@ -215,3 +215,36 @@ systemctl enable dnsmasq
 whiptail --msgbox "Hotspot setup complete. Rebooting now." 8 40
 reboot
 }
+
+
+module_options+=(
+["network_hostname,author"]=""
+["network_hostname,ref_link"]=""
+["network_hostname,feature"]="network_hostname"
+["network_hostname,desc"]="Set hostname"
+["network_hostname,example"]="network_hostname"
+["network_hostname,status"]="Pending Review"
+["network_hostname,doc_link"]=""
+)
+#
+# @description pass arg, if none prompts user for input
+#
+network_hostname(){
+
+    local arg="$1"
+
+    if [[ -n $arg ]]; then
+        # Set hostname for cli
+        nmcli general hostname "$arg"
+        #echo "Set hostname: $arg"
+        exit 0
+    else
+        # Pass The Title and Instruction to get_user_input
+        TITLE="Networking"
+        INSTUCTION="Please input Hostname"
+        default="$HOSTNAME"
+        # use get_user_input to get the user input
+        nmcli general hostname $(get_user_input)
+    fi
+
+}


### PR DESCRIPTION

Added: 

- `Configure network interfaces (NetworkManager)` Menu sub section.
- input box to pass user data 
- Has --api (advanced mode) aka "CLI Mode" option to pass arg to change hostname or --cli (simple mode) to use the input box

## Issue reference:  
https://github.com/armbian/configng/issues/53  

## Pull request reference:
https://github.com/armbian/configng/pull/55

## Implementation Details

Configure network interfaces (NetworkManager) 

The existing nmtui was expanded to include other network setting for the TUI

I used for tui "simple mode"
```
sudo "./bin/armbian-configng" --cli SN07
```
I used  for "cli mode"

```
sudo "./bin/armbian-configng" --api network_hostname  khadasvim3
```

## justification 
This could be a good way to ensure that the basic network configuration is covered 
NetworkManager is still compatible with Netplan and included with desktop and Server images.  
```
[[ -n $( grep -m1 'renderer: NetworkManager' /etc/netplan/*.yaml) ]]
```


