### PR TITLE
Overlay management: disable showing this option where its not supported

### DIFF
--- a/tools/json/config.system.json
+++ b/tools/json/config.system.json
@@ -331,7 +331,7 @@
                     ],
                     "status": "Stable",
                     "author": "@viraniac @igorpecovnik",
-                    "condition": "[ -d /boot/dtb/ ]"
+                    "condition": "[ -d /boot/dtb/ ] && [ -f /boot/armbianEnv.txt ]"
                 }
             ]
         }


### PR DESCRIPTION
# Description

Odroid XU4 is the only board where /boot/boot.ini way of setting boot parameters is used. Since this is not supported, makes not point showing an option in the menu.

Issue reference:  https://forum.armbian.com/topic/47782-booting-with-a-hc1-overlay

# Implementation Details

Hiding menu if files we manipulate are not present.

# Testing Procedure

- [x] Shows when present, doesn't if absent

# Checklist

- [x] My code follows the style guidelines of this project