### PR TITLE
Disable desktops as we don't have consistency at build side

### DIFF
--- a/tests/CINNAMON01.conf
+++ b/tests/CINNAMON01.conf
@@ -1,2 +1,2 @@
-ENABLED=true
+ENABLED=false
 CONDITION="[ -f /usr/share/xsessions/cinnamon.desktop ]"

--- a/tests/GNOME01.conf
+++ b/tests/GNOME01.conf
@@ -1,3 +1,2 @@
-# Install and tests gnome desktop
-ENABLED=true
+ENABLED=false
 CONDITION="[ -f /usr/share/xsessions/gnome.desktop ]"

--- a/tests/XFCE01.conf
+++ b/tests/XFCE01.conf
@@ -1,3 +1,2 @@
-# Installs XFCE desktop and test it
-ENABLED=true
+ENABLED=false
 CONDITION="[ -f /usr/share/xsessions/xfce.desktop ]"

--- a/tools/json/config.software.json
+++ b/tools/json/config.software.json
@@ -7,6 +7,7 @@
                 {
                     "id": "Desktops",
                     "description": "Desktop Environments",
+                    "status": "Disabled",
                     "sub": [
                         {
                             "id": "XFCE",


### PR DESCRIPTION
# Description

Once desktop is full, once bare. This needs to be fixed, then enabling this back.

Issue reference:  https://github.com/armbian/configng/issues/225

# Checklist

- [x] My code follows the style guidelines of this project
- [x] No new external dependencies are included
- [x] Changes have been tested and verified