### PR TITLE
Bugfix: we can't fully disable desktop due to automation

### DIFF
--- a/tools/json/config.software.json
+++ b/tools/json/config.software.json
@@ -7,11 +7,12 @@
                 {
                     "id": "Desktops",
                     "description": "Desktop Environments",
-                    "status": "Disabled",
+                    "status": "Stable",
                     "sub": [
                         {
                             "id": "XFCE",
                             "description": "XFCE desktop",
+                            "status": "Disabled",
                             "sub": [
                                 {
                                     "id": "XFCE01",
@@ -59,6 +60,7 @@
                         {
                             "id": "Gnome",
                             "description": "Gnome desktop",
+                            "status": "Disabled",
                             "sub": [
                                 {
                                     "id": "GNOME01",
@@ -152,6 +154,7 @@
                         {
                             "id": "Cinnamon",
                             "description": "Cinnamon desktop",
+                            "status": "Disabled",
                             "sub": [
                                 {
                                     "id": "CINNAMON01",

--- a/tools/modules/software/install_openhab.sh
+++ b/tools/modules/software/install_openhab.sh
@@ -27,16 +27,16 @@ openhab() {
 			# Optional preinstall top 10 tools
 			apt_install_wrapper apt-get -y install zulu17-jdk
 			apt_install_wrapper apt-get -y install openhab openhab-addons
-			systemctl daemon-reload
-			systemctl enable openhab.service
-			systemctl start openhab.service
+			systemctl daemon-reload 2> /dev/null
+			systemctl enable openhab.service 2> /dev/null
+			systemctl start openhab.service 2> /dev/null
 
 			;;
 
 		uninstall)
 
 			apt_install_wrapper apt-get -y remove zulu17-jdk openhab openhab-addons
-			systemctl disable openhab.service
+			systemctl disable openhab.service 2> /dev/null
 			rm -f /usr/share/keyrings/openhab.gpg /usr/share/keyrings/azul.gpg
 			rm -f /etc/apt/sources.list.d/zulu.list /etc/apt/sources.list.d/openhab.list
 


### PR DESCRIPTION
# Description

- disable particular desktops, not index recreation.
- suppress service startup for OpenHab

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] No new external dependencies are included
- [x] Changes have been tested and verified