### PR TITLE
Change development repository domain name to github.armbian.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ sudo bin/armbian-config
 Run the following commands in your terminal:
 
 ```bash
-echo "deb [signed-by=/usr/share/keyrings/armbian.gpg] https://armbian.github.io/configng stable main" | sudo tee /etc/apt/sources.list.d/armbian-development.list > /dev/null
+echo "deb [signed-by=/usr/share/keyrings/armbian.gpg] https://github.armbian.com/configng stable main" | sudo tee /etc/apt/sources.list.d/armbian-development.list > /dev/null
 sudo apt update
 sudo apt -y install armbian-config
 ```


### PR DESCRIPTION
# Description

After bonding Github organisation pages with our domain name, repository pages goes under github.armbian.com/REPOSITORY

# Checklist

- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
