### PR TITLE
Add wrapper for service manipulation

### DIFF
--- a/tools/json/config.software.json
+++ b/tools/json/config.software.json
@@ -1634,7 +1634,7 @@
                                 "pkg_install avahi-daemon libnss-mdns",
                                 "cp /usr/share/doc/avahi-daemon/examples/sftp-ssh.service /etc/avahi/services/",
                                 "cp /usr/share/doc/avahi-daemon/examples/ssh.service /etc/avahi/services/",
-                                "service restart avahi-daemon"
+                                "srv_restart avahi-daemon.service"
                             ],
                             "status": "Stable",
                             "author": "@armbian",

--- a/tools/json/config.software.json
+++ b/tools/json/config.software.json
@@ -580,7 +580,7 @@
                             ],
                             "status": "Stable",
                             "author": "@igorpecovnik",
-                            "condition": "systemctl is-active --quiet service display-manager"
+                            "condition": "srv_active display-manager"
                         }
                     ]
                 },
@@ -1645,7 +1645,7 @@
                             "description": "avahi-daemon remove",
                             "prompt": "This operation will remove avahi-daemon.",
                             "command": [
-                                "systemctl stop avahi-daemon avahi-daemon.socket",
+                                "srv_stop avahi-daemon avahi-daemon.socket",
                                 "pkg_remove avahi-daemon"
                             ],
                             "status": "Stable",

--- a/tools/json/config.system.json
+++ b/tools/json/config.system.json
@@ -233,7 +233,7 @@
                             "description": "Disable root login",
                             "command": [
                                 "sed -i \"s|^#\\?PermitRootLogin.*|PermitRootLogin no|\" /etc/ssh/sshd_config",
-                                "systemctl restart sshd.service 2>/dev/null | systemctl restart ssh.service 2>/dev/null"
+                                "srv_restart ssh"
                             ],
                             "status": "Stable",
                             "author": "@igorpecovnik",
@@ -244,7 +244,7 @@
                             "description": "Enable root login",
                             "command": [
                                 "sed -i \"s/^#\\?PermitRootLogin.*/PermitRootLogin yes/\" /etc/ssh/sshd_config",
-                                "systemctl restart sshd.service 2>/dev/null | systemctl restart ssh.service 2>/dev/null"
+                                "srv_restart ssh"
                             ],
                             "status": "Stable",
                             "author": "@igorpecovnik",
@@ -255,7 +255,7 @@
                             "description": "Disable password login",
                             "command": [
                                 "sed -i \"s/^#\\?PasswordAuthentication.*/PasswordAuthentication no/\" /etc/ssh/sshd_config",
-                                "systemctl restart sshd.service 2>/dev/null | systemctl restart ssh.service 2>/dev/null"
+                                "srv_restart ssh"
                             ],
                             "status": "Stable",
                             "author": "@igorpecovnik",
@@ -266,7 +266,7 @@
                             "description": "Enable password login",
                             "command": [
                                 "sed -i \"s/^#\\?PasswordAuthentication.*/PasswordAuthentication yes/\" /etc/ssh/sshd_config",
-                                "systemctl restart sshd.service 2>/dev/null | systemctl restart ssh.service 2>/dev/null"
+                                "srv_restart ssh"
                             ],
                             "status": "Stable",
                             "author": "@igorpecovnik",
@@ -277,7 +277,7 @@
                             "description": "Disable Public key authentication login",
                             "command": [
                                 "sed -i \"s/^#\\?PubkeyAuthentication.*/PubkeyAuthentication no/\" /etc/ssh/sshd_config",
-                                "systemctl restart sshd.service 2>/dev/null | systemctl restart ssh.service 2>/dev/null"
+                                "srv_restart ssh"
                             ],
                             "status": "Stable",
                             "author": "@igorpecovnik",
@@ -288,7 +288,7 @@
                             "description": "Enable Public key authentication login",
                             "command": [
                                 "sed -i \"s/^#\\?PubkeyAuthentication.*/PubkeyAuthentication yes/\" /etc/ssh/sshd_config",
-                                "systemctl restart sshd.service 2>/dev/null | systemctl restart ssh.service 2>/dev/null"
+                                "srv_restart ssh"
                             ],
                             "status": "Stable",
                             "author": "@igorpecovnik",
@@ -302,7 +302,7 @@
                                 "! pkg_installed libpam-google-authenticator && ! pkg_installed qrencode || pkg_remove libpam-google-authenticator qrencode",
                                 "sed -i \"s/^#\\?ChallengeResponseAuthentication.*/ChallengeResponseAuthentication no/\" /etc/ssh/sshd_config || sed -i \"0,/KbdInteractiveAuthentication/s//ChallengeResponseAuthentication yes/\" /etc/ssh/sshd_config",
                                 "sed -i '/^auth required pam_google_authenticator.so nullok/ d' /etc/pam.d/sshd",
-                                "systemctl restart sshd.service 2>/dev/null | systemctl restart ssh.service 2>/dev/null"
+                                "srv_restart ssh"
                             ],
                             "status": "Stable",
                             "author": "@igorpecovnik",
@@ -317,7 +317,7 @@
                                 "sed -i \"s/^#\\?ChallengeResponseAuthentication.*/ChallengeResponseAuthentication yes/\" /etc/ssh/sshd_config",
                                 "sed -i $'/KbdInteractiveAuthentication/{iChallengeResponseAuthentication yes\\n:a;n;ba}' /etc/ssh/sshd_config || sed -n -i '/password updating/{p;:a;N;/@include common-password/!ba;s/.*\\n/auth required pam_google_authenticator.so nullok\\nauth required pam_permit.so\\n/};p' /etc/pam.d/sshd",
                                 "[ ! -f /root/.google_authenticator ] && qr_code generate",
-                                "systemctl restart sshd.service 2>/dev/null | systemctl restart ssh.service 2>/dev/null"
+                                "srv_restart ssh"
                             ],
                             "status": "Stable",
                             "author": "@igorpecovnik",
@@ -348,7 +348,7 @@
                             "description": "Disable last login banner",
                             "command": [
                                 "sed -i \"s/^#\\?PrintLastLog.*/PrintLastLog no/\" /etc/ssh/sshd_config",
-                                "systemctl restart ssh.service "
+                                "srv_restart ssh"
                             ],
                             "status": "Stable",
                             "author": "@igorpecovnik",
@@ -359,7 +359,7 @@
                             "description": "Enable last login banner",
                             "command": [
                                 "sed -i \"s/^#\\?PrintLastLog.*/PrintLastLog yes/\" /etc/ssh/sshd_config",
-                                "systemctl restart ssh.service "
+                                "srv_restart ssh"
                             ],
                             "status": "Stable",
                             "author": "@igorpecovnik",

--- a/tools/modules/functions/check_desktop.sh
+++ b/tools/modules/functions/check_desktop.sh
@@ -13,13 +13,13 @@ module_options+=(
 #
 function check_desktop() {
 
-	DISPLAY_MANAGER=""
-	DESKTOP_INSTALLED=""
+	unset DESKTOP_INSTALLED
 	pkg_installed nodm && DESKTOP_INSTALLED="nodm"
 	pkg_installed lightdm && DESKTOP_INSTALLED="lightdm"
 	pkg_installed gdm3 && DESKTOP_INSTALLED="gnome"
-	[[ -n $(service lightdm status 2> /dev/null | grep -w active) ]] && DISPLAY_MANAGER="lightdm"
-	[[ -n $(service nodm status 2> /dev/null | grep -w active) ]] && DISPLAY_MANAGER="nodm"
-	[[ -n $(service gdm status 2> /dev/null | grep -w active) ]] && DISPLAY_MANAGER="gdm"
 
+	unset DISPLAY_MANAGER
+	srv_active nodm && DISPLAY_MANAGER="nodm"
+	srv_active lightdm && DISPLAY_MANAGER="lightdm"
+	srv_active gdm && DISPLAY_MANAGER="gdm"
 }

--- a/tools/modules/functions/service.sh
+++ b/tools/modules/functions/service.sh
@@ -1,18 +1,125 @@
 # service.sh
 
+# internal function
+_srv_inside_jail() { systemd-detect-virt -qc; }
+
 declare -A module_options
 module_options+=(
-	["service,author"]="@dimitry-ishenko"
-	["service,desc"]="Wrapper for service manipulation"
-	["service,example"]="service install some.service"
-	["service,feature"]="service"
-	["service,status"]="active"
+	["srv_active,author"]="@dimitry-ishenko"
+	["srv_active,desc"]="Check if service is active"
+	["srv_active,example"]="srv_active ssh.service"
+	["srv_active,feature"]="srv_active"
+	["srv_active,status"]="Interface"
 )
 
-function service()
+srv_active()
 {
-	# ignore these commands, if running inside container
-	[[ "$1" =~ ^(reload|restart|start|status|stop)$ ]] && systemd-detect-virt -qc && return 0
-	systemctl daemon-reload
-	systemctl "$@"
+	# ignore inside container
+	_srv_inside_jail && return 1 || systemctl is-active --quiet "$@"
 }
+
+module_options+=(
+	["srv_disable,author"]="@dimitry-ishenko"
+	["srv_disable,desc"]="Disable service"
+	["srv_disable,example"]="srv_disable ssh.service"
+	["srv_disable,feature"]="srv_disable"
+	["srv_disable,status"]="Interface"
+)
+
+srv_disable() { systemctl disable "$@"; }
+
+module_options+=(
+	["srv_enable,author"]="@dimitry-ishenko"
+	["srv_enable,desc"]="Enable service"
+	["srv_enable,example"]="srv_enable ssh.service"
+	["srv_enable,feature"]="srv_enable"
+	["srv_enable,status"]="Interface"
+)
+
+srv_enable() { systemctl enable "$@"; }
+
+module_options+=(
+	["srv_enabled,author"]="@dimitry-ishenko"
+	["srv_enabled,desc"]="Check if service is enabled"
+	["srv_enabled,example"]="srv_enabled ssh.service"
+	["srv_enabled,feature"]="srv_enabled"
+	["srv_enabled,status"]="Interface"
+)
+
+srv_enabled() { systemctl is-enabled "$@"; }
+
+module_options+=(
+	["srv_mask,author"]="@dimitry-ishenko"
+	["srv_mask,desc"]="Mask service"
+	["srv_mask,example"]="srv_mask ssh.service"
+	["srv_mask,feature"]="srv_mask"
+	["srv_mask,status"]="Interface"
+)
+
+srv_mask() { systemctl mask "$@"; }
+
+module_options+=(
+	["srv_reload,author"]="@dimitry-ishenko"
+	["srv_reload,desc"]="Reload service"
+	["srv_reload,example"]="srv_reload ssh.service"
+	["srv_reload,feature"]="srv_reload"
+	["srv_reload,status"]="Interface"
+)
+
+srv_reload()
+{
+	# ignore inside container
+	_srv_inside_jail || systemctl reload "$@"
+}
+
+module_options+=(
+	["srv_restart,author"]="@dimitry-ishenko"
+	["srv_restart,desc"]="Restart service"
+	["srv_restart,example"]="srv_restart ssh.service"
+	["srv_restart,feature"]="srv_restart"
+	["srv_restart,status"]="Interface"
+)
+
+srv_restart()
+{
+	# ignore inside container
+	_srv_inside_jail || systemctl restart "$@"
+}
+
+module_options+=(
+	["srv_start,author"]="@dimitry-ishenko"
+	["srv_start,desc"]="Start service"
+	["srv_start,example"]="srv_start ssh.service"
+	["srv_start,feature"]="srv_start"
+	["srv_start,status"]="Interface"
+)
+
+srv_start()
+{
+	# ignore inside container
+	_srv_inside_jail || systemctl start "$@"
+}
+
+module_options+=(
+	["srv_stop,author"]="@dimitry-ishenko"
+	["srv_stop,desc"]="Stop service"
+	["srv_stop,example"]="srv_stop ssh.service"
+	["srv_stop,feature"]="srv_stop"
+	["srv_stop,status"]="Interface"
+)
+
+srv_stop()
+{
+	# ignore inside container
+	_srv_inside_jail || systemctl stop "$@"
+}
+
+module_options+=(
+	["srv_unmask,author"]="@dimitry-ishenko"
+	["srv_unmask,desc"]="Unmask service"
+	["srv_unmask,example"]="srv_unmask ssh.service"
+	["srv_unmask,feature"]="srv_unmask"
+	["srv_unmask,status"]="Interface"
+)
+
+srv_unmask() { systemctl unmask "$@"; }

--- a/tools/modules/functions/service.sh
+++ b/tools/modules/functions/service.sh
@@ -18,6 +18,21 @@ srv_active()
 	_srv_system_running && systemctl is-active --quiet "$@"
 }
 
+declare -A module_options
+module_options+=(
+	["srv_daemon_reload,author"]="@dimitry-ishenko"
+	["srv_daemon_reload,desc"]="Reload systemd configuration"
+	["srv_daemon_reload,example"]="srv_daemon_reload"
+	["srv_daemon_reload,feature"]="srv_daemon_reload"
+	["srv_daemon_reload,status"]="Interface"
+)
+
+srv_daemon_reload()
+{
+	# ignore inside container
+	_srv_system_running && systemctl daemon-reload || true
+}
+
 module_options+=(
 	["srv_disable,author"]="@dimitry-ishenko"
 	["srv_disable,desc"]="Disable service"

--- a/tools/modules/functions/service.sh
+++ b/tools/modules/functions/service.sh
@@ -116,6 +116,16 @@ srv_start()
 }
 
 module_options+=(
+	["srv_status,author"]="@dimitry-ishenko"
+	["srv_status,desc"]="Show service status information"
+	["srv_status,example"]="srv_status ssh.service"
+	["srv_status,feature"]="srv_status"
+	["srv_status,status"]="Interface"
+)
+
+srv_status() { systemctl status "$@"; }
+
+module_options+=(
 	["srv_stop,author"]="@dimitry-ishenko"
 	["srv_stop,desc"]="Stop service"
 	["srv_stop,example"]="srv_stop ssh.service"

--- a/tools/modules/functions/service.sh
+++ b/tools/modules/functions/service.sh
@@ -1,7 +1,7 @@
 # service.sh
 
 # internal function
-_srv_inside_jail() { systemd-detect-virt -qc; }
+_srv_system_running() { [[ $(systemctl is-system-running) =~ ^(running|degraded)$ ]]; }
 
 declare -A module_options
 module_options+=(
@@ -14,8 +14,8 @@ module_options+=(
 
 srv_active()
 {
-	# ignore inside container
-	_srv_inside_jail && return 1 || systemctl is-active --quiet "$@"
+	# fail inside container
+	_srv_system_running && systemctl is-active --quiet "$@"
 }
 
 module_options+=(
@@ -69,7 +69,7 @@ module_options+=(
 srv_reload()
 {
 	# ignore inside container
-	_srv_inside_jail || systemctl reload "$@"
+	_srv_system_running && systemctl reload "$@" || true
 }
 
 module_options+=(
@@ -83,7 +83,7 @@ module_options+=(
 srv_restart()
 {
 	# ignore inside container
-	_srv_inside_jail || systemctl restart "$@"
+	_srv_system_running && systemctl restart "$@" || true
 }
 
 module_options+=(
@@ -97,7 +97,7 @@ module_options+=(
 srv_start()
 {
 	# ignore inside container
-	_srv_inside_jail || systemctl start "$@"
+	_srv_system_running && systemctl start "$@" || true
 }
 
 module_options+=(
@@ -111,7 +111,7 @@ module_options+=(
 srv_stop()
 {
 	# ignore inside container
-	_srv_inside_jail || systemctl stop "$@"
+	_srv_system_running && systemctl stop "$@" || true
 }
 
 module_options+=(

--- a/tools/modules/functions/set_runtime_variables.sh
+++ b/tools/modules/functions/set_runtime_variables.sh
@@ -31,7 +31,7 @@ function set_runtime_variables() {
 	fi
 
 	# Determine which network renderer is in use for NetPlan
-	if systemctl is-active NetworkManager 1> /dev/null; then
+	if srv_active NetworkManager; then
 		NETWORK_RENDERER=NetworkManager
 	else
 		NETWORK_RENDERER=networkd

--- a/tools/modules/network/default_network_config.sh
+++ b/tools/modules/network/default_network_config.sh
@@ -22,8 +22,8 @@ function default_network_config() {
 		# remove all configs
 		rm -f /etc/netplan/*.yaml
 		# disable hostapd
-		systemctl stop hostapd 2> /dev/null
-		systemctl disable hostapd 2> /dev/null
+		srv_stop hostapd
+		srv_disable hostapd
 		# reset netplan config
 		netplan set --origin-hint ${yamlfile} renderer=${NETWORK_RENDERER}
 		netplan set --origin-hint ${yamlfile} ethernets.all-eth-interfaces.dhcp4=true

--- a/tools/modules/network/default_wireless_network_config.sh
+++ b/tools/modules/network/default_wireless_network_config.sh
@@ -27,9 +27,9 @@ function default_wireless_network_config(){
 	rm -f /etc/NetworkManager/dispatcher.d/armbian-ap
 
 	# hostapd needs more cleaning
-	if systemctl is-active hostapd 1> /dev/null; then
-		systemctl stop hostapd 2> /dev/null
-		systemctl disable hostapd 2> /dev/null
+	if srv_active hostapd; then
+		srv_stop hostapd
+		srv_disable hostapd
 	fi
 
 	# apply config
@@ -39,7 +39,7 @@ function default_wireless_network_config(){
 	if [[ "${NETWORK_RENDERER}" == "NetworkManager" ]]; then
 		# uninstall packages
 		pkg_remove hostapd
-		systemctl restart NetworkManager
+		srv_restart NetworkManager
 	else
 		# uninstall packages
 		pkg_remove hostapd networkd-dispatcher

--- a/tools/modules/network/network_config.sh
+++ b/tools/modules/network/network_config.sh
@@ -40,7 +40,7 @@ function network_config() {
 		if [[ "$adapter" == w* ]]; then
 
 			LIST=()
-			if systemctl is-active --quiet service hostapd; then
+			if srv_active hostapd; then
 				LIST+=("stop" "Disable access point")
 			else
 				LIST=("sta" "Connect to access point")
@@ -142,9 +142,9 @@ function network_config() {
 						EOF
 						netplan apply
 						# Start hostapd services
-						systemctl unmask hostapd 2>/dev/null
-						systemctl enable hostapd 2>/dev/null
-						systemctl start hostapd 2>/dev/null
+						srv_unmask hostapd
+						srv_enable hostapd
+						srv_start hostapd
 						# Sometimes it fails to add to the bridge
 						brctl addif br0 $adapter 2>/dev/null
 						# Add hooks to hack wrong if type
@@ -158,7 +158,7 @@ function network_config() {
 							case "\$status" in
 								up)
 									if [[ "\$interface" == "br0" ]]; then
-										service hostapd restart
+										srv_restart hostapd
 										brctl addif br0 $adapter
 									fi
 								;;
@@ -231,7 +231,7 @@ function network_config() {
 				if [[ $? = 0 ]]; then
 					# apply NetPlan
 					netplan apply
-					[[ "${NETWORK_RENDERER}" == "NetworkManager" ]] && systemctl restart NetworkManager;
+					[[ "${NETWORK_RENDERER}" == "NetworkManager" ]] && srv_restart NetworkManager
 				else
 					restore_netplan_config
 				fi
@@ -280,7 +280,7 @@ function network_config() {
 						if [[ $? = 0 ]]; then
 							# apply NetPlan
 							netplan apply
-							[[ "${NETWORK_RENDERER}" == "NetworkManager" ]] && systemctl restart NetworkManager;
+							[[ "${NETWORK_RENDERER}" == "NetworkManager" ]] && srv_restart NetworkManager
 						else
 							restore_netplan_config
 						fi

--- a/tools/modules/software/module_adguardhome.sh
+++ b/tools/modules/software/module_adguardhome.sh
@@ -58,14 +58,14 @@ function module_adguardhome () {
 				fi
 			done
 			local container_ip=$(docker inspect --format '{{ .NetworkSettings.Networks.lsio.IPAddress }}' adguardhome)
-			if systemctl is-active --quiet systemd-resolved.service; then
+			if srv_active systemd-resolved; then
 				mkdir -p /etc/systemd/resolved.conf.d/
 				cat > "/etc/systemd/resolved.conf.d/armbian-defaults.conf" <<- EOT
 				[Resolve]
 				DNS=127.0.0.1 ${container_ip}
 				DNSStubListener=no
 				EOT
-				systemctl restart systemd-resolved.service
+				srv_restart systemd-resolved
 				sleep 2
 			fi
 		;;
@@ -73,13 +73,13 @@ function module_adguardhome () {
 			[[ "${container}" ]] && docker container rm -f "$container" >/dev/null
 			[[ "${image}" ]] && docker image rm "$image" >/dev/null
 			# restore DNS settings
-			if systemctl is-active --quiet systemd-resolved.service; then
+			if srv_active systemd-resolved; then
 				mkdir -p /etc/systemd/resolved.conf.d/
 				cat > "/etc/systemd/resolved.conf.d/armbian-defaults.conf" <<- EOT
 				[Resolve]
 				DNSStubListener=no
 				EOT
-				systemctl restart systemd-resolved.service
+				srv_restart systemd-resolved
 				sleep 2
 			fi
 		;;

--- a/tools/modules/software/module_cockpit.sh
+++ b/tools/modules/software/module_cockpit.sh
@@ -27,16 +27,15 @@ function module_cockpit() {
 		if [[ -z "$condition" ]]; then
 			echo -e "  install\t- Install $title."
 		else
-			if [[ "$(systemctl is-active cockpit.socket 2>/dev/null)" == "active" ]]; then
+			if srv_active cockpit.socket; then
 				echo -e "\tstop\t- Stop the $title service."
 			else
-			echo -e "\tstart\t- Start the $title service."
+				echo -e "\tstart\t- Start the $title service."
 			fi
-			if [[ $(systemctl is-enabled cockpit.socket) == "enabled" ]]; then
-			echo -e "\tdisable\t- Disable $title from starting on boot."
-			elif [[ $(systemctl is-enabled cockpit.socket) == "disabled" ]]; then
-			echo -e "\tenable\t- Enable $title to start on boot."
-
+			if srv_enabled cockpit.socket; then
+				echo -e "\tdisable\t- Disable $title from starting on boot."
+			else
+				echo -e "\tenable\t- Enable $title to start on boot."
 			fi
 			echo -e "\tstatus\t- Show the status of the $title service."
 			echo -e "\tremove\t- Remove $title."
@@ -44,52 +43,40 @@ function module_cockpit() {
 		echo
 		;;
 		"${commands[1]}")
-		## install cockpit
 		pkg_update
 		pkg_install cockpit cockpit-ws cockpit-system cockpit-storaged
 		echo "Cockpit installed successfully."
 		;;
 		"${commands[2]}")
-		## remove cockpit
-		systemctl disable cockpit cockpit.socket
+		srv_disable cockpit cockpit.socket
 		pkg_remove cockpit
 		echo "Cockpit removed successfully."
 		;;
 		"${commands[3]}")
-		## start cockpit
-
-		systemctl start cockpit.socket
+		srv_start cockpit.socket
 		echo "Cockpit service started."
 		;;
 		"${commands[4]}")
-		## stop cockpit
-
-		systemctl stop cockpit.socket
+		srv_stop cockpit.socket
 		echo "Cockpit service stopped."
 		;;
 		"${commands[5]}")
-		## enable cockpit
-		#systemctl enable cockpit
-		systemctl enable cockpit.socket
+		srv_enable cockpit.socket
 		echo "Cockpit service enabled."
 		;;
 		"${commands[6]}")
-		## disable cockpit
-		#systemctl disable cockpit
-		systemctl disable cockpit.socket
+		srv_disable cockpit.socket
 		echo "Cockpit service disabled."
 		;;
 		"${commands[7]}")
-		## status cockpit
-		#systemctl status cockpit
-		systemctl status cockpit.socket
+		srv_status cockpit.socket
 		;;
 		"${commands[-1]}")
 		## check cockpit status
-		if [[ $(systemctl is-active cockpit.socket) == "active" ]]; then
+		if srv_active cockpit.socket; then
 			echo "Cockpit service is active."
 			return 0
-		elif [[ $(systemctl is-enabled cockpit.socket) == "disabled" ]]; then
+		elif ! srv_enabled cockpit.socket; then
 			echo "Cockpit service is disabled."
 			return 0
 		else

--- a/tools/modules/software/module_docker.sh
+++ b/tools/modules/software/module_docker.sh
@@ -45,9 +45,8 @@ function module_docker() {
 
 					groupadd docker 2>/dev/null || true
 					[[ -n "${SUDO_USER}" ]] && usermod -aG docker "${SUDO_USER}"
-					systemctl enable docker.service > /dev/null 2>&1
-					systemctl enable containerd.service > /dev/null 2>&1
-					systemctl start docker.service > /dev/null 2>&1
+					srv_enable docker containerd
+					srv_start docker
 					docker network create lsio 2> /dev/null
 				fi
 			else

--- a/tools/modules/software/module_haos.sh
+++ b/tools/modules/software/module_haos.sh
@@ -34,7 +34,7 @@ function module_haos() {
 			[[ -d "$HAOS_BASE" ]] || mkdir -p "$HAOS_BASE" || { echo "Couldn't create storage directory: $HAOS_BASE"; exit 1; }
 
 			# this hack will allow running it on minimal image, but this has to be done properly in the network section, to allow easy switching
-			systemctl disable systemd-networkd
+			srv_disable systemd-networkd
 
 			# hack to force install
 			sed -i 's/^PRETTY_NAME=".*/PRETTY_NAME="Debian GNU\/Linux 12 (bookworm)"/g' "${SDCARD}/etc/os-release"
@@ -62,7 +62,7 @@ function module_haos() {
 			while true; do
 			if ha supervisor info 2>&1 | grep -q "healthy: false"; then
 				echo "Unhealthy detected, restarting" | systemd-cat -t $(basename "$0") -p debug
-				systemctl restart hassio-supervisor.service
+				srv_restart hassio-supervisor
 				sleep 600
 			else
 				sleep 5
@@ -103,8 +103,8 @@ function module_haos() {
 			done | $DIALOG --gauge "Preparing Home Assistant Supervised\n\nPlease wait! (can take 15 minutes) " 10 50 0
 
 			# enable service
-			systemctl enable supervisor-fix >/dev/null 2>&1
-			systemctl start supervisor-fix >/dev/null 2>&1
+			srv_enable supervisor-fix
+			srv_start supervisor-fix
 
 			# restore os-release
 			sed -i "s/^PRETTY_NAME=\".*/PRETTY_NAME=\"${VENDOR} ${REVISION} ($VERSION_CODENAME)\"/g" "/etc/os-release"
@@ -112,8 +112,8 @@ function module_haos() {
 		;;
 		"${commands[1]}")
 			# disable service
-			systemctl disable supervisor-fix >/dev/null 2>&1
-			systemctl stop supervisor-fix >/dev/null 2>&1
+			srv_disable supervisor-fix
+			srv_stop supervisor-fix
 			pkg_remove homeassistant-supervised os-agent
 			echo -e "Removing Home Assistant containers.\n\nPlease wait few minutes! "
 			if [[ "${container}" ]]; then
@@ -126,7 +126,7 @@ function module_haos() {
 			rm -f /usr/local/bin/supervisor_fix.sh
 			rm -f /etc/systemd/system/supervisor-fix.service
 			sed -i "s/ systemd.unified_cgroup_hierarchy=0 apparmor=1 security=apparmor//" /boot/armbianEnv.txt
-			systemctl daemon-reload >/dev/null 2>&1
+			srv_daemon_reload
 			# restore os-release
 			sed -i "s/^PRETTY_NAME=\".*/PRETTY_NAME=\"${VENDOR} ${REVISION} ($VERSION_CODENAME)\"/g" "/etc/os-release"
 		;;

--- a/tools/modules/software/module_openhab.sh
+++ b/tools/modules/software/module_openhab.sh
@@ -30,9 +30,9 @@ function module_openhab() {
 			pkg_update
 			pkg_install zulu17-jdk
 			pkg_install openhab openhab-addons
-			systemctl daemon-reload 2> /dev/null
-			srv_enable openhab.service 2> /dev/null
-			srv_start openhab.service 2> /dev/null
+			srv_daemon_reload
+			srv_enable openhab
+			srv_start openhab
 			;;
 		"${commands[1]}")
 			pkg_remove zulu17-jdk openhab openhab-addons

--- a/tools/modules/software/module_openhab.sh
+++ b/tools/modules/software/module_openhab.sh
@@ -31,8 +31,8 @@ function module_openhab() {
 			pkg_install zulu17-jdk
 			pkg_install openhab openhab-addons
 			systemctl daemon-reload 2> /dev/null
-			service enable openhab.service 2> /dev/null
-			service start openhab.service 2> /dev/null
+			srv_enable openhab.service 2> /dev/null
+			srv_start openhab.service 2> /dev/null
 			;;
 		"${commands[1]}")
 			pkg_remove zulu17-jdk openhab openhab-addons

--- a/tools/modules/software/module_pi-hole.sh
+++ b/tools/modules/software/module_pi-hole.sh
@@ -58,14 +58,14 @@ function module_pi_hole () {
 				fi
 			done
 			local container_ip=$(docker inspect --format '{{ .NetworkSettings.Networks.lsio.IPAddress }}' pihole)
-			if systemctl is-active --quiet systemd-resolved.service; then
+			if srv_active systemd-resolved; then
 				mkdir -p /etc/systemd/resolved.conf.d/
 				cat > "/etc/systemd/resolved.conf.d/armbian-defaults.conf" <<- EOT
 				[Resolve]
 				DNS=127.0.0.1 ${container_ip}
 				DNSStubListener=no
 				EOT
-				systemctl restart systemd-resolved.service
+				srv_restart systemd-resolved
 				sleep 2
 			fi
 		;;
@@ -73,13 +73,13 @@ function module_pi_hole () {
 			[[ "${container}" ]] && docker container rm -f "$container" >/dev/null
 			[[ "${image}" ]] && docker image rm "$image" >/dev/null
 			# restore DNS settings
-			if systemctl is-active --quiet systemd-resolved.service; then
+			if srv_active systemd-resolved; then
 				mkdir -p /etc/systemd/resolved.conf.d/
 				cat > "/etc/systemd/resolved.conf.d/armbian-defaults.conf" <<- EOT
 				[Resolve]
 				DNSStubListener=no
 				EOT
-				systemctl restart systemd-resolved.service
+				srv_restart systemd-resolved
 				sleep 2
 			fi
 		;;

--- a/tools/modules/software/module_webmin.sh
+++ b/tools/modules/software/module_webmin.sh
@@ -29,7 +29,7 @@ function module_webmin() {
 				echo -e "  install\t- Install $title."
 			else
 
-			if [[ "$(systemctl is-active webmin 2>/dev/null)" == "active" ]]; then
+			if srv_active webmin; then
 				echo -e "\tstop\t- Stop the $title service."
 				echo -e "\tdisable\t- Disable $title from starting on boot."
 			else
@@ -54,7 +54,7 @@ function module_webmin() {
 		;;
 		"${commands[2]}")
 			## remove webmin
-			systemctl disable webmin
+			srv_disable webmin
 			pkg_remove webmin
 			rm /etc/apt/sources.list.d/webmin.list
 			rm /usr/share/keyrings/webmin-archive-keyring.gpg
@@ -63,40 +63,35 @@ function module_webmin() {
 		;;
 
 		"${commands[3]}")
-			## start webmin
-			sudo systemctl start webmin
+			srv_start webmin
 			echo "Webmin service started."
 			;;
 
 		"${commands[4]}")
-			## stop webmin
-			sudo systemctl stop webmin
+			srv_stop webmin
 			echo "Webmin service stopped."
 			;;
 
 		"${commands[5]}")
-			## enable webmin
-			sudo systemctl enable webmin
+			srv_enable webmin
 			echo "Webmin service enabled."
 			;;
 
 		"${commands[6]}")
-			## disable webmin
-			sudo systemctl disable webmin
+			srv_disable webmin
 			echo "Webmin service disabled."
 			;;
 
 		"${commands[7]}")
-			## status webmin
-			sudo systemctl status webmin
+			srv_status webmin
 			;;
 
 		"${commands[8]}")
 			## check webmin status
-			if [[ $(systemctl is-active webmin) == "active" ]]; then
+			if srv_active webmin; then
 				echo "Webmin service is active."
 				return 0
-			elif [[ $(systemctl is-enabled webmin) == "disabled" ]]; then
+			elif ! srv_enabled webmin ]]; then
 				echo "Webmin service is disabled."
 				return 1
 			else

--- a/tools/modules/system/manage_desktops.sh
+++ b/tools/modules/system/manage_desktops.sh
@@ -60,16 +60,14 @@ function manage_desktops() {
 			manage_desktops "$desktop" "auto"
 
 			# stop display managers in case we are switching them
-			service gdm3 stop
-			service lightdm stop
-			service sddm stop
+			srv_stop gdm3 lightdm sddm
 
 			# start new default display manager
-			service display-manager restart
+			srv_restart display-manager
 		;;
 		uninstall)
 			# we are uninstalling all variants until build time packages are fixed to prevent installing one over another
-			service display-manager stop
+			srv_stop display-manager
 			pkg_remove -o Dpkg::Options::="--force-confold" armbian-${DISTROID}-desktop-$1 \
 				xfce4-session gnome-session slick-greeter lightdm gdm3 sddm cinnamon-session i3-wm
 			# disable autologins
@@ -109,7 +107,7 @@ function manage_desktops() {
 				;;
 			esac
 			# restart after selection
-			service display-manager restart
+			srv_restart display-manager
 		;;
 		manual)
 			case "$desktop" in
@@ -118,7 +116,7 @@ function manage_desktops() {
 				*)        rm -f /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf ;;
 			esac
 			# restart after selection
-			service display-manager restart
+			srv_restart display-manager
 		;;
 	esac
 

--- a/tools/modules/system/module_nfs.sh
+++ b/tools/modules/system/module_nfs.sh
@@ -75,7 +75,7 @@ function module_nfs () {
 								mkdir -p ${mount_folder}
 								sed -i '\?^'$nfs_server:$shares'?d' /etc/fstab
 								echo "${nfs_server}:${shares} ${mount_folder} nfs ${mount_options}" >> /etc/fstab
-								systemctl daemon-reload
+								srv_daemon_reload
 								mount ${mount_folder}
 								show_message <<< $(mount -t nfs4 | cut -d" " -f1)
 							fi

--- a/tools/modules/system/module_nfsd.sh
+++ b/tools/modules/system/module_nfsd.sh
@@ -154,7 +154,7 @@ function module_nfsd () {
 								read
 								sed -i '\?^'$nfs_server:$shares'?d' /etc/fstab
 								echo "${nfs_server}:${shares} ${mount_folder} nfs ${mount_options}" >> /etc/fstab
-								systemctl daemon-reload
+								srv_daemon_reload
 								mount ${mount_options}
 							fi
 							fi

--- a/tools/modules/system/module_nfsd.sh
+++ b/tools/modules/system/module_nfsd.sh
@@ -29,7 +29,7 @@ function module_nfsd () {
 			pkg_install nfs-common nfs-kernel-server
 			# add some exports
 			${module_options["module_nfsd,feature"]} ${commands[2]}
-			service restart $service_name
+			srv_restart $service_name
 		;;
 		"${commands[1]}")
 			pkg_remove nfs-kernel-server
@@ -67,7 +67,7 @@ function module_nfsd () {
 					break
 				fi
 			done
-			service restart $service_name
+			srv_restart $service_name
 		;;
 		"${commands[3]}")
 			# choose between most common options

--- a/tools/modules/system/toggle_ssh_lastlog.sh
+++ b/tools/modules/system/toggle_ssh_lastlog.sh
@@ -14,7 +14,7 @@ function toggle_ssh_lastlog() {
 	if ! grep -q '^#\?PrintLastLog ' "${SDCARD}/etc/ssh/sshd_config"; then
 		# If PrintLastLog is not found, append it with the value 'yes'
 		echo 'PrintLastLog no' >> "${SDCARD}/etc/ssh/sshd_config"
-		sudo service ssh restart
+		srv_restart ssh
 	else
 		# If PrintLastLog is found, toggle between 'yes' and 'no'
 		sed -i '/^#\?PrintLastLog /
@@ -23,7 +23,7 @@ function toggle_ssh_lastlog() {
 	t;
 	s/PrintLastLog no/PrintLastLog yes/
 }' "${SDCARD}/etc/ssh/sshd_config"
-		sudo service ssh restart
+		srv_restart ssh
 	fi
 
 }


### PR DESCRIPTION
# Description

Add consistent interface to enable/disable, start/stop and query systemd services. This PR tries to abstract package manipulation (not entirely unlike PR #320), remove some boiler-plate and have something that's easy to maintain in the future.

For example, `srv_reload`, `srv_start`, etc. functions check if they are running inside container, and if so, will silently ignore their command.

# Implementation Details

The following functions were added:
```
srv_active  some.service
srv_daemon_reload
srv_disable some.service
srv_enable  some.service
srv_enabled some.service
srv_mask    some.service
srv_reload  some.service
srv_restart some.service
srv_start   some.service
srv_stop    some.service
srv_status  some.service
srv_unmask  some.service
```
# Testing Procedure

Used `armbian-config` in interactive mode to install/uninstall several apps that start and stop services. Also, used non-interactive mode to run several `--cmd` commands.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
