### PR TITLE
Netplan status only works with networkd type of networking

### DIFF
--- a/lib/armbian-configng/config.ng.jobs.json
+++ b/lib/armbian-configng/config.ng.jobs.json
@@ -465,12 +465,12 @@
                             {
                                 "id": "N14",
                                 "description": "Display status",
-                                "command": [ "show_message <<< \"$(sudo netplan status)\"" ],
+                                "command": [ "show_message <<< \"$(netplan status --all)\"" ],
                                 "status": "Active",
                                 "doc_link": "",
                                 "src_reference": "",
                                 "author": "Igor Pecovnik",
-                                "condition": ""
+                                "condition": "[ $(netplan get network.renderer) == networkd ]"
                             }
                             ]
                 },


### PR DESCRIPTION
# Description

Prevent showing option where its n/a.

# Testing Procedure

- [x] Manual run on NM and networkd system

# Checklist

- [x] Changes have been tested and verified
