### PR TITLE
Overlay management - reverting to previous logic 

### DIFF
--- a/tools/json/config.system.json
+++ b/tools/json/config.system.json
@@ -331,7 +331,7 @@
                     ],
                     "status": "Stable",
                     "author": "@viraniac @igorpecovnik",
-                    "condition": "[ -n $OVERLAY_DIR ] && [ -n $BOOT_SOC ]"
+                    "condition": "[ -d /boot/dtb/ ]"
                 }
             ]
         }

--- a/tools/modules/system/manage_dtoverlays.sh
+++ b/tools/modules/system/manage_dtoverlays.sh
@@ -14,44 +14,49 @@ function manage_dtoverlays () {
 	# check if user agree to enter this area
 	local changes="false"
 	local overlayconf="/boot/armbianEnv.txt"
+	local overlaydir="/boot/dtb/overlay";
+	[[ "$LINUXFAMILY" == "sunxi64" ]] && overlaydir="/boot/dtb/allwinner/overlay";
+	[[ "$LINUXFAMILY" == "meson64" ]] && overlaydir="/boot/dtb/amlogic/overlay";
+	[[ "$LINUXFAMILY" == "rockchip64" || "$LINUXFAMILY" == "rk3399" || "$LINUXFAMILY" == "rockchip-rk3588" || "$LINUXFAMILY" == "rk35xx" ]] && overlaydir="/boot/dtb/rockchip/overlay";
 
-	if [[ -z "${OVERLAY_DIR}" ]]; then
-		show_message <<< "Error: OVERLAY folder not found.\n\nThis feature requires Armbian v24.11.1 or newer!"
-	else
-		while true; do
-			local options=()
-			j=0
-			available_overlays=$(ls -1 ${OVERLAY_DIR}/*.dtbo | sed "s#^${OVERLAY_DIR}/##" | sed 's/.dtbo//g' | grep $BOOT_SOC | tr '\n' ' ')
-			for overlay in ${available_overlays}; do
-				local status="OFF"
-				grep '^fdt_overlays' ${overlayconf} | grep -qw ${overlay} && status=ON
-				options+=( "$overlay" "" "$status")
-			done
-			selection=$($DIALOG --title "Manage devicetree overlays" --cancel-button "Back" \
-				--ok-button "Save" --checklist "\nUse <space> to toggle functions and save them.\nExit when you are done.\n " \
-				0 0 0 "${options[@]}" 3>&1 1>&2 2>&3)
-			exit_status=$?
-			case $exit_status in
-				0)
-					changes="true"
-					newoverlays=$(echo $selection | sed 's/"//g')
-					sed -i "s/^fdt_overlays=.*/fdt_overlays=$newoverlays/" ${overlayconf}
-					if ! grep -q "^fdt_overlays" ${overlayconf}; then echo "fdt_overlays=$newoverlays" >> ${overlayconf}; fi
-					sync
-					;;
-				1)
-					if [[ "$changes" == "true" ]]; then
-						$DIALOG --title " Reboot required " --yes-button "Reboot" \
-							--no-button "Cancel" --yesno "A reboot is required to apply the changes. Shall we reboot now?" 7 34
-						if [[ $? = 0 ]]; then
-							reboot
-						fi
-					fi
-					break
-					;;
-				255)
-					;;
-			esac
+	[[ -f "${overlayconf}" ]] && source "${overlayconf}"
+	while true; do
+		local options=()
+		j=0
+		if [[ -n "${BOOT_SOC}" ]]; then
+		available_overlays=$(ls -1 ${overlaydir}/*.dtbo | sed "s#^${overlaydir}/##" | sed 's/.dtbo//g' | grep $BOOT_SOC | tr '\n' ' ')
+		else
+		available_overlays=$(ls -1 ${overlaydir}/*.dtbo | sed "s#^${overlaydir}/##" | sed 's/.dtbo//g' | tr '\n' ' ')
+		fi
+		for overlay in ${available_overlays}; do
+			local status="OFF"
+			grep '^fdt_overlays' ${overlayconf} | grep -qw ${overlay} && status=ON
+			options+=( "$overlay" "" "$status")
 		done
-	fi
+		selection=$($DIALOG --title "Manage devicetree overlays" --cancel-button "Back" \
+			--ok-button "Save" --checklist "\nUse <space> to toggle functions and save them.\nExit when you are done.\n " \
+			0 0 0 "${options[@]}" 3>&1 1>&2 2>&3)
+		exit_status=$?
+		case $exit_status in
+			0)
+				changes="true"
+				newoverlays=$(echo $selection | sed 's/"//g')
+				sed -i "s/^fdt_overlays=.*/fdt_overlays=$newoverlays/" ${overlayconf}
+				if ! grep -q "^fdt_overlays" ${overlayconf}; then echo "fdt_overlays=$newoverlays" >> ${overlayconf}; fi
+				sync
+				;;
+			1)
+				if [[ "$changes" == "true" ]]; then
+					$DIALOG --title " Reboot required " --yes-button "Reboot" \
+						--no-button "Cancel" --yesno "A reboot is required to apply the changes. Shall we reboot now?" 7 34
+					if [[ $? = 0 ]]; then
+						reboot
+					fi
+				fi
+				break
+				;;
+			255)
+				;;
+		esac
+	done
 }


### PR DESCRIPTION
# Description

Old armbian config doesn't need changes at build time. It seems all overlays are in the same place except legacy / vendor kernels. We need to look into if exceptions are still needed:

https://github.com/armbian/config/blob/master/debian-config-functions#L58-L61

@wizbandit @stephengraf @The-going

# Testing Procedure

- [ ] Manual on H3 based hw

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have ensured that my changes do not introduce new warnings or errors
- [ ] No new external dependencies are included
- [ ] Changes have been tested and verified
- [ ] I have included necessary metadata in the code, including associative arrays
