### PR TITLE
Add independent CPUFREQ config manipulation options

### DIFF
--- a/lib/armbian-configng/config.ng.functions.sh
+++ b/lib/armbian-configng/config.ng.functions.sh
@@ -212,6 +212,16 @@ function set_runtime_variables() {
 	DIALOG_CANCEL=1
 	DIALOG_ESC=255
 
+	# Generate empty CPU freq file in case it does not exists
+	if [[ ! -f /etc/default/armbian-cpufrequtils ]]; then
+	cat <<- EOF > "/etc/default/armbian-cpufrequtils"
+	ENABLE=false
+	MIN_SPEED=
+	MAX_SPEED=
+	GOVERNOR=
+	EOF
+	fi
+
 	# we have our own lsb_release which does not use Python. Others shell install it here
 	if [[ ! -f /usr/bin/lsb_release ]]; then
 		if is_package_manager_running; then
@@ -730,8 +740,43 @@ show_menu() {
 	else
 		exit 0
 	fi
-
 }
+
+
+module_options+=(
+["generic_select,author"]="Gunjan Gupta"
+["generic_select,ref_link"]=""
+["generic_select,feature"]="generic_select"
+["generic_select,desc"]="Display a menu a given list of options with a provided prompt"
+["generic_select,example"]="generic_select \"true false\" \"Select an option\""
+["generic_select,doc_link"]=""
+["generic_select,status"]="Active"
+)
+#
+#  Display a menu a given list of options with a provided prompt
+#
+function generic_select()
+{
+	IFS=$' '
+	PARAMETER=($1)
+	local LIST=()
+	for i in "${PARAMETER[@]}"
+	do
+		if [[ -n $3 ]]; then
+			[[ ${i[0]} -ge $3 ]] && \
+			LIST+=( "${i[0]//[[:blank:]]/}" "" )
+		else
+			LIST+=( "${i[0]//[[:blank:]]/}" "" )
+		fi
+	done
+	LIST_LENGTH=$((${#LIST[@]}/2));
+	if [ "$LIST_LENGTH" -eq 1 ]; then
+		PARAMETER=${LIST[0]}
+	else
+		PARAMETER=$($DIALOG --title "$2" --menu "" 0 0 9 "${LIST[@]}" 3>&1 1>&2 2>&3)
+	fi
+}
+
 
 module_options+=(
 	["get_user_continue,author"]="Joey Turner"

--- a/lib/armbian-configng/config.ng.jobs.json
+++ b/lib/armbian-configng/config.ng.jobs.json
@@ -383,7 +383,92 @@
                             "author": "Igor Pecovnik",
                             "condition": "[ -f /etc/armbian-distribution-status ] && release_upgrade rolling verify"
                         }
-                ]
+                    ]
+                },
+                {
+                    "id": "S28",
+                    "description": "Set CPU speed and governor",
+                    "sub": [
+                        {
+                            "id": "S1001",
+                            "description": "Disable CPU frequency utilities",
+                            "command": [
+                                "sed -i \"s/ENABLE=.*/ENABLE=false/\" /etc/default/armbian-cpufrequtils",
+                                "#systemctl restart armbian-cpufrequtils"
+                            ],
+                            "status": "Active",
+                            "doc_link": "",
+                            "src_reference": "",
+                            "author": "",
+                            "condition": "grep -q '^ENABLE=true' /etc/default/armbian-cpufrequtils 2>/dev/null"
+                        },
+                        {
+                            "id": "S1002",
+                            "description": "Enable CPU frequency utilities",
+                            "command": [
+                                "sed -i \"s/ENABLE=.*/ENABLE=true/\" /etc/default/armbian-cpufrequtils 2>/dev/null",
+                                "#systemctl restart armbian-cpufrequtils"
+                            ],
+                            "status": "Active",
+                            "doc_link": "",
+                            "src_reference": "",
+                            "author": "",
+                            "condition": "grep -q '^ENABLE=false' /etc/default/armbian-cpufrequtils 2>/dev/null"
+                        },
+                        {
+                            "id": "S1003",
+                            "description": "Set minimum CPU speed",
+                            "command": [
+                                "set_cpufreq_option MIN_SPEED"
+                            ],
+                            "status": "Active",
+                            "doc_link": "",
+                            "src_reference": "",
+                            "author": "",
+                            "condition": "grep -q '^ENABLE=true' /etc/default/armbian-cpufrequtils 2>/dev/null"
+                        },
+                        {
+                            "id": "S1004",
+                            "description": "Set maximum CPU speed",
+                            "command": [
+                                "set_cpufreq_option MAX_SPEED"
+                            ],
+                            "status": "Active",
+                            "doc_link": "",
+                            "src_reference": "",
+                            "author": "",
+                            "condition": "grep -q '^ENABLE=true' /etc/default/armbian-cpufrequtils 2>/dev/null"
+                        },
+                        {
+                            "id": "S1005",
+                            "description": "Set CPU scaling governor",
+                            "command": [
+                                "set_cpufreq_option GOVERNOR"
+                            ],
+                            "status": "Active",
+                            "doc_link": "",
+                            "src_reference": "",
+                            "author": "",
+                            "condition": "grep -q '^ENABLE=true' /etc/default/armbian-cpufrequtils 2>/dev/null"
+                        },
+                        {
+                            "id": "S1006",
+                            "description": "Show configuration",
+                            "command": [
+                                "show_message <<< \"$(cat /etc/default/armbian-cpufrequtils)\""
+                            ],
+                            "status": "Preview",
+                            "doc_link": "",
+                            "src_reference": "",
+                            "author": "Igor Pecovnik",
+                            "condition": "grep -q '^ENABLE=true' /etc/default/armbian-cpufrequtils 2>/dev/null && [[ -f /etc/default/armbian-cpufrequtils ]]"
+                        }
+                    ],
+                    "status": "Disabled",
+                    "doc_link": "",
+                    "src_reference": "",
+                    "author": "Gunjan Gupta",
+                    "condition": ""
                 }
             ] 
         },


### PR DESCRIPTION
# Description

Introducing new config `/etc/default/armbian-cpufrequtils` that is independent from deprecated cpufrequtils. Functionality only manipulate config file, while service needs to be added at buildtime.

# Implementation Details

A service that will read /etc/default/armbian-cpufrequtils needs to be added to armbian OS. Functionality should be merged in "Disabled" state.

# Testing Procedure

- [x] Configuration is generated and manipulated correctly

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] No new external dependencies are included
- [x] Changes have been tested and verified
