### PR TITLE
Simplify sudo check require it always.

### DIFF
--- a/bin/armbian-configng
+++ b/bin/armbian-configng
@@ -21,6 +21,8 @@ json_file="$lib_dir/config.ng.jobs.json"
 # Load The Bash procedure Objects
 json_data=$(<"$json_file")
 
+# Check if help or doc otherwise run sudo -E
+[[ $EUID != 0 ]] && exec sudo "$0" "$@"
 #
 # 'whiptail' is a simple dialog box utility that works well with Bash. It doesn't have all the features of some other dialog box utilities, but it does everything we need for this script.
 [[ -x "$(command -v whiptail)" ]] && DIALOG="whiptail"
@@ -76,21 +78,11 @@ case "$1" in
 	exit 0
 	;;
 "--doc")
-	if [[ $EUID != 0 ]]; then
-		generate_readme
-		exit 0
-	else
-		echo "Error: You must run this command as a normal user"
-		exit 1
-	fi
+generate_readme
+exit 0
 	;;
 "--cmd")
 	INPUTMODE="cmd"
-	if [[ $EUID != 0 ]]; then
-		echo "Error: Requires root privileges. Please run as root or use sudo."
-		exit 1
-	fi
-
 	shift
 	if [[ -z "$1" || "$1" == "help" ]]; then
 		see_cmd_list
@@ -102,10 +94,6 @@ case "$1" in
 	exit 0
 	;;
 "--api")
-	if [[ $EUID != 0 ]]; then
-		echo "Error: The --api option requires root privileges. Please run as root or use sudo."
-		exit 1
-	fi
 	shift
 	if [[ -z "$1" || "$1" == "help" ]]; then
 		see_use


### PR DESCRIPTION
Check for sudo and prompt If NOT

Caveat:

- Breaks in serve_doc can be removed not used or moved to tools for future use.
- Will need sudo privileges to run help messages.