### PR TITLE
Function process_input: return 1 on fail, don't exit with 1

### DIFF
--- a/lib/armbian-configng/config.ng.functions.sh
+++ b/lib/armbian-configng/config.ng.functions.sh
@@ -775,7 +775,7 @@ menu_options+=(
 function process_input() {
 	local input="$1"
 	if [ "$input" = "No" ]; then
-		exit 1
+		return 1
 	fi
 }
 


### PR DESCRIPTION
# Description

I think its better to go back in the menu, then exiting to the prompt.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
