### PR TITLE
Add: Promt section for menu and bypass for --cmd option

### DIFF
--- a/bin/armbian-configng
+++ b/bin/armbian-configng
@@ -60,7 +60,7 @@ clear
 
 case "$1" in
      "--help")
-               see_cli_list
+               see_cmd_list
                exit 0
           ;;
      "--doc")

--- a/bin/armbian-configng
+++ b/bin/armbian-configng
@@ -72,12 +72,18 @@ case "$1" in
                exit 1
           fi
           ;; 
-     "--cli")
+     "--cmd")
+          INPUTMODE="cmd"
           if [[ $EUID != 0 ]]; then
-               echo "Error: The --cli option requires root privileges. Please run as root or use sudo."
+               echo "Error: Requires root privileges. Please run as root or use sudo."
                exit 1
           fi
+
           shift
+          if [[ -z "$1" || "$1" == "help" ]]; then
+               see_cmd_list
+               exit 0
+          fi
           args=$(sanitize_input "$@")
           execute_command "$args"
           exit 0

--- a/lib/armbian-configng/config.ng.docs.sh
+++ b/lib/armbian-configng/config.ng.docs.sh
@@ -2,6 +2,7 @@
 
 # This file is part of Armbian configuration utility.
 
+
 module_options+=(
     ["generate_readme,author"]="Joey Turner"
     ["generate_readme,ref_link"]="#L17"
@@ -69,7 +70,7 @@ armbian-config --help
 
 Outputs:
 ~~~
-$(see_cli_list)
+$(see_cmd_list)
 ~~~
 
 ## Legacy options
@@ -465,18 +466,18 @@ jq -r '
 }
 
 module_options+=(
-    ["see_cli_list,author"]="Joey Turner"
-    ["see_cli_list,ref_link"]=""
-    ["see_cli_list,feature"]="see_cli_list"
-    ["see_cli_list,desc"]="Generate a Help message for cli commands."
-    ["see_cli_list,example"]="see_cli_list"
-    ["see_cli_list,status"]="review"
-    ["see_cli_list,doc_link"]=""
+    ["see_cmd_list,author"]="Joey Turner"
+    ["see_cmd_list,ref_link"]=""
+    ["see_cmd_list,feature"]="see_cmd_list"
+    ["see_cmd_list,desc"]="Generate a Help message for cli commands."
+    ["see_cmd_list,example"]="see_cmd_list"
+    ["see_cmd_list,status"]="review"
+    ["see_cmd_list,doc_link"]=""
 )
 #
 # See command line options
 #
-function see_cli_list() {
+function see_cmd_list() {
     local script_name=$(basename "$0")
     cat << EOF
 Usage:  $script_name [option] [arguments]
@@ -485,15 +486,14 @@ Usage:  $script_name [option] [arguments]
     main=Help   -  Display Legacy Options (Backward Compatible)
 
 EOF
-    # TODO: Migrate More features.
+    # TODO: Migrate More features. 
     #echo " main=help   -  Display Legacy cli commands."
     jq -r --arg script_name "$script_name" '
-	def process_item(item):
-	    "    --cli " + item.id + "  -  " + item.description,
+        def process_item(item):
+	    "    --cmd " + item.id + "  -  " + item.description,
 	    (item.sub[]? | process_item(.));
-
-	.menu[] |
-	.sub[]? | process_item(.)
+	    .menu[] |
+	    .sub[]? | process_item(.)
     ' $json_file
 }
 

--- a/lib/armbian-configng/config.ng.jobs.json
+++ b/lib/armbian-configng/config.ng.jobs.json
@@ -6,7 +6,8 @@
             "sub": [
                 {
                     "id": "S01",
-                    "description": "Enable Armbian kernel upgrades",
+                    "description": "Enable Armbian kernel/firmware upgrades",
+                    "prompt": "This will enable Armbian kernel upgrades?\nWould you like to continue?",
                     "command": [
                         "armbian_fw_manipulate unhold"
                     ],
@@ -19,6 +20,7 @@
                 {
                     "id": "S02",
                     "description": "Disable Armbian kernel upgrades",
+                    "prompt": "Disable Armbian kernel/firmware upgrades\nWould you like to continue?",
                     "command": [
                         "armbian_fw_manipulate hold"
                     ],
@@ -31,8 +33,8 @@
                 {
                     "id": "S03",
                     "description": "Edit the boot environment",
+                    "prompt": "This will open /boot/armbianEnv.txt file to edit\nCTRL+S to save\nCTLR+X to exit\nwould you like to continue?",
                     "command": [
-                        "get_user_continue \"This will open /boot/armbianEnv.txt file to edit\nCTRL+S to save\nCTLR+X to exit\nwould you like to continue?\" process_input",
                         "nano /boot/armbianEnv.txt"
                     ],
                     "status": "Active",
@@ -252,10 +254,8 @@
                 {
                     "id": "S10",
                     "description": "Switch to rolling release",
-                    "command": [
-                        "get_user_continue \"This will switch to rolling releases\n\nwould you like to continue?\" process_input",
-                        "set_rolling"
-                    ],
+                    "prompt": "This will switch to rolling releases\n\nwould you like to continue?",
+                    "command": [ "set_rolling" ],
                     "status": "Active",
                     "doc_link": "",
                     "src_reference": "https://github.com/armbian/config/blob/master/debian-config-jobs#L1446",
@@ -265,10 +265,8 @@
                 {
                     "id": "S11",
                     "description": "Switch to stable release",
-                    "command": [
-                        "get_user_continue \"This will switch to stable releases\n\nwould you like to continue?\" process_input",
-                        "set_stable"
-                    ],
+                    "prompt": "This will switch to stable releases\n\nwould you like to continue?",
+                    "command": [ "set_stable" ],
                     "status": "Active",
                     "doc_link": "",
                     "src_reference": "https://github.com/armbian/config/blob/master/debian-config-jobs#L1446",
@@ -409,10 +407,8 @@
                             {
                                 "id": "N05",
                                 "description": "Apply common configs",
-                                "command": [                                    
-                                                "get_user_continue \"This will apply new network configuration\n\nwould you like to continue?\" process_input",
-                                                "netplan apply"
-                                    ],
+                                "prompt": "This will apply new network configuration\n\nwould you like to continue?",
+                                "command": [ "netplan apply" ],
                                 "status": "Active",
                                 "doc_link": "",
                                 "src_reference": "",
@@ -453,10 +449,8 @@
                 {
                     "id": "N15",
                     "description": "Bluetooth Discover",
-                    "command": [
-						"get_user_continue \"Verify that your Bluetooth device is discoverable!\" process_input ; connect_bt_interface"
-
-                    ],
+                    "prompt": "This will enable bluetooth and discover devices\n\nWould you like to continue?",
+                    "command": [ "connect_bt_interface" ],
                     "status": "Active",
                     "doc_link": "",
                     "src_reference": "",
@@ -466,10 +460,8 @@
                 {
                     "id": "N16",
                     "description": "Toggle system IPv6/IPv4 internet protocol",
-                    "command": [
-                        "get_user_continue \"This will toggle your internet protocol\nWould you like to continue?\" process_input",
-                        "toggle_ipv6 | show_infobox"
-                    ],
+                    "prompt": "This will toggle your internet protocol\nWould you like to continue?",
+                    "command": [ "toggle_ipv6 | show_infobox" ],
                     "status": "Active",
                     "doc_link": "",
                     "src_reference": "",
@@ -478,8 +470,8 @@
                 {
                     "id": "N17",
                     "description": "Announce system in the network (Avahi)",
+                    "prompt": "This operation will install avahi-daemon and add configuration files.\nDo you wish to continue?",
                     "command": [
-                        "get_user_continue \"This operation will install avahi-daemon and add configuration files.\nDo you wish to continue?\" process_input",
                         "check_if_installed avahi-daemon",
 						"debconf-apt-progress -- apt-get -y install avahi-daemon libnss-mdns",
 						"cp /usr/share/doc/avahi-daemon/examples/sftp-ssh.service /etc/avahi/services/",
@@ -495,8 +487,8 @@
                 {
                     "id": "N18",
                     "description": "Disable system announce in the network (Avahi)",
+                    "prompt": "This operation will purge avahi-daemon\nDo you wish to continue?",
                     "command": [
-                        "get_user_continue \"This operation will purge avahi-daemon \nDo you wish to continue?\" process_input",
                         "check_if_installed avahi-daemon",
 						"systemctl stop avahi-daemon avahi-daemon.socket",
 						"debconf-apt-progress -- apt-get -y purge avahi-daemon"
@@ -552,13 +544,12 @@
                 {
                     "id": "L03",
                     "description": "Change APT mirrors",
+                    "prompt": "This will change the APT mirrors\nWould you like to continue?",
                     "command": [
                         "get_user_continue \"This is only a frontend test\" process_input"
                     ],
                     "disabled": true,
                     "status": "Active",
-                    "doc_link": "",
-                    "src_reference": "",
                     "author": ""
                 }
             ]
@@ -570,10 +561,8 @@
                 {
                     "id": "I00",
                     "description": "Update Application Repository",
-                    "command": [
-                        "get_user_continue \"This will update apt\" process_input",
-                        "debconf-apt-progress -- apt update"
-                    ],
+                    "prompt": "This will update the apt repository\nWould you like to continue?",
+                    "command": [ "debconf-apt-progress -- apt update" ],
                     "status": "Active",
                     "doc_link": "",
                     "src_reference": "",


### PR DESCRIPTION
# Description

Added A yes/no prompt section to menu that can be bypassed with --cmd option

Issue reference:  
#53 

# test
`sudo /bin/armbian-configng' from menu select system, select S01 or S02  yes/no prompts shows. exits on no 
`sudo /bin/armbian-configng --cmd S01' no prompt 

 