### PR TITLE
Enable distro upgrades procedure

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -110,14 +110,16 @@ jobs:
             apt -y install wget gpg
 
             # add armbian repository
-            URL=apt.armbian.com
+            URL=beta.armbian.com
             wget https://${URL}/armbian.key -O key
             gpg --dearmor < key | tee /usr/share/keyrings/armbian.gpg > /dev/null
             chmod go+r /usr/share/keyrings/armbian.gpg
             echo "deb [signed-by=/usr/share/keyrings/armbian.gpg] http://${URL} $RELEASE main ${RELEASE}-utils ${RELEASE}-desktop" | tee /etc/apt/sources.list.d/armbian.list
             apt update -y
             apt upgrade -y
-            apt -y install sudo procps systemd whiptail jq lsb-release iproute2
+            apt -y -o Dpkg::Options::="--force-confold" install sudo procps systemd whiptail jq lsb-release iproute2 armbian-bsp-cli-wsl2-x86-current-grub
+            sudo -b unshare --pid --fork --mount-proc /lib/systemd/systemd --system-unit=basic.target
+            cat /etc/armbian-distribution-status
 
             # install packages / except howdy as its too large
             export DEBIAN_FRONTEND=noninteractive

--- a/lib/armbian-configng/config.ng.jobs.json
+++ b/lib/armbian-configng/config.ng.jobs.json
@@ -355,8 +355,37 @@
                     "src_reference": "",
                     "author": "Igor Pecovnik",
                     "condition": ""
+                },
+                {
+                    "id": "S25",
+                    "description": "Distribution upgrades",
+                    "condition": "[ -f /etc/armbian-distribution-status ] && release_upgrade rolling verify || release_upgrade stable verify",
+                    "sub": [
+                        {
+                            "id": "S26",
+                            "description": "Upgrade to latest stable / LTS",
+                            "prompt": "Release upgrade is irriversible operation which upgrades all packages. \n\nResoulted upgrade might break your build beyond repair!",
+                            "command": [
+                                            "release_upgrade stable"
+                                        ],
+                            "status": "Active",
+                            "author": "Igor Pecovnik",
+                            "condition": "[ -f /etc/armbian-distribution-status ] && release_upgrade stable verify"
+                        },
+                        {
+                            "id": "S27",
+                            "description": "Upgrade to rolling unstable",
+                            "prompt": "Release upgrade is irriversible operation which upgrades all packages. \n\nResoulted upgrade might break your build beyond repair!",
+                            "command": [
+                                            "release_upgrade rolling"
+                                        ],
+                            "status": "Active",
+                            "author": "Igor Pecovnik",
+                            "condition": "[ -f /etc/armbian-distribution-status ] && release_upgrade rolling verify"
+                        }
+                ]
                 }
-            ]
+            ] 
         },
         {
             "id": "Network",

--- a/lib/armbian-configng/config.ng.software.sh
+++ b/lib/armbian-configng/config.ng.software.sh
@@ -106,3 +106,5 @@ install_docker() {
 		whiptail --msgbox "ERROR ! ${DISTRO} $DISTROID distribution not found in repository!" 7 70
 	fi
 }
+
+

--- a/lib/armbian-configng/config.ng.system.sh
+++ b/lib/armbian-configng/config.ng.system.sh
@@ -13,10 +13,59 @@ module_options+=(
 #
 function apt_install_wrapper() {
 	if [ -t 0 ]; then
-		debconf-apt-progress -- "$@"
+		DEBIAN_FRONTEND=noninteractive debconf-apt-progress -- "$@"
 	else
 		# Terminal not defined - proceed without TUI
-		"$@"
+		DEBIAN_FRONTEND=noninteractive "$@"
+	fi
+}
+
+module_options+=(
+	["release_upgrade,author"]="Igor Pecovnik"
+	["release_upgrade,ref_link"]=""
+	["release_upgrade,feature"]="Upgrade upstream distribution release"
+	["release_upgrade,desc"]="Upgrade to next stable or rolling release"
+	["release_upgrade,example"]="release_upgrade stable verify"
+	["release_upgrade,status"]="Active"
+)
+#
+# Upgrade distribution
+#
+release_upgrade(){
+
+	local upgrade_type=$1
+	local verify=$2
+
+	local distroid=${DISTROID}
+
+	if [[ "${upgrade_type}" == stable ]]; then
+		local filter=$(grep "supported" /etc/armbian-distribution-status | cut -d"=" -f1)
+	elif [[ "${upgrade_type}" == rolling ]]; then
+		local filter=$(grep "eos\|csc" /etc/armbian-distribution-status | cut -d"=" -f1 | sed "s/sid/testing/g")
+	else
+		local filter=$(cat /etc/armbian-distribution-status | cut -d"=" -f1)
+	fi
+
+	local upgrade=$(for j in $filter; do
+		for i in $(grep "^${distroid}" /etc/armbian-distribution-status | cut -d";" -f2 | cut -d"=" -f2 | sed "s/,/ /g"); do
+			if [[ $i == $j ]]; then
+				echo $i
+			fi
+		done
+	done | tail -1)
+
+	if [[ -z "${upgrade}" ]]; then
+		return 1;
+	elif [[ -z "${verify}" ]]; then
+		[[ -f /etc/apt/sources.list.d/ubuntu.sources ]] && sed -i "s/$distroid/$upgrade/g" /etc/apt/sources.list.d/ubuntu.sources
+		[[ -f /etc/apt/sources.list.d/debian.sources ]] && sed -i "s/$distroid/$upgrade/g" /etc/apt/sources.list.d/debian.sources
+		[[ -f /etc/apt/sources.list ]] && sed -i "s/$distroid/$upgrade/g" /etc/apt/sources.list
+		[[ "${upgrade}" == "testing" ]] && upgrade="sid" # our repo and everything is tied to sid
+		[[ -f /etc/apt/sources.list.d/armbian.list ]] && sed -i "s/$distroid/$upgrade/g" /etc/apt/sources.list.d/armbian.list
+		apt_install_wrapper apt-get -y update
+		apt_install_wrapper apt-get -y -o Dpkg::Options::="--force-confold" upgrade --without-new-pkgs
+		apt_install_wrapper apt-get -y -o Dpkg::Options::="--force-confold" full-upgrade
+		apt_install_wrapper apt-get -y --purge autoremove
 	fi
 }
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -4,4 +4,4 @@
 - ENABLED=false|true
 - PREINSTALL="cmd" in order to satisfy test case
 - CONDITION must return 0 for test success
-
+- RELEASE="bookworm:jammy:noble" run on specific or leave empty to run on all

--- a/tests/S26.conf
+++ b/tests/S26.conf
@@ -1,0 +1,2 @@
+ENABLED=true
+RELEASE="jammy:bullseye"

--- a/tests/S27.conf
+++ b/tests/S27.conf
@@ -1,0 +1,2 @@
+ENABLED=true
+RELEASE="bullseye:bookworm:trixie:jammy:noble"


### PR DESCRIPTION
# Description

Implement functionality for upgrading to latest distribution release. It only provides options, defined by build framework.

When more options are possible, it prompts:

![image](https://github.com/user-attachments/assets/8bfd31ca-46f7-4c52-839a-d5066dd01eda)

It works the same on Ubuntu and Debian. Units tests are provided, but this still doesn't mean upgrades will be successful on users side. Feature prompts user for danger.

Issue reference:  https://github.com/armbian/build/pull/7303

# Implementation Details

Function returns false or true of second parameter "verify" is added, otherwise it does the job. It only provides option to latest possible. If we upgrade from Focal and want stable upgrade, it will upgrade to Noble. If we upgrade bullseye to unstable, it will upgrade to testing.

# Testing Procedure

- [x] Manual tests
- [x] Unit tests are enabled

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
