### PR TITLE
Transmission: add docker subnet to the whitelist

### DIFF
--- a/tools/modules/functions/set_runtime_variables.sh
+++ b/tools/modules/functions/set_runtime_variables.sh
@@ -60,7 +60,14 @@ function set_runtime_variables() {
 	DEFAULT_ADAPTER=$(ip -4 route ls | grep default | tail -1 | grep -Po '(?<=dev )(\S+)')
 	LOCALIPADD=$(ip -4 addr show dev $DEFAULT_ADAPTER | awk '/inet/ {print $2}' | cut -d'/' -f1)
 	LOCALSUBNET=$(echo ${LOCALIPADD} | cut -d"." -f1-3).0/24
-	LOCALWHITELIST=$(echo ${LOCALIPADD} | cut -d"." -f1-3)".*" # for transmission
+
+	# create local lan and docker lan whitelist for transmission
+	TRANSMISSION_WHITELIST=$(echo ${LOCALIPADD} | cut -d"." -f1-3)".*"
+	local docker_subnet=$(docker network inspect lsio 2> /dev/null | grep Subnet | xargs | cut -d" " -f2 | cut -d"/" -f1 | cut -d"." -f1-2)
+	if [[ -n "${docker_subnet}" ]]; then
+		TRANSMISSION_WHITELIST+=",${docker_subnet}.*.*"
+	fi
+
 	BACKTITLE="Contribute: https://github.com/armbian/configng"
 	TITLE="Armbian configuration utility"
 	[[ -z "${DEFAULT_ADAPTER// /}" ]] && DEFAULT_ADAPTER="lo"

--- a/tools/modules/software/module_transmission.sh
+++ b/tools/modules/software/module_transmission.sh
@@ -41,7 +41,7 @@ function module_transmission () {
 			-e TZ="$(cat /etc/timezone)" \
 			-e USER="${TRANSMISSION_USER}" \
 			-e PASS="${TRANSMISSION_PASS}" \
-			-e WHITELIST="${LOCALWHITELIST}" \
+			-e WHITELIST="${TRANSMISSION_WHITELIST}" \
 			-p 9091:9091 \
 			-p 51413:51413 \
 			-p 51413:51413/udp \


### PR DESCRIPTION
# Description

If we want that reverse proxy can connect to the web interface, we need to allow Docker bridge subnet.

# Testing Procedure

- [x] Interface is accessible after adding docker subnet

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
