### PR TITLE
Corrected torrent servers to torrent clients

### DIFF
--- a/tools/json/config.software.json
+++ b/tools/json/config.software.json
@@ -428,8 +428,8 @@
                     "sub": [
                         {
                             "id": "DOW001",
-                            "description": "qBittorrent BitTorrent server ",
-                            "about": "This operation will install qBittorrent BitTorrent server",
+                            "description": "qBittorrent BitTorrent client ",
+                            "about": "This operation will install qBittorrent BitTorrent client",
                             "command": [
                                 "module_qbittorrent install"
                             ],
@@ -440,7 +440,7 @@
                         {
                             "id": "DOW002",
                             "description": "qBittorrent remove",
-                            "about": "This operation will remove qBittorrent BitTorrent server",
+                            "about": "This operation will remove qBittorrent BitTorrent client",
                             "command": [
                                 "module_qbittorrent remove"
                             ],
@@ -461,8 +461,8 @@
                         },
                         {
                             "id": "DEL001",
-                            "description": "Deluge BitTorrent server",
-                            "about": "This operation will install BitTorrent server",
+                            "description": "Deluge BitTorrent client",
+                            "about": "This operation will install BitTorrent client",
                             "command": [
                                 "module_deluge install"
                             ],
@@ -473,7 +473,7 @@
                         {
                             "id": "DEL002",
                             "description": "Deluge remove",
-                            "about": "This operation will remove Deluge BitTorrent server",
+                            "about": "This operation will remove Deluge BitTorrent client",
                             "command": [
                                 "module_deluge remove"
                             ],
@@ -484,7 +484,7 @@
                         {
                             "id": "DEL003",
                             "description": "Deluge purge with data folder",
-                            "about": "This operation will remove Deluge BitTorrent server data folder",
+                            "about": "This operation will remove Deluge BitTorrent client data folder",
                             "command": [
                                 "module_deluge purge"
                             ],
@@ -494,8 +494,8 @@
                         },
                         {
                             "id": "TRA001",
-                            "description": "Transmission BitTorrent server",
-                            "about": "This operation will install Transmission BitTorrent server",
+                            "description": "Transmission BitTorrent client",
+                            "about": "This operation will install Transmission BitTorrent client",
                             "command": [
                                 "module_transmission install"
                             ],
@@ -506,7 +506,7 @@
                         {
                             "id": "TRA002",
                             "description": "Transmission remove",
-                            "about": "This operation will remove Transmission BitTorrent server",
+                            "about": "This operation will remove Transmission BitTorrent client",
                             "command": [
                                 "module_transmission remove"
                             ],
@@ -517,7 +517,7 @@
                         {
                             "id": "TRA003",
                             "description": "Transmission purge with data folder",
-                            "about": "This operation will remove Transmission BitTorrent server data folder",
+                            "about": "This operation will remove Transmission BitTorrent client data folder",
                             "command": [
                                 "module_transmission purge"
                             ],

--- a/tools/modules/software/module_transmission.sh
+++ b/tools/modules/software/module_transmission.sh
@@ -31,8 +31,8 @@ function module_transmission () {
 		"${commands[0]}")
 			pkg_installed docker-ce || module_docker install
 			[[ -d "$TRANSMISSION_BASE" ]] || mkdir -p "$TRANSMISSION_BASE" || { echo "Couldn't create storage directory: $TRANSMISSION_BASE"; exit 1; }
-			TRANSMISSION_USER=$($DIALOG --title "Enter username for Transmission server" --inputbox "\nHit enter for defaults" 9 50 "armbian" 3>&1 1>&2 2>&3)
-			TRANSMISSION_PASS=$($DIALOG --title "Enter password for Transmission server" --inputbox "\nHit enter for defaults" 9 50 "armbian" 3>&1 1>&2 2>&3)
+			TRANSMISSION_USER=$($DIALOG --title "Enter username for Transmission client" --inputbox "\nHit enter for defaults" 9 50 "armbian" 3>&1 1>&2 2>&3)
+			TRANSMISSION_PASS=$($DIALOG --title "Enter password for Transmission client" --inputbox "\nHit enter for defaults" 9 50 "armbian" 3>&1 1>&2 2>&3)
 			docker run -d \
 			--name=transmission \
 			--net=lsio \


### PR DESCRIPTION
# Description

Really minor thing but Deluge, qBittorrent and Transmission are torrent _clients_, not torrent _servers_ :)
