### PR TITLE
Desktops: refactor desktop install, enable working ones, add unit tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -6,8 +6,6 @@ on:
     - cron: '0 2 * * *'
   pull_request:
     types: [opened, reopened, edited, synchronize, review_requested]
-#    paths:
-#      - 'tests/*.conf'
 
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -47,17 +45,20 @@ jobs:
           # define docker images where we will run test install
           dockerimages=("debian:bookworm" "ubuntu:jammy" "ubuntu:noble")
 
-          # read tests cases and loop them
+          # go to repo folder
+          cd config
 
+          # read tests cases
           if [[ -n "${{ steps.changed-files.outputs.all_changed_files }}" ]]; then
-              tests=($(echo ${{ steps.changed-files.outputs.all_changed_files }} | tr " " "\n" | cut -d"." -f1 | cut -d"/" -f2))
+              tests=($(grep -rw ${{ steps.changed-files.outputs.all_changed_files }} -e "ENABLED=true" | cut -d":" -f1))
               else
-              tests=($(grep -rw config/tests/*.conf -e "ENABLED=true" | cut -d"/" -f3 | cut -d"." -f1))
+              tests=($(grep -rw tests/*.conf -e "ENABLED=true" | cut -d":" -f1))
           fi
 
+          # loop enabled tests
           for i in "${tests[@]}"; do
              unset RELEASE
-             source config/tests/${i}.conf
+             source "${i}"
              if [[ -z "${RELEASE}" ]]; then RELEASE=all; fi
              # if we speficy releases, we need to loop docker images and use if there is a match
              if [[ $RELEASE != all || -z $RELEASE ]]; then
@@ -88,6 +89,7 @@ jobs:
 
     name: "I"
     runs-on: ubuntu-latest
+    timeout-minutes: 7
     container:
         image: "${{ matrix.image.image }}"
     steps:
@@ -101,13 +103,15 @@ jobs:
         run: |
 
             # source vars
-            . "config/tests/${{ matrix.image.package }}.conf"
+            . "config/${{ matrix.image.package }}"
             echo ${TEST_TITLE}
 
-            export DEBIAN_FRONTEND=noninteractive
             RELEASE=$(echo "${{ matrix.image.image }}" | cut -d":" -f2)
+            TEST_ID=$(echo "${{ matrix.image.package }}" | cut -d "/" -f2 | cut -d "." -f1)
+            # update index
             apt update
-            apt -y install wget gpg
+            # install basics
+            DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata keyboard-configuration wget gpg
 
             # add armbian repository
             URL=beta.armbian.com
@@ -125,13 +129,13 @@ jobs:
             export DEBIAN_FRONTEND=noninteractive
             cd config
             eval "$PREINSTALL"
-            sudo bash bin/armbian-configng --cmd "${{ matrix.image.package }}"
+            sudo bash bin/armbian-configng --cmd "$TEST_ID"
             eval "$CONDITION"
 
             # stats
-            FILENAME="data-"$(echo ${{ matrix.image.image }} | sed "s/:/-/g")"-${{ matrix.image.package }}.teststats"
+            FILENAME="data-"$(echo ${{ matrix.image.image }} | sed "s/:/-/g")"-${TEST_ID}.teststats"
             echo $RELEASE >> ../${FILENAME}
-            bash bin/armbian-configng --cmd | grep "${{ matrix.image.package }}" | xargs >> ../${FILENAME}
+            bash bin/armbian-configng --cmd | grep "${TEST_ID}" | xargs >> ../${FILENAME}
             echo " " >> ../${FILENAME}
 
       - name: Upload test

--- a/lib/armbian-configng/config.ng.jobs.json
+++ b/lib/armbian-configng/config.ng.jobs.json
@@ -574,67 +574,249 @@
             "sub": [
                 {
                     "id": "Desktops",
-                    "description": "Install Desktop Environments",
+                    "description": "Desktop Environments",
                     "sub": [
                         {
-                            "id": "SW02",
-                            "description": "Install XFCE desktop",
-                            "command": [
-                                "install_de \"xfce\""
-                            ],
-                            "status": "Preview",
-                            "doc_link": "",
-                            "src_reference": "",
-                            "author": "",
-                            "condition": ""
+                            "id": "DE00",
+                            "description": "XFCE desktop",
+                            "sub": [
+                                {
+                                    "id": "DE01",
+                                    "description": "XFCE desktop Install",
+                                    "command": [
+                                        "manage_desktops 'xfce' 'install'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ ! -f /usr/share/xsessions/xfce.desktop ]"
+                                },
+                                {
+                                    "id": "DE02",
+                                    "description": "Uninstall",
+                                    "command": [
+                                        "manage_desktops 'xfce' 'uninstall'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ -f /usr/share/xsessions/xfce.desktop ]"
+                                },
+                                {
+                                    "id": "DE03",
+                                    "description": "Enable autologin",
+                                    "command": [
+                                        "manage_desktops 'xfce' 'auto'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ -f /usr/share/xsessions/xfce.desktop ] && [ ! -f /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf ]"
+                                },
+                                {
+                                    "id": "DE04",
+                                    "description": "Disable autologin",
+                                    "command": [
+                                        "manage_desktops 'xfce' 'manual'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ -f /usr/share/xsessions/xfce.desktop ] && [ -f /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf ]"
+                                }
+                            ]
                         },
                         {
-                            "id": "SW03",
-                            "description": "Install Gnome desktop",
-                            "command": [
-                                "install_de \"gnome\""
-                            ],
-                            "status": "Preview",
-                            "doc_link": "",
-                            "src_reference": "",
-                            "author": "",
-                            "condition": ""
+                            "id": "DE10",
+                            "description": "Gnome desktop",
+                            "sub": [
+                                {
+                                    "id": "DE11",
+                                    "description": "Gnome desktop Install",
+                                    "command": [
+                                        "manage_desktops 'gnome' 'install'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ ! -f /usr/share/xsessions/gnome.desktop ]"
+                                },
+                                {
+                                    "id": "DE12",
+                                    "description": "Uninstall",
+                                    "command": [
+                                        "manage_desktops 'gnome' 'uninstall'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ -f /usr/share/xsessions/gnome.desktop ]"
+                                },
+                                {
+                                    "id": "DE13",
+                                    "description": "Enable autologin",
+                                    "command": [
+                                        "manage_desktops 'gnome' 'auto'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ -f /usr/share/xsessions/gnome.desktop ] && ! cat /etc/gdm3/custom.conf 2>/dev/null | grep AutomaticLoginEnable | grep true >/dev/null"
+                                },
+                                {
+                                    "id": "DE14",
+                                    "description": "Disable autologin",
+                                    "command": [
+                                        "manage_desktops 'gnome' 'manual'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ -f /usr/share/xsessions/gnome.desktop ] && cat /etc/gdm3/custom.conf 2>/dev/null | grep AutomaticLoginEnable | grep true >/dev/null"
+                                }
+                            ]
                         },
                         {
-                            "id": "SW04",
-                            "description": "Install i3-wm desktop",
-                            "command": [
-                                "install_de \"i3-wm\""
-                            ],
-                            "status": "Preview",
-                            "doc_link": "",
-                            "src_reference": "",
-                            "author": "",
-                            "condition": ""
+                            "id": "DE20",
+                            "description": "i3-wm desktop",
+                            "status": "Disabled",
+                            "sub": [
+                                {
+                                    "id": "DE21",
+                                    "description": "i3 desktop Install",
+                                    "command": [
+                                        "manage_desktops 'i3-wm' 'install'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ ! -f /usr/share/xsessions/i3.desktop ]"
+                                },
+                                {
+                                    "id": "DE22",
+                                    "description": "i3 desktop uninstall",
+                                    "command": [
+                                        "manage_desktops 'i3-wm' 'uninstall'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ -f /usr/share/xsessions/i3.desktop ]"
+                                },
+                                {
+                                    "id": "DE23",
+                                    "description": "Enable autologin",
+                                    "command": [
+                                        "manage_desktops 'i3-wm' 'auto'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ -f /usr/share/xsessions/i3.desktop ] && [ ! -f /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf ]"
+                                },
+                                {
+                                    "id": "DE24",
+                                    "description": "Disable autologin",
+                                    "command": [
+                                        "manage_desktops 'i3-wm' 'manual'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ -f /usr/share/xsessions/i3.desktop ] && [ -f /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf ]"
+                                }
+                            ]
                         },
                         {
-                            "id": "SW05",
-                            "description": "Install Cinnamon desktop",
-                            "command": [
-                                "install_de \"cinnamon\""
-                            ],
-                            "status": "Preview",
-                            "doc_link": "",
-                            "src_reference": "",
-                            "author": "",
-                            "condition": ""
+                            "id": "DE30",
+                            "description": "Cinnamon desktop",
+                            "sub": [
+                                {
+                                    "id": "DE31",
+                                    "description": "Cinnamon desktop Install",
+                                    "command": [
+                                        "manage_desktops 'cinnamon' 'install'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ ! -f /usr/share/xsessions/cinnamon.desktop ] && [ ! -f /usr/share/xsessions/cinnamon2d.desktop ]"
+                                },
+                                {
+                                    "id": "DE32",
+                                    "description": "Cinnamon desktop uninstall",
+                                    "command": [
+                                        "manage_desktops 'cinnamon' 'uninstall'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ -f /usr/share/xsessions/cinnamon.desktop ] || [ -f /usr/share/xsessions/cinnamon2d.desktop ]"
+                                },
+                                {
+                                    "id": "DE33",
+                                    "description": "Enable autologin",
+                                    "command": [
+                                        "manage_desktops 'cinnamon' 'auto'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ -f /usr/share/xsessions/cinnamon.desktop ] && [ ! -f /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf ]"
+                                },
+                                {
+                                    "id": "DE34",
+                                    "description": "Disable autologin",
+                                    "command": [
+                                        "manage_desktops 'cinnamon' 'manual'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ -f /usr/share/xsessions/cinnamon.desktop ] && [ -f /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf ]"
+                                }
+                            ]
                         },
                         {
-                            "id": "SW06",
-                            "description": "Install kde-neon desktop",
+                            "id": "DE40",
+                            "description": "Kde-neon desktop",
+                            "status": "Disabled",
+                            "sub": [
+                                {
+                                    "id": "DE41",
+                                    "description": "Kde-neon desktop Install",
+                                    "command": [
+                                        "manage_desktops 'kde-neon' 'install'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ ! -f /usr/share/xsessions/gnome.desktop ]"
+                                },
+                                {
+                                    "id": "DE42",
+                                    "description": "Uninstall",
+                                    "command": [
+                                        "manage_desktops 'kde-neon' 'uninstall'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ -f /usr/share/xsessions/gnome.desktop ]"
+                                },
+                                {
+                                    "id": "DE43",
+                                    "description": "Enable autologin",
+                                    "command": [
+                                        "manage_desktops 'kde-neon' 'auto'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ -f /usr/share/xsessions/gnome.desktop ] && [ ! -f /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf ]"
+                                },
+                                {
+                                    "id": "DE44",
+                                    "description": "Disable autologin",
+                                    "command": [
+                                        "manage_desktops 'kde-neon' 'manual'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ -f /usr/share/xsessions/gnome.desktop ] && [ -f /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf ]"
+                                }
+                            ]
+                        },
+                        {
+                            "id": "DE99",
+                            "description": "Improve application search speed",
                             "command": [
-                                "install_de \"kde-neon\""
+                                "update-apt-xapian-index -u; sleep 3"
                             ],
-                            "status": "Preview",
-                            "doc_link": "",
-                            "src_reference": "",
-                            "author": "",
-                            "condition": ""
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "systemctl is-active --quiet service display-manager"
                         }
                     ]
                 },

--- a/lib/armbian-configng/config.ng.system.sh
+++ b/lib/armbian-configng/config.ng.system.sh
@@ -87,64 +87,131 @@ release_upgrade(){
 }
 
 module_options+=(
-	["install_de,author"]="Igor Pecovnik"
-	["install_de,ref_link"]=""
-	["install_de,feature"]="install_de"
-	["install_de,desc"]="Install DE"
-	["install_de,example"]="install_de"
-	["install_de,status"]="Active"
+	["manage_desktops,author"]="@igorpecovnik"
+	["manage_desktops,ref_link"]=""
+	["manage_desktops,feature"]="install_de"
+	["manage_desktops,desc"]="Install Desktop environment"
+	["manage_desktops,example"]="manage_desktops xfce install"
+	["manage_desktops,status"]="Active"
 )
 #
 # Install desktop
 #
-function install_de() {
+function manage_desktops() {
+
+	local desktop=$1
+	local command=$2
 
 	# get user who executed this script
 	if [ $SUDO_USER ]; then local user=$SUDO_USER; else local user=$(whoami); fi
 
-	#debconf-apt-progress --
-	apt-get update
-	#debconf-apt-progress --
-	apt-get -o Dpkg::Options::="--force-confold" -y --install-recommends install armbian-${DISTROID}-desktop-$1 # armbian-bsp-desktop-${BOARD}-${BRANCH}
+	case "$command" in
+		install)
 
-	# clean apt cache
-	apt-get -y clean
+			# desktops has different default login managers
+			case "$desktop" in
+				gnome)
+					echo "/usr/sbin/gdm3" > /etc/X11/default-display-manager
+					#apt_install_wrapper DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get -y install gdm3
+				;;
+				kde-neon)
+					echo "/usr/sbin/sddm" > /etc/X11/default-display-manager
+					#apt_install_wrapper DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get -y install sddm
+				;;
+				*)
+					echo "/usr/sbin/lightdm" > /etc/X11/default-display-manager
+					#apt_install_wrapper DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get -y install lightdm
+				;;
+			esac
 
-	# add user to groups
-	for additionalgroup in sudo netdev audio video dialout plugdev input bluetooth systemd-journal ssh; do
-		usermod -aG ${additionalgroup} ${user} 2> /dev/null
-	done
+			# just make sure we have everything in order
+			apt_install_wrapper dpkg --configure -a
 
-	# Recreating Synaptic search index
-	update-apt-xapian-index -u
+			# install desktop
+			export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true
+			apt_install_wrapper apt-get -o Dpkg::Options::="--force-confold" -y --install-recommends install armbian-${DISTROID}-desktop-${desktop}
 
-	# set up profile sync daemon on desktop systems
-	which psd > /dev/null 2>&1
-	if [[ $? -eq 0 && -z $(grep overlay-helper /etc/sudoers) ]]; then
-		echo "${user} ALL=(ALL) NOPASSWD: /usr/bin/psd-overlay-helper" >> /etc/sudoers
-		touch /home/${user}/.activate_psd
-	fi
+			# add user to groups
+			for additionalgroup in sudo netdev audio video dialout plugdev input bluetooth systemd-journal ssh; do
+				usermod -aG ${additionalgroup} ${user} 2> /dev/null
+			done
 
-	# update skel
-	update_skel
+			# set up profile sync daemon on desktop systems
+			which psd > /dev/null 2>&1
+			if [[ $? -eq 0 && -z $(grep overlay-helper /etc/sudoers) ]]; then
+				echo "${user} ALL=(ALL) NOPASSWD: /usr/bin/psd-overlay-helper" >> /etc/sudoers
+				touch /home/${user}/.activate_psd
+			fi
+			# update skel
+			update_skel
 
-	# desktops has different default login managers
-	case "$1" in
-		gnome)
-			# gdm3
-			;;
-		*)
-			# lightdm
-			mkdir -p /etc/lightdm/lightdm.conf.d
-			echo "[Seat:*]" > /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf
-			echo "autologin-user=${username}" >> /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf
-			echo "autologin-user-timeout=0" >> /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf
-			echo "user-session=xfce" >> /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf
-			ln -s /lib/systemd/system/lightdm.service /etc/systemd/system/display-manager.service > /dev/null 2>&1
-			service lightdm start > /dev/null 2>&1
-			;;
+			# enable auto login
+			manage_desktops "$desktop" "auto"
+
+			# stop display managers in case we are switching them
+			service gdm3 stop
+			service lightdm stop
+			service sddm stop
+
+			# start new default display manager
+			service display-manager restart
+		;;
+		uninstall)
+			# we are uninstalling all variants until build time packages are fixed to prevent installing one over another
+			service display-manager stop
+			apt_install_wrapper apt-get -o Dpkg::Options::="--force-confold" -y --install-recommends purge armbian-${DISTROID}-desktop-$1 \
+			xfce4-session gnome-session slick-greeter lightdm gdm3 sddm cinnamon-session i3-wm
+			apt_install_wrapper apt-get -y autoremove
+			# disable autologins
+			rm -f /etc/gdm3/custom.conf
+			rm -f /etc/sddm.conf.d/autologin.conf
+			rm -f /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf
+		;;
+		auto)
+			# desktops has different login managers and autologin methods
+			case "$desktop" in
+				gnome)
+					# gdm3 autologin
+					mkdir -p /etc/gdm3
+					cat <<- EOF > /etc/gdm3/custom.conf
+					[daemon]
+					AutomaticLoginEnable = true
+					AutomaticLogin = ${user}
+					EOF
+				;;
+				kde-neon)
+					# sddm autologin
+					cat <<- EOF > "/etc/sddm.conf.d/autologin.conf"
+					[Autologin]
+					User=${user}
+					EOF
+				;;
+				*)
+					# lightdm autologin
+					mkdir -p /etc/lightdm/lightdm.conf.d
+					cat <<- EOF > "/etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf"
+					[Seat:*]
+					autologin-user=${user}
+					autologin-user-timeout=0
+					user-session=xfce
+					EOF
+
+				;;
+			esac
+			# restart after selection
+			service display-manager restart
+		;;
+		manual)
+			case "$desktop" in
+				gnome)    rm -f  /etc/gdm3/custom.conf ;;
+				kde-neon) rm -f /etc/sddm.conf.d/autologin.conf ;;
+				*)        rm -f /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf ;;
+			esac
+			# restart after selection
+			service display-manager restart
+		;;
 	esac
-	exit
+
 }
 
 module_options+=(

--- a/tests/DE01.conf
+++ b/tests/DE01.conf
@@ -1,0 +1,2 @@
+ENABLED=true
+CONDITION="[ -f /usr/share/xsessions/xfce.desktop ]"

--- a/tests/DE11.conf
+++ b/tests/DE11.conf
@@ -1,0 +1,2 @@
+ENABLED=true
+CONDITION="[ -f /usr/share/xsessions/gnome.desktop ]"

--- a/tests/DE21.conf
+++ b/tests/DE21.conf
@@ -1,0 +1,2 @@
+ENABLED=false
+CONDITION="[ -f /usr/share/xsessions/i3.desktop ]"

--- a/tests/DE31.conf
+++ b/tests/DE31.conf
@@ -1,0 +1,2 @@
+ENABLED=true
+CONDITION="[ -f /usr/share/xsessions/cinnamon.desktop ]"

--- a/tools/json/config.software.json
+++ b/tools/json/config.software.json
@@ -6,67 +6,249 @@
             "sub": [
                 {
                     "id": "Desktops",
-                    "description": "Install Desktop Environments",
+                    "description": "Desktop Environments",
                     "sub": [
                         {
-                            "id": "SW02",
-                            "description": "Install XFCE desktop",
-                            "command": [
-                                "install_de \"xfce\""
-                            ],
-                            "status": "Preview",
-                            "doc_link": "",
-                            "src_reference": "",
-                            "author": "",
-                            "condition": ""
+                            "id": "DE00",
+                            "description": "XFCE desktop",
+                            "sub": [
+                                {
+                                    "id": "DE01",
+                                    "description": "XFCE desktop Install",
+                                    "command": [
+                                        "manage_desktops 'xfce' 'install'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ ! -f /usr/share/xsessions/xfce.desktop ]"
+                                },
+                                {
+                                    "id": "DE02",
+                                    "description": "Uninstall",
+                                    "command": [
+                                        "manage_desktops 'xfce' 'uninstall'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ -f /usr/share/xsessions/xfce.desktop ]"
+                                },
+                                {
+                                    "id": "DE03",
+                                    "description": "Enable autologin",
+                                    "command": [
+                                        "manage_desktops 'xfce' 'auto'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ -f /usr/share/xsessions/xfce.desktop ] && [ ! -f /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf ]"
+                                },
+                                {
+                                    "id": "DE04",
+                                    "description": "Disable autologin",
+                                    "command": [
+                                        "manage_desktops 'xfce' 'manual'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ -f /usr/share/xsessions/xfce.desktop ] && [ -f /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf ]"
+                                }
+                            ]
                         },
                         {
-                            "id": "SW03",
-                            "description": "Install Gnome desktop",
-                            "command": [
-                                "install_de \"gnome\""
-                            ],
-                            "status": "Preview",
-                            "doc_link": "",
-                            "src_reference": "",
-                            "author": "",
-                            "condition": ""
+                            "id": "DE10",
+                            "description": "Gnome desktop",
+                            "sub": [
+                                {
+                                    "id": "DE11",
+                                    "description": "Gnome desktop Install",
+                                    "command": [
+                                        "manage_desktops 'gnome' 'install'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ ! -f /usr/share/xsessions/gnome.desktop ]"
+                                },
+                                {
+                                    "id": "DE12",
+                                    "description": "Uninstall",
+                                    "command": [
+                                        "manage_desktops 'gnome' 'uninstall'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ -f /usr/share/xsessions/gnome.desktop ]"
+                                },
+                                {
+                                    "id": "DE13",
+                                    "description": "Enable autologin",
+                                    "command": [
+                                        "manage_desktops 'gnome' 'auto'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ -f /usr/share/xsessions/gnome.desktop ] && ! cat /etc/gdm3/custom.conf 2>/dev/null | grep AutomaticLoginEnable | grep true >/dev/null"
+                                },
+                                {
+                                    "id": "DE14",
+                                    "description": "Disable autologin",
+                                    "command": [
+                                        "manage_desktops 'gnome' 'manual'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ -f /usr/share/xsessions/gnome.desktop ] && cat /etc/gdm3/custom.conf 2>/dev/null | grep AutomaticLoginEnable | grep true >/dev/null"
+                                }
+                            ]
                         },
                         {
-                            "id": "SW04",
-                            "description": "Install i3-wm desktop",
-                            "command": [
-                                "install_de \"i3-wm\""
-                            ],
-                            "status": "Preview",
-                            "doc_link": "",
-                            "src_reference": "",
-                            "author": "",
-                            "condition": ""
+                            "id": "DE20",
+                            "description": "i3-wm desktop",
+                            "status": "Disabled",
+                            "sub": [
+                                {
+                                    "id": "DE21",
+                                    "description": "i3 desktop Install",
+                                    "command": [
+                                        "manage_desktops 'i3-wm' 'install'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ ! -f /usr/share/xsessions/i3.desktop ]"
+                                },
+                                {
+                                    "id": "DE22",
+                                    "description": "i3 desktop uninstall",
+                                    "command": [
+                                        "manage_desktops 'i3-wm' 'uninstall'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ -f /usr/share/xsessions/i3.desktop ]"
+                                },
+                                {
+                                    "id": "DE23",
+                                    "description": "Enable autologin",
+                                    "command": [
+                                        "manage_desktops 'i3-wm' 'auto'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ -f /usr/share/xsessions/i3.desktop ] && [ ! -f /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf ]"
+                                },
+                                {
+                                    "id": "DE24",
+                                    "description": "Disable autologin",
+                                    "command": [
+                                        "manage_desktops 'i3-wm' 'manual'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ -f /usr/share/xsessions/i3.desktop ] && [ -f /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf ]"
+                                }
+                            ]
                         },
                         {
-                            "id": "SW05",
-                            "description": "Install Cinnamon desktop",
-                            "command": [
-                                "install_de \"cinnamon\""
-                            ],
-                            "status": "Preview",
-                            "doc_link": "",
-                            "src_reference": "",
-                            "author": "",
-                            "condition": ""
+                            "id": "DE30",
+                            "description": "Cinnamon desktop",
+                            "sub": [
+                                {
+                                    "id": "DE31",
+                                    "description": "Cinnamon desktop Install",
+                                    "command": [
+                                        "manage_desktops 'cinnamon' 'install'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ ! -f /usr/share/xsessions/cinnamon.desktop ] && [ ! -f /usr/share/xsessions/cinnamon2d.desktop ]"
+                                },
+                                {
+                                    "id": "DE32",
+                                    "description": "Cinnamon desktop uninstall",
+                                    "command": [
+                                        "manage_desktops 'cinnamon' 'uninstall'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ -f /usr/share/xsessions/cinnamon.desktop ] || [ -f /usr/share/xsessions/cinnamon2d.desktop ]"
+                                },
+                                {
+                                    "id": "DE33",
+                                    "description": "Enable autologin",
+                                    "command": [
+                                        "manage_desktops 'cinnamon' 'auto'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ -f /usr/share/xsessions/cinnamon.desktop ] && [ ! -f /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf ]"
+                                },
+                                {
+                                    "id": "DE34",
+                                    "description": "Disable autologin",
+                                    "command": [
+                                        "manage_desktops 'cinnamon' 'manual'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ -f /usr/share/xsessions/cinnamon.desktop ] && [ -f /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf ]"
+                                }
+                            ]
                         },
                         {
-                            "id": "SW06",
-                            "description": "Install kde-neon desktop",
+                            "id": "DE40",
+                            "description": "Kde-neon desktop",
+                            "status": "Disabled",
+                            "sub": [
+                                {
+                                    "id": "DE41",
+                                    "description": "Kde-neon desktop Install",
+                                    "command": [
+                                        "manage_desktops 'kde-neon' 'install'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ ! -f /usr/share/xsessions/gnome.desktop ]"
+                                },
+                                {
+                                    "id": "DE42",
+                                    "description": "Uninstall",
+                                    "command": [
+                                        "manage_desktops 'kde-neon' 'uninstall'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ -f /usr/share/xsessions/gnome.desktop ]"
+                                },
+                                {
+                                    "id": "DE43",
+                                    "description": "Enable autologin",
+                                    "command": [
+                                        "manage_desktops 'kde-neon' 'auto'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ -f /usr/share/xsessions/gnome.desktop ] && [ ! -f /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf ]"
+                                },
+                                {
+                                    "id": "DE44",
+                                    "description": "Disable autologin",
+                                    "command": [
+                                        "manage_desktops 'kde-neon' 'manual'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ -f /usr/share/xsessions/gnome.desktop ] && [ -f /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf ]"
+                                }
+                            ]
+                        },
+                        {
+                            "id": "DE99",
+                            "description": "Improve application search speed",
                             "command": [
-                                "install_de \"kde-neon\""
+                                "update-apt-xapian-index -u; sleep 3"
                             ],
-                            "status": "Preview",
-                            "doc_link": "",
-                            "src_reference": "",
-                            "author": "",
-                            "condition": ""
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "systemctl is-active --quiet service display-manager"
                         }
                     ]
                 },


### PR DESCRIPTION
# Description

Enabling **well tested desktop variants**, disable those we need to work more on. All enabled are covered with unit tests.

# Implementation Details

Installing Armbian desktop packages + enabling respective login manager.

# Testing Procedure

Odroid M1 hooked to the 1080p monitor

Armbian Jammy arm64

- [x] XFCE install / uninstall
- [x] Gnome install / uninstall
- [x] Cinnamon install / uninstall

Armbian Bookworm arm64

- [x] XFCE install / uninstall ([armbian wallpaper is not set to default](https://github.com/armbian/build/issues/7362))
- [x] Gnome install / uninstall
- [x] Cinnamon install / uninstall (lock screen is without wallpaper)

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
