### PR TITLE
[bug] Need at least one enabled sub

### DIFF
--- a/tools/json/config.software.json
+++ b/tools/json/config.software.json
@@ -7,7 +7,7 @@
                 {
                     "id": "Desktops",
                     "description": "Desktop Environments",
-                    "status": "Stable",
+                    "status": "Disabled",
                     "sub": [
                         {
                             "id": "XFCE",


### PR DESCRIPTION
Using menu under Desktop gets stuck message loops. 
all sub entries seemed disabled so the parent also needs disabled.

Quick fix for disabled Desktop, 

