### PR TITLE
Drop DEBIAN_FRONTEND=noninteractive prefix as it shows nothing at more recent apt app

### DIFF
--- a/lib/armbian-configng/config.ng.system.sh
+++ b/lib/armbian-configng/config.ng.system.sh
@@ -14,10 +14,10 @@ module_options+=(
 function apt_install_wrapper() {
 
 	if [ -t 0 ]; then
-		DEBIAN_FRONTEND=noninteractive debconf-apt-progress -- "$@"
+		debconf-apt-progress -- "$@"
 	else
 		# Terminal not defined - proceed without TUI
-		DEBIAN_FRONTEND=noninteractive "$@"
+		"$@"
 	fi
 }
 


### PR DESCRIPTION
# Description

Another small UX improvement.

# Testing Procedure

Tested with and without on Ubuntu 24.04

# Checklist

- [x] My code follows the style guidelines of this project
- [x] Changes have been tested and verified
