### PR TITLE
Add Samba package

### DIFF
--- a/tools/json/config.software.json
+++ b/tools/json/config.software.json
@@ -354,6 +354,28 @@
                             "status": "Stable",
                             "author": "@armbian",
                             "condition": "check_if_installed avahi-daemon"
+                        },
+                        {
+                            "id": "NET009",
+                            "description": "Install Samba",
+                            "command": [
+                                "get_user_continue \"This operation will install Samba service.\nDo you wish to continue?\" process_input",
+                                "debconf-apt-progress -- apt-get -y install samba"
+                            ],
+                            "status": "Stable",
+                            "author": "@dimitry-ishenko",
+                            "condition": "! check_if_installed samba"
+                        },
+                        {
+                            "id": "NET010",
+                            "description": "Uninstall Samba",
+                            "command": [
+                                "get_user_continue \"This operation will purge Samba service.\nDo you wish to continue?\" process_input",
+                                "debconf-apt-progress -- apt-get -y autopurge samba"
+                            ],
+                            "status": "Stable",
+                            "author": "@dimitry-ishenko",
+                            "condition": "check_if_installed samba"
                         }
                     ]
                 },


### PR DESCRIPTION
This is a draft PR to make sure I am on the right track.

@igorpecovnik in #242 you have _enable_, _disable_ and _config_ options. What did you have in mind exactly?

Also, couple of issues I've noticed so far:

1. I've had issues with `debconf-apt-progress` not being able to uninstall `samba` with the following error:
```
Removing samba (2:4.19.5+dfsg-4ubuntu9) ...
Setting up samba-common (2:4.19.5+dfsg-4ubuntu9) ...
Can't locate object method "new" via package "Text::Iconv" (perhaps you forgot to load "Text::Iconv"?) at /usr/share/perl5/Debconf/Encoding.pm line 65, <GEN2> line 2.
dpkg: error processing package samba-common (--configure):
 installed samba-common package post-installation script subprocess returned error exit status 255
dpkg: dependency problems prevent configuration of samba-common-bin:
 samba-common-bin depends on samba-common (= 2:4.19.5+dfsg-4ubuntu9); however:
  Package samba-common is not configured yet.

dpkg: error processing package samba-common-bin (--configure):
 dependency problems - leaving unconfigured
Processing triggers for man-db (2.12.0-4build2) ...
Errors were encountered while processing:
 samba-common
 samba-common-bin
E: Sub-process /usr/bin/dpkg returned an error code (1)
```
Installing `libtext-iconv-perl` handled the error...

2. I've noticed that noticed that most (all?) packages use `apt-get purge` to uninstall themselves. The problem with this is that it does not uninstall dependencies. I've used `apt-get autopurge` instead, which add `--autoremove` option to remove all dangling dependent packages.