### PR TITLE
[fix] Non interactive modes ( [Bug]: sanitize_input #324 )

### DIFF
--- a/bin/armbian-config
+++ b/bin/armbian-config
@@ -97,13 +97,19 @@ case "$1" in
 	;;
 "--api")
 	shift
+	# stage for seperation 
+	[[ -z "$@" ]] && generate_json_options ;
+	exit 0
+	;;
+"--noint")
+	shift
 	if [[ -z "$1" || "$1" == "help" ]]; then
 		see_use
 		exit 0
 	fi
 	option="$1"
 	shift
-	args=$(sanitize_input "$@")
+	args="$@"
 	# echo -e "\"$option\" \"$args\""
 	"$option" "$args"
 	exit 0


### PR DESCRIPTION
Issues 
- #324 
- #322 
- #325 

Staging for refining `Non interactive` modes. 
added option "--noint" 
stage "--api" for json I/O (currently only out). 
Remove calls for `sanitize_input` in main binary options, 


