### PR TITLE
Adjust OVERLAY_DIR variable to match build framework settings

### DIFF
--- a/lib/armbian-configng/config.ng.jobs.json
+++ b/lib/armbian-configng/config.ng.jobs.json
@@ -395,7 +395,7 @@
                     "doc_link": "",
                     "src_reference": "",
                     "author": "Gunjan Gupta",
-                    "condition": "[ -n $OVERLAYDIR ] && [ -n $BOOT_SOC ]"
+                    "condition": "[ -n $OVERLAY_DIR ] && [ -n $BOOT_SOC ]"
                 }
             ]
         },

--- a/lib/armbian-configng/config.ng.system.sh
+++ b/lib/armbian-configng/config.ng.system.sh
@@ -357,7 +357,7 @@ function manage_dtoverlays () {
 	while true; do
 		local options=()
 		j=0
-		available_overlays=$(ls -1 ${OVERLAYDIR}/*.dtbo | sed "s#^${OVERLAYDIR}/##" | sed 's/.dtbo//g' | grep $BOOT_SOC | tr '\n' ' ')
+		available_overlays=$(ls -1 ${OVERLAY_DIR}/*.dtbo | sed "s#^${OVERLAY_DIR}/##" | sed 's/.dtbo//g' | grep $BOOT_SOC | tr '\n' ' ')
 		for overlay in ${available_overlays}; do
 			local status="OFF"
 			grep '^fdt_overlays' ${overlayconf} | grep -qw ${overlay} && status=ON

--- a/tools/json/config.system.json
+++ b/tools/json/config.system.json
@@ -395,7 +395,7 @@
                     "doc_link": "",
                     "src_reference": "",
                     "author": "Gunjan Gupta",
-                    "condition": "[ -n $OVERLAYDIR ] && [ -n $BOOT_SOC ]"
+                    "condition": "[ -n $OVERLAY_DIR ] && [ -n $BOOT_SOC ]"
                 }
             ]
         }


### PR DESCRIPTION
# Description

There was inconsistency with this variable. It was set as OVERLAY_DIR and somewhere as OVERLAYDIR. 

# Testing Procedure

Tested on device with freshly build image containing this fix https://github.com/armbian/build/pull/7351

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
