### PR TITLE
Adjust package dependencies - needed for bare cloud images

### DIFF
--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -21,7 +21,7 @@ jobs:
       homepage: "https://www.armbian.com"
       section: "default"
       priority: "optional"
-      depends: "bash, jq, whiptail"
+      depends: "bash, jq, whiptail, sudo, procps, systemd, lsb-release, iproute2"
       description: "Configng"
 
     secrets:


### PR DESCRIPTION
# Description

If we are going to use package as source for unit testing, its better to store base dependencies straight into package.

# Checklist

- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] Changes have been tested and verified