### PR TITLE
Harden network management and configuration

### DIFF
--- a/lib/armbian-configng/config.ng.functions.sh
+++ b/lib/armbian-configng/config.ng.functions.sh
@@ -203,10 +203,10 @@ function set_runtime_variables() {
 	fi
 
 	# Determine which network renderer is in use for NetPlan
-	if systemctl is-active systemd-networkd 1> /dev/null; then
-		renderer=networkd
+	if systemctl is-active NetworkManager 1> /dev/null; then
+		NETWORK_RENDERER=NetworkManager
 	else
-		renderer=NetworkManager
+		NETWORK_RENDERER=networkd
 	fi
 
 	DIALOG_CANCEL=1

--- a/lib/armbian-configng/config.ng.jobs.json
+++ b/lib/armbian-configng/config.ng.jobs.json
@@ -409,7 +409,7 @@
                     "sub": [
                         {
                             "id": "N02",
-                            "description": "Add interface",
+                            "description": "Add / change interface",
                             "command": [
                                 "network_config armbian"
                             ],
@@ -419,17 +419,17 @@
                         },
                         {
                             "id": "N03",
-                            "description": "Revert to defaults",
+                            "description": "Revert to Armbian defaults",
                             "command": [
                                 "default_network_config"
                             ],
                             "status": "Preview",
                             "author": "Igor Pecovnik",
-                            "condition": "[[ -f /etc/netplan/armbian.yaml ]] && ! cat /etc/netplan/armbian.yaml | diff -q 1>/dev/null <(netplan get all) - || [[ ! -f /etc/netplan/10-dhcp-all-interfaces.yaml ]] && ! cat /etc/netplan/10-dhcp-all-interfaces.yaml 2>/dev/null | diff -q 1>/dev/null <(netplan get all) -"
+                            "condition": ""
                         },
                         {
                             "id": "N04",
-                            "description": "Show draft configuration",
+                            "description": "Show configuration",
                             "command": [
                                 "show_message <<< \"$(netplan get all)\""
                             ],
@@ -438,19 +438,6 @@
                             "src_reference": "",
                             "author": "Igor Pecovnik",
                             "condition": "[[ -f /etc/netplan/armbian.yaml ]]"
-                        },
-                        {
-                            "id": "N05",
-                            "description": "Apply changes",
-                            "prompt": "This will apply new network configuration\n\nwould you like to continue?",
-                            "command": [
-                                "netplan apply"
-                            ],
-                            "status": "Preview",
-                            "doc_link": "",
-                            "src_reference": "",
-                            "author": "Igor Pecovnik",
-                            "condition": "[[ -f /etc/netplan/armbian.yaml ]] && ! cat /etc/netplan/armbian.yaml | diff -q 1>/dev/null <(netplan get all) - || [[ -f /etc/netplan/10-dhcp-all-interfaces.yaml ]]"
                         },
                         {
                             "id": "N06",

--- a/lib/armbian-configng/config.ng.system.sh
+++ b/lib/armbian-configng/config.ng.system.sh
@@ -390,3 +390,45 @@ function manage_dtoverlays () {
 		esac
 	done
 }
+
+module_options+=(
+["store_netplan_config,author"]="Igor Pecovnik"
+["store_netplan_config,ref_link"]=""
+["store_netplan_config,feature"]="Storing netplan config to tmp"
+["store_netplan_config,desc"]=""
+["store_netplan_config,example"]=""
+["store_netplan_config,status"]="Active"
+)
+#
+# @description Storing Netplan configuration to temp folder
+#
+function store_netplan_config () {
+
+	# store current configs to temporal folder
+	restore_netplan_config_folder=$(mktemp -d /tmp/XXXXXXXXXX)
+	rsync --quiet /etc/netplan/* ${restore_netplan_config_folder}/ 2>/dev/null
+	trap restore_netplan_config 1 2 3 6
+
+}
+
+module_options+=(
+["store_netplan_config,author"]="Igor Pecovnik"
+["store_netplan_config,ref_link"]=""
+["store_netplan_config,feature"]="Storing netplan config to tmp"
+["store_netplan_config,desc"]=""
+["store_netplan_config,example"]=""
+["store_netplan_config,status"]="Active"
+)
+#
+# @description Restoring Netplan configuration from temp folder
+#
+restore_netplan_config() {
+
+	echo "Restoring NetPlan configs" | show_infobox
+	# just in case
+	if [[ -n ${restore_netplan_config_folder} ]]; then
+		rm -f /etc/netplan/*
+		rsync -ar ${restore_netplan_config_folder}/. /etc/netplan
+	fi
+
+}

--- a/tools/json/config.network.json
+++ b/tools/json/config.network.json
@@ -10,7 +10,7 @@
                     "sub": [
                         {
                             "id": "N02",
-                            "description": "Add interface",
+                            "description": "Add / change interface",
                             "command": [
                                 "network_config armbian"
                             ],
@@ -20,17 +20,17 @@
                         },
                         {
                             "id": "N03",
-                            "description": "Revert to defaults",
+                            "description": "Revert to Armbian defaults",
                             "command": [
                                 "default_network_config"
                             ],
                             "status": "Preview",
                             "author": "Igor Pecovnik",
-                            "condition": "[[ -f /etc/netplan/armbian.yaml ]] && ! cat /etc/netplan/armbian.yaml | diff -q 1>/dev/null <(netplan get all) - || [[ ! -f /etc/netplan/10-dhcp-all-interfaces.yaml ]] && ! cat /etc/netplan/10-dhcp-all-interfaces.yaml 2>/dev/null | diff -q 1>/dev/null <(netplan get all) -"
+                            "condition": ""
                         },
                         {
                             "id": "N04",
-                            "description": "Show draft configuration",
+                            "description": "Show configuration",
                             "command": [
                                 "show_message <<< \"$(netplan get all)\""
                             ],
@@ -39,19 +39,6 @@
                             "src_reference": "",
                             "author": "Igor Pecovnik",
                             "condition": "[[ -f /etc/netplan/armbian.yaml ]]"
-                        },
-                        {
-                            "id": "N05",
-                            "description": "Apply changes",
-                            "prompt": "This will apply new network configuration\n\nwould you like to continue?",
-                            "command": [
-                                "netplan apply"
-                            ],
-                            "status": "Preview",
-                            "doc_link": "",
-                            "src_reference": "",
-                            "author": "Igor Pecovnik",
-                            "condition": "[[ -f /etc/netplan/armbian.yaml ]] && ! cat /etc/netplan/armbian.yaml | diff -q 1>/dev/null <(netplan get all) - || [[ -f /etc/netplan/10-dhcp-all-interfaces.yaml ]]"
                         },
                         {
                             "id": "N06",


### PR DESCRIPTION
# Description

Add support for automatic restore on cancellation, retest and harden functionality.

# Testing Procedure

Minimal systemdnetwork Jammy image:

- setting wired DHCP and static
- setting AP, connecting to it, rebooting, disabling it

Minimal NetworkManager Jammy image:

- setting wired DHCP and static
- setting AP, connecting to it, rebooting, disabling it

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [ ] No new external dependencies are included (added / removed hostapd networkd-dispatcher)
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
