### PR TITLE
Docker engine bugifix: adding service start command

### DIFF
--- a/tools/modules/software/module_docker.sh
+++ b/tools/modules/software/module_docker.sh
@@ -47,6 +47,7 @@ function module_docker() {
 					usermod -aG docker $SUDO_USER
 					systemctl enable docker.service > /dev/null 2>&1
 					systemctl enable containerd.service > /dev/null 2>&1
+					systemctl start docker.service > /dev/null 2>&1
 					docker network create lsio 2> /dev/null
 				fi
 			else


### PR DESCRIPTION
# Description

Docker installation on some variants needs manual start.

# Testing Procedure

- [x] Tested on Ubuntu Noble

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
