### PR TITLE
Docker improvements and enabling auto testing

### DIFF
--- a/lib/armbian-configng/config.ng.jobs.json
+++ b/lib/armbian-configng/config.ng.jobs.json
@@ -838,7 +838,9 @@
                                 "prompt": "This operation will delete all Docker images, containers, and volumes.\nWould you like to continue?",
                                 "command": [
                                     "rm -rf /var/lib/docker",
-                                    "rm -rf /var/lib/containerd"
+                                    "rm -rf /var/lib/containerd",
+                                    "rm -f /usr/share/keyrings/docker.gpg",
+                                    "rm -f /etc/apt/sources.list.d/docker.list"
                                 ],
                                 "status": "Active",
                                 "doc_link": "",

--- a/lib/armbian-configng/config.ng.software.sh
+++ b/lib/armbian-configng/config.ng.software.sh
@@ -101,6 +101,7 @@ install_docker() {
 			fi
 			systemctl enable docker.service > /dev/null 2>&1
 			systemctl enable containerd.service > /dev/null 2>&1
+			sudo usermod -aG docker $USER > /dev/null 2>&1
 			whiptail --msgbox "To test that Docker has installed successfully\nrun the following command: docker run hello-world" 9 70
 		fi
 	else

--- a/lib/armbian-configng/config.ng.software.sh
+++ b/lib/armbian-configng/config.ng.software.sh
@@ -82,7 +82,6 @@ module_options+=(
 #
 install_docker() {
 	# Check if repo for distribution exists.
-	DISTROID=bookworm
 	URL="https://download.docker.com/linux/${DISTRO,,}/dists/$DISTROID"
 	if wget --spider "${URL}" 2> /dev/null; then
 		# Add Docker's official GPG key:
@@ -101,7 +100,6 @@ install_docker() {
 			fi
 			systemctl enable docker.service > /dev/null 2>&1
 			systemctl enable containerd.service > /dev/null 2>&1
-			sudo usermod -aG docker $USER > /dev/null 2>&1
 			whiptail --msgbox "To test that Docker has installed successfully\nrun the following command: docker run hello-world" 9 70
 		fi
 	else

--- a/tests/SW26.conf
+++ b/tests/SW26.conf
@@ -1,0 +1,3 @@
+ENABLED=true
+RELEASE="bookworm:jammy:noble"
+CONDITION="docker run hello-world"


### PR DESCRIPTION
# Description

Rework Docker install and enable automated testing routine.

# Implementation Details

Rework Docker install to use wget only. We don't need to use Curl and wget. When using BASH 4+ (which we do), we can use internal function to conduct _lowercasing_. Also improve purging by deleting the key and sources.

# Testing Procedure

- [x] Auto testing enabled and successful

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
