### PR TITLE
Add a label "not armbian-config" bug

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -37,7 +37,7 @@
 - name: "Good first issue"
   color: "ffb3ff"
   description: "Feel free to contribute :) "
-- name: "Not framework bug"
+- name: "Not armbian-config bug"
   color: "CD456C"
   description: "Bug in 3rd party component"
 - name: "Python"


### PR DESCRIPTION
# Description

We copy / pasted label system from build framework. Changing the name of label to indicate armbian-config bug instead of framework.

# Checklist

- [x] My code follows the style guidelines of this project
