### PR TITLE
Add missing deps for generating deb file

### DIFF
--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -22,7 +22,7 @@ jobs:
       section: "default"
       priority: "optional"
       compile: "tools/config-assemble.sh -p"
-      depends: "bash, jq, whiptail, sudo, procps, systemd, lsb-release, iproute2"
+      depends: "bash, jq, whiptail, sudo, procps, systemd, lsb-release, iproute2, debconf, libtext-iconv-perl"
       description: "Armbian config: The Next Generation"
 
     secrets:


### PR DESCRIPTION
# Description

Adding dependencies for debian file generation.

Issue reference:  https://github.com/armbian/build/pull/7562 

# Implementation Details

@dimitry-ishenko added them to the main build framework, copy pasting here. We will eventually drop making .deb files twice and only install them from build framework. This should be dropped at one point https://armbian.atlassian.net/browse/AR-2562

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
