### PR TITLE
Closes #333 - Remove redundant install argument in module_armbian_firmware.sh

### DIFF
--- a/tools/modules/system/module_armbian_firmware.sh
+++ b/tools/modules/system/module_armbian_firmware.sh
@@ -103,7 +103,7 @@ function module_armbian_firmware() {
 			for pkg in ${packages[@]}; do
 				purge_pkg=$(echo $pkg | sed -e 's/linux-image.*/linux-image*/;s/linux-dtb.*/linux-dtb*/;s/linux-headers.*/linux-headers*/;s/armbian-firmware.*/armbian-firmware*/')
 				# if test install is succesfull, proceed
-				pkg_install --simulate --download-only --allow-downgrades install "${pkg}"
+				pkg_install --simulate --download-only --allow-downgrades "${pkg}"
 				if [[ $? == 0 ]]; then
 					pkg_remove "${purge_pkg}"
 					pkg_install --allow-downgrades "${pkg}"


### PR DESCRIPTION
# Description

Removes redundant install argument from pkg_install comment when installing kernels. Issue introduced by #320.

Issue reference: Fixes #333
Related documentation: N/A

# Implementation Details

Removes a redundant argument so that kernel installation works properly.

- [x] Key changes introduced by this PR
- [x] Justification for the changes
- [x] Confirmation that no new external dependencies or modules have been introduced

# Documentation Summary

- [x] **Metadata Included:** N/A
- [x] **Document Generated:** N/A - no documentation change

# Testing Procedure

_Describe the tests you ran to verify your changes. Provide relevant details about your test configuration._

- [x] Test 1: Manually edited /lib/armbian-config/config.system.sh on my machine and ran and it successfully installed the kernel whereas before it wasn't working.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
