### PR TITLE
Bugfix: enable linter on bash .sh files, not just on executable ones

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,10 @@ on:
   workflow_dispatch:
   pull_request:
 
+concurrency:
+  group: linter-${{github.event.pull_request.number}}
+  cancel-in-progress: true
+
 jobs:
 
   Shellcheck:
@@ -23,7 +27,7 @@ jobs:
          shell: bash {0}
          run: |
 
-           for file in $(find . -type f -executable ! -path '*/.git*/*' -exec grep -Iq . {} \; -print); do
+           for file in $(find . -name "*.sh" ! -path '*/.git*/*' -exec grep -Iq . {} \; -print); do
                if grep -qE "^#\!/.*bash" $file; then
                    shellcheck --severity=error $file || ret=$?
                fi


### PR DESCRIPTION
# Description

Copy pasted implementation was checking executable bit, while we want to check all functions too, those which don't have that set.

# Testing Procedure

Tested in private fork.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
