### PR TITLE
System: add virtual read-only overlayfs module

### DIFF
--- a/lib/armbian-configng/config.ng.jobs.json
+++ b/lib/armbian-configng/config.ng.jobs.json
@@ -272,8 +272,29 @@
                     "src_reference": "https://github.com/armbian/config/blob/master/debian-config-jobs#L1446",
                     "author": "Igor Pecovnik",
                     "condition": "grep -q 'beta.armbian.com' /etc/apt/sources.list.d/armbian.list && [[ -z \"$(apt-mark showhold)\" ]]"
+                },
+                {
+                    "id": "S12",
+                    "description": "Enable read only filesystem",
+                    "prompt": "This will enable Armbian read-only filesystem. Reboot is mandatory?\n\nWould you like to continue?",
+                    "command": [ "manage_overlayfs enable" ],
+                    "status": "Active",
+                    "doc_link": "",
+                    "src_reference": "",
+                    "author": "Igor Pecovnik",
+                    "condition": "modinfo overlay > /dev/null 2>&1 && [[ -z $(findmnt -k /media/root-ro | tail -1) ]] && [[ \"${DISTRO}\"=Ubuntu ]]"
+                },
+                {
+                    "id": "S13",
+                    "description": "Disable read only filesystem",
+                    "prompt": "This will disable Armbian read-only filesystem. Reboot is mandatory?\n\nWould you like to continue?",
+                    "command": [ "manage_overlayfs disable" ],
+                    "status": "Active",
+                    "doc_link": "",
+                    "src_reference": "",
+                    "author": "Igor Pecovnik",
+                    "condition": "command -v overlayroot-chroot > /dev/null 2>&1 && findmnt -k /media/root-ro | tail -1 | grep -w /media/root-ro > /dev/null 2>&1"
                 }
-
             ]
         },
         {

--- a/lib/armbian-configng/config.ng.system.sh
+++ b/lib/armbian-configng/config.ng.system.sh
@@ -91,3 +91,29 @@ if ! grep -q 'beta.armbian.com' /etc/apt/sources.list.d/armbian.list; then
 	armbian_fw_manipulate "reinstall"
 fi
 }
+
+module_options+=(
+["manage_overlayfs,author"]="igorpecovnik"
+["manage_overlayfs,ref_link"]=""
+["manage_overlayfs,feature"]="overlayfs"
+["manage_overlayfs,desc"]="Set Armbian root filesystem to read only"
+["manage_overlayfs,example"]="manage_overlayfs enable|disable"
+["manage_overlayfs,status"]="Active"
+)
+#
+# @description set/unset Armbian root filesystem to read only
+#
+function manage_overlayfs () {
+
+if [[ "$1" == "enable" ]]; then
+	debconf-apt-progress -- apt-get -o Dpkg::Options::="--force-confold" -y install overlayroot cryptsetup cryptsetup-bin
+	[[ ! -f /etc/overlayroot.conf ]] && cp /etc/overlayroot.conf.dpkg-new /etc/overlayroot.conf
+	sed -i "s/^overlayroot=.*/overlayroot=\"tmpfs\"/" /etc/overlayroot.conf
+	sed -i "s/^overlayroot_cfgdisk=.*/overlayroot_cfgdisk=\"enabled\"/" /etc/overlayroot.conf
+	else	
+	overlayroot-chroot rm /etc/overlayroot.conf > /dev/null 2>&1
+	debconf-apt-progress -- apt-get -y purge overlayroot cryptsetup cryptsetup-bin
+fi
+# reboot is mandatory
+reboot
+}


### PR DESCRIPTION
# Description

Enable / disable overlayrootfs aka virtual ready only mode. 

# Implementation Details

Works only in Ubuntu, Debian needs some tacking.

# Testing Procedure

Tested manually under Ubuntu Noble on Odroid M1.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
