### PR TITLE
Disable distribution upgrade as its still pretty fragile

### DIFF
--- a/tools/json/config.system.json
+++ b/tools/json/config.system.json
@@ -296,6 +296,7 @@
                 {
                     "id": "SY016",
                     "description": "Distribution upgrades",
+                    "status": "Disabled",
                     "condition": "[ -f /etc/armbian-distribution-status ] && release_upgrade rolling verify || release_upgrade stable verify",
                     "sub": [
                         {

--- a/tools/modules/system/release_upgrade.sh
+++ b/tools/modules/system/release_upgrade.sh
@@ -42,8 +42,8 @@ release_upgrade(){
 		[[ "${upgrade}" == "testing" ]] && upgrade="sid" # our repo and everything is tied to sid
 		[[ -f /etc/apt/sources.list.d/armbian.list ]] && sed -i "s/$distroid/$upgrade/g" /etc/apt/sources.list.d/armbian.list
 		apt_install_wrapper apt-get -y update
-		apt_install_wrapper apt-get -y -o Dpkg::Options::="--force-confold" upgrade --without-new-pkgs
-		apt_install_wrapper apt-get -y -o Dpkg::Options::="--force-confold" full-upgrade
+		apt_install_wrapper DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get -y -o Dpkg::Options::="--force-confold" upgrade --without-new-pkgs
+		apt_install_wrapper DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get -y -o Dpkg::Options::="--force-confold" full-upgrade
 		apt_install_wrapper apt-get -y --purge autoremove
 	fi
 }


### PR DESCRIPTION
# Description

After few testings, this is not ready yet. Disabling.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
