### PR TITLE
[Bugfix] feature array names, 

### DIFF
--- a/tools/modules/software/install_openhab.sh
+++ b/tools/modules/software/install_openhab.sh
@@ -2,7 +2,7 @@
 module_options+=(
 	["openhab,author"]="@igorpecovnik"
 	["openhab,ref_link"]=""
-	["openhab,feature"]="install_openhab"
+	["openhab,feature"]="openhab"
 	["openhab,desc"]="Install openhab from a repo using apt"
 	["openhab,example"]="install uinstall"
 	["openhab,status"]="Active"

--- a/tools/modules/system/apt_install_wrapper.sh
+++ b/tools/modules/system/apt_install_wrapper.sh
@@ -2,7 +2,7 @@
 module_options+=(
 	["apt_install_wrapper,author"]="@igorpecovnik"
 	["apt_install_wrapper,ref_link"]=""
-	["apt_install_wrapper,feature"]="Install wrapper"
+	["apt_install_wrapper,feature"]="apt_install_wrapper"
 	["apt_install_wrapper,desc"]="Install wrapper"
 	["apt_install_wrapper,example"]="apt_install_wrapper apt-get -y purge armbian-zsh"
 	["apt_install_wrapper,status"]="Active"

--- a/tools/modules/system/manage_desktops.sh
+++ b/tools/modules/system/manage_desktops.sh
@@ -1,7 +1,7 @@
 module_options+=(
 	["manage_desktops,author"]="@igorpecovnik"
 	["manage_desktops,ref_link"]=""
-	["manage_desktops,feature"]="install_de"
+	["manage_desktops,feature"]="manage_desktops"
 	["manage_desktops,desc"]="Install Desktop environment"
 	["manage_desktops,example"]="manage_desktops xfce install"
 	["manage_desktops,status"]="Active"

--- a/tools/modules/system/manage_dtoverlays.sh
+++ b/tools/modules/system/manage_dtoverlays.sh
@@ -2,7 +2,7 @@
 module_options+=(
 ["manage_dtoverlays,author"]="@viraniac"
 ["manage_dtoverlays,ref_link"]=""
-["manage_dtoverlays,feature"]="dtoverlays"
+["manage_dtoverlays,feature"]="manage_dtoverlays"
 ["manage_dtoverlays,desc"]="Enable/disable device tree overlays"
 ["manage_dtoverlays,example"]="manage_dtoverlays"
 ["manage_dtoverlays,status"]="Active"

--- a/tools/modules/system/manage_overlayfs.sh
+++ b/tools/modules/system/manage_overlayfs.sh
@@ -1,7 +1,7 @@
 module_options+=(
 	["manage_overlayfs,author"]="@igorpecovnik"
 	["manage_overlayfs,ref_link"]=""
-	["manage_overlayfs,feature"]="overlayfs"
+	["manage_overlayfs,feature"]="manage_overlayfs"
 	["manage_overlayfs,desc"]="Set Armbian root filesystem to read only"
 	["manage_overlayfs,example"]="manage_overlayfs enable/disable"
 	["manage_overlayfs,status"]="Active"


### PR DESCRIPTION
no helper or modules named "overlayfs", "dtoverlay"
This oversight does not break array parsing, but does break database.

note: `dtoverlay` description is blank as was the `overlayfs` before correction. 
valid json
<img width="740" alt="image" src="https://github.com/user-attachments/assets/1781bc5e-dfb0-47bf-96ec-5bdac472806a">



