### PR TITLE
[Bugfix]:  Unexpected command executed when config overlays #349

### DIFF
--- a/tools/modules/system/manage_dtoverlays.sh
+++ b/tools/modules/system/manage_dtoverlays.sh
@@ -1,11 +1,15 @@
 
 module_options+=(
 ["manage_dtoverlays,author"]="@viraniac"
+["manage_dtoverlays,maintainer"]=""
 ["manage_dtoverlays,ref_link"]=""
 ["manage_dtoverlays,feature"]="manage_dtoverlays"
 ["manage_dtoverlays,desc"]="Enable/disable device tree overlays"
-["manage_dtoverlays,example"]="manage_dtoverlays"
+["manage_dtoverlays,example"]=""
 ["manage_dtoverlays,status"]="Active"
+["manage_dtoverlays,group"]="Kernel"
+["manage_dtoverlays,port"]=""
+["manage_dtoverlays,arch"]="aarch64 armhf"
 )
 #
 # @description Enable/disable device tree overlays
@@ -19,7 +23,8 @@ function manage_dtoverlays () {
 	[[ "$LINUXFAMILY" == "meson64" ]] && overlaydir="/boot/dtb/amlogic/overlay";
 	[[ "$LINUXFAMILY" == "rockchip64" || "$LINUXFAMILY" == "rk3399" || "$LINUXFAMILY" == "rockchip-rk3588" || "$LINUXFAMILY" == "rk35xx" ]] && overlaydir="/boot/dtb/rockchip/overlay";
 
-	[[ -f "${overlayconf}" ]] && source "${overlayconf}"
+
+	#[[ -f "${overlayconf}" ]] && source "${overlayconf}"
 	while true; do
 		local options=()
 		j=0

--- a/tools/modules/system/manage_dtoverlays.sh
+++ b/tools/modules/system/manage_dtoverlays.sh
@@ -23,7 +23,7 @@ function manage_dtoverlays () {
 	[[ "$LINUXFAMILY" == "meson64" ]] && overlaydir="/boot/dtb/amlogic/overlay";
 	[[ "$LINUXFAMILY" == "rockchip64" || "$LINUXFAMILY" == "rk3399" || "$LINUXFAMILY" == "rockchip-rk3588" || "$LINUXFAMILY" == "rk35xx" ]] && overlaydir="/boot/dtb/rockchip/overlay";
 
-
+	[[ ! -f "${overlayconf}" || ! -d "${overlaydir}" ]] && echo -e "Incompatible OS configuration\nArmbian device tree configuration files not found" | show_message && return 1
 	#[[ -f "${overlayconf}" ]] && source "${overlayconf}"
 	while true; do
 		local options=()


### PR DESCRIPTION
remove problem line that sources `/boot/armbianEnv.txt` no obiouse adverce effets. 

issue: https://github.com/armbian/configng/issues/349


