### PR TITLE
Add a warning when tool runs with outdated BSP package

### DIFF
--- a/tools/modules/system/manage_dtoverlays.sh
+++ b/tools/modules/system/manage_dtoverlays.sh
@@ -14,39 +14,44 @@ function manage_dtoverlays () {
 	# check if user agree to enter this area
 	local changes="false"
 	local overlayconf="/boot/armbianEnv.txt"
-	while true; do
-		local options=()
-		j=0
-		available_overlays=$(ls -1 ${OVERLAY_DIR}/*.dtbo | sed "s#^${OVERLAY_DIR}/##" | sed 's/.dtbo//g' | grep $BOOT_SOC | tr '\n' ' ')
-		for overlay in ${available_overlays}; do
-			local status="OFF"
-			grep '^fdt_overlays' ${overlayconf} | grep -qw ${overlay} && status=ON
-			options+=( "$overlay" "" "$status")
-		done
-		selection=$($DIALOG --title "Manage devicetree overlays" --cancel-button "Back" \
-			--ok-button "Save" --checklist "\nUse <space> to toggle functions and save them.\nExit when you are done.\n " \
-			0 0 0 "${options[@]}" 3>&1 1>&2 2>&3)
-		exit_status=$?
-		case $exit_status in
-			0)
-				changes="true"
-				newoverlays=$(echo $selection | sed 's/"//g')
-				sed -i "s/^fdt_overlays=.*/fdt_overlays=$newoverlays/" ${overlayconf}
-				if ! grep -q "^fdt_overlays" ${overlayconf}; then echo "fdt_overlays=$newoverlays" >> ${overlayconf}; fi
-				sync
-				;;
-			1)
-				if [[ "$changes" == "true" ]]; then
-					$DIALOG --title " Reboot required " --yes-button "Reboot" \
-						--no-button "Cancel" --yesno "A reboot is required to apply the changes. Shall we reboot now?" 7 34
-					if [[ $? = 0 ]]; then
-						reboot
+
+	if [[ -z "${OVERLAY_DIR}" ]]; then
+		show_message <<< "Error: OVERLAY folder not found.\n\nThis feature requires Armbian v24.11.1 or newer!"
+	else
+		while true; do
+			local options=()
+			j=0
+			available_overlays=$(ls -1 ${OVERLAY_DIR}/*.dtbo | sed "s#^${OVERLAY_DIR}/##" | sed 's/.dtbo//g' | grep $BOOT_SOC | tr '\n' ' ')
+			for overlay in ${available_overlays}; do
+				local status="OFF"
+				grep '^fdt_overlays' ${overlayconf} | grep -qw ${overlay} && status=ON
+				options+=( "$overlay" "" "$status")
+			done
+			selection=$($DIALOG --title "Manage devicetree overlays" --cancel-button "Back" \
+				--ok-button "Save" --checklist "\nUse <space> to toggle functions and save them.\nExit when you are done.\n " \
+				0 0 0 "${options[@]}" 3>&1 1>&2 2>&3)
+			exit_status=$?
+			case $exit_status in
+				0)
+					changes="true"
+					newoverlays=$(echo $selection | sed 's/"//g')
+					sed -i "s/^fdt_overlays=.*/fdt_overlays=$newoverlays/" ${overlayconf}
+					if ! grep -q "^fdt_overlays" ${overlayconf}; then echo "fdt_overlays=$newoverlays" >> ${overlayconf}; fi
+					sync
+					;;
+				1)
+					if [[ "$changes" == "true" ]]; then
+						$DIALOG --title " Reboot required " --yes-button "Reboot" \
+							--no-button "Cancel" --yesno "A reboot is required to apply the changes. Shall we reboot now?" 7 34
+						if [[ $? = 0 ]]; then
+							reboot
+						fi
 					fi
-				fi
-				break
-				;;
-			255)
-				;;
-		esac
-	done
+					break
+					;;
+				255)
+					;;
+			esac
+		done
+	fi
 }


### PR DESCRIPTION
# Description

![image](https://github.com/user-attachments/assets/26f18f2f-af64-458a-9ca7-ec223435939b)

Possible fix for: https://github.com/armbian/configng/issues/250

# Testing Procedure

- [x] Tested on x86 system that have no OVERLAY_DIR defined

@The-going

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
