### PR TITLE
nfsd fixes

### DIFF
--- a/tools/json/config.system.json
+++ b/tools/json/config.system.json
@@ -152,7 +152,7 @@
                             "id": "NFS03",
                             "description": "Remove network filesystem (NFS) daemon",
                             "command": [
-                                "module_nfsd uninstall"
+                                "module_nfsd remove"
                             ],
                             "status": "Stable",
                             "author": "@igorpecovnik",

--- a/tools/modules/functions/service.sh
+++ b/tools/modules/functions/service.sh
@@ -1,0 +1,17 @@
+# service.sh
+
+declare -A module_options
+module_options+=(
+	["service,author"]="@dimitry-ishenko"
+	["service,desc"]="Wrapper for service manipulation"
+	["service,example"]="service install some.service"
+	["service,feature"]="service"
+	["service,status"]="active"
+)
+
+function service()
+{
+	# ignore these commands, if running inside container
+	[[ "$1" =~ ^(reload|restart|start|status|stop)$ ]] && systemd-detect-virt -qc && return 0
+	systemctl "$@"
+}

--- a/tools/modules/network/module_nfsd.sh
+++ b/tools/modules/network/module_nfsd.sh
@@ -14,6 +14,9 @@ function module_nfsd () {
 	local title="nfsd"
 	local condition=$(which "$title" 2>/dev/null)?
 
+	local package_name=nfs-kernel-server
+	local service_name=nfs-server.service
+
 	# we will store our config in subfolder
 	mkdir -p /etc/exports.d/
 
@@ -24,13 +27,13 @@ function module_nfsd () {
 
 	case "$1" in
 		"${commands[0]}")
-			apt_install_wrapper apt-get -y install nfs-common nfs-kernel-server
+			apt_install_wrapper apt-get -y install $package_name
 			# add some exports
 			${module_options["module_nfsd,feature"]} ${commands[2]}
-			systemctl restart nfs-server.service
+			service restart $service_name
 		;;
 		"${commands[1]}")
-			apt_install_wrapper apt-get -y autopurge nfs-kernel-server
+			apt_install_wrapper apt-get -y autopurge $package_name
 		;;
 		"${commands[2]}")
 			while true; do
@@ -65,7 +68,7 @@ function module_nfsd () {
 					break
 				fi
 			done
-			systemctl restart nfs-server.service
+			service restart $service_name
 		;;
 		"${commands[3]}")
 			# choose between most common options
@@ -96,11 +99,7 @@ function module_nfsd () {
 			fi
 		;;
 		"${commands[4]}")
-			if systemctl is-active --quiet nfs-server.service; then
-				return 0
-			else
-				return 1
-			fi
+			check_if_installed $package_name
 		;;
 		"${commands[5]}")
 			echo -e "\nUsage: ${module_options["module_nfsd,feature"]} <command>"
@@ -114,7 +113,7 @@ function module_nfsd () {
 			echo
 		;;
 		*)
-		${module_options["module_nfsd,feature"]} ${commands[5]}
+			${module_options["module_nfsd,feature"]} ${commands[5]}
 		;;
 	esac
 }


### PR DESCRIPTION
# Description

Added a few small fixes for the nfsd module while reviewing it for my Samba work. 

# Implementation Details

- [ ] Key changes introduced by this PR

1. Added a small wrapper script to abstract away dealing with systemd services. I work inside a container (using systemd-nspawn) so all commands attempting to start/stop/restart a service fail.

2. Fixed `status` command which didn't work inside the container due to failing `systemctl is-active` command. Plus, checking if the service is active is not the same as checking if it was installed.

3. Fixed `uninstall` command, which should be `remove` instead.

- [ ] Justification for the changes

See above.

- [ ] Confirmation that no new external dependencies or modules have been introduced

Confirmed.

# Documentation Summary

- [ ] **Metadata Included:**  
 
None.

- [ ] **Document Generated:**  

None.

# Testing Procedure

Installed and uninstalled nfsd inside the container a few times.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
