### PR TITLE
Introduce apt_install_wrapper function to run apt commands depending on the terminal

### DIFF
--- a/lib/armbian-configng/config.ng.system.sh
+++ b/lib/armbian-configng/config.ng.system.sh
@@ -1,6 +1,27 @@
 #!/bin/bash
 
 
+ module_options+=(
+["apt_install_wrapper,author"]="igorpecovnik"
+["apt_install_wrapper,ref_link"]=""
+["apt_install_wrapper,feature"]="Install wrapper"
+["apt_install_wrapper,desc"]="Install wrapper"
+["apt_install_wrapper,example"]="apt_install_wrapper apt-get -y purge armbian-zsh"
+["apt_install_wrapper,status"]="Active"
+)
+#
+# @description Use TUI / GUI for apt install if exists
+#
+function apt_install_wrapper
+{
+if [ -t 0 ] ; then
+	debconf-apt-progress -- $@
+else
+	# Terminal not defined - proceed without TUI
+	$@
+fi
+
+
 module_options+=(
 ["install_de,author"]="Igor Pecovnik"
 ["install_de,ref_link"]=""


### PR DESCRIPTION
# Description

When running armbian-config headless and where terminal is not defined, we can't run debconf-apt-progress function. This adds a wrapper to check if terminal is defined and proceed accordingly.

# Implementation Details

Simple wrapper function.

# Testing Procedure

Install packages on both methods:

```
debconf-apt-progress -- apt-get -y purge armbian-zsh
apt_install_wrapper apt-get -y purge armbian-zsh
```
# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
