### PR TITLE
manage_dtoverlays: also set overlays with board name available

### DIFF
--- a/tools/modules/system/manage_dtoverlays.sh
+++ b/tools/modules/system/manage_dtoverlays.sh
@@ -24,7 +24,7 @@ function manage_dtoverlays () {
 		local options=()
 		j=0
 		if [[ -n "${BOOT_SOC}" ]]; then
-		available_overlays=$(ls -1 ${overlaydir}/*.dtbo | sed "s#^${overlaydir}/##" | sed 's/.dtbo//g' | grep $BOOT_SOC | tr '\n' ' ')
+		available_overlays=$(ls -1 ${overlaydir}/*.dtbo | sed "s#^${overlaydir}/##" | sed 's/.dtbo//g' | grep -E "$BOOT_SOC|$BOARD" | tr '\n' ' ')
 		else
 		available_overlays=$(ls -1 ${overlaydir}/*.dtbo | sed "s#^${overlaydir}/##" | sed 's/.dtbo//g' | tr '\n' ' ')
 		fi


### PR DESCRIPTION
There are dtbos with no BOOT_SOC, but board name in filename.
There are many of them in rockchip vendor kernel: https://github.com/armbian/linux-rockchip/tree/rk-6.1-rkr4.1/arch/arm64/boot/dts/rockchip/overlay. So set then available.