### PR TITLE
Remove escape character from runtime

### DIFF
--- a/tools/modules/runtime/config.runtime.sh
+++ b/tools/modules/runtime/config.runtime.sh
@@ -54,7 +54,7 @@ module_options+=(
 	["update_sub_submenu_data,author"]="@Tearran"
 	["update_sub_submenu_data,feature"]="update_sub_submenu_data"
 	["update_sub_submenu_data,desc"]="Update sub-submenu descriptions based on conditions"
-	["update_sub_submenu_data,example"]="update_sub_submenu_data \"MenuID\" \"SubID\" \"SubSubID\" \"CMD\""
+	["update_sub_submenu_data,example"]="update_sub_submenu_data MenuID SubID SubSubID CMD"
 	["update_sub_submenu_data,status"]=""
 )
 #


### PR DESCRIPTION
# Description

Fix: error

manually testing `./bin/armbian-config --api generate_json_options` results in Invalid JSON!

```
Error: Parse error on line 683:
...e_sub_submenu_data "MenuID" "SubID" "Sub
-----------------------^
Expecting 'EOF', '}', ':', ',', ']', got 'undefined'
```

- [x] Removed escape characters and quotes runtime.sh
- [x] no other notable *escape characters* are used in the module_option array. 


