### PR TITLE
Cockpit: add support for KVM management

### DIFF
--- a/tools/modules/system/module_armbian_kvmtest.sh
+++ b/tools/modules/system/module_armbian_kvmtest.sh
@@ -18,7 +18,7 @@ function module_armbian_kvmtest () {
 	# read additional parameters from command line
 	local parameter
 	IFS=' ' read -r -a parameter <<< "${1}"
-	for feature in instances provisioning firstconfig startingip gateway keyword arch kvmprefix network bridge memory vcpus; do
+	for feature in instances provisioning firstconfig startingip gateway keyword arch kvmprefix network bridge memory vcpus size; do
 	for selected in ${parameter[@]}; do
 		IFS='=' read -r -a split <<< "${selected}"
 		[[ ${split[0]} == $feature ]] && eval "$feature=${split[1]}"
@@ -37,6 +37,7 @@ function module_armbian_kvmtest () {
 	local network="${network:-default}"
 	if [[ -n "${bridge}" ]]; then network="bridge=${bridge}"; fi
 	local instances="${instances:-01}" # number of instances
+	local size="${size:-10}" # number of instances
 	local destination="${destination:-/var/lib/libvirt/images}"
 	local kvmprefix="${kvmprefix:-kvmtest}"
 	local memory="${memory:-3072}"
@@ -96,7 +97,7 @@ function module_armbian_kvmtest () {
 					local image="$i"-"${kvmprefix}"-"${filename}" # get image name
 					cp ${tempfolder}/${filename} ${destination}/${image} # make a copy under different number
 					sync
-					qemu-img resize ${destination}/${image} +10G # expand
+					qemu-img resize ${destination}/${image} +"${size}"G # expand
 					qemu-nbd --connect=/dev/nbd0 ${destination}/${image} # connect to qemu image
 					printf "fix\n" | sudo parted ---pretend-input-tty /dev/nbd0 print >/dev/null # fix resize
 					mount /dev/nbd0p3 ${mounttempfolder} # 3rd partition on uefi images is rootfs


### PR DESCRIPTION
# Description

- install libvirt by default
- dynamically add bridge interfaces to libvirt
- improve documentation

# Implementation Details

apt install

# Testing Procedure

- [x] Importing KVM image to the Cockpit via WEB interface
- [x] Install / remove

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
