### PR TITLE
Sandboxed SSH server: add rsync to the Docker container

### DIFF
--- a/tools/modules/system/module_sshserver.sh
+++ b/tools/modules/system/module_sshserver.sh
@@ -62,6 +62,8 @@ function module_openssh-server () {
 					exit 1
 				fi
 			done
+			# install rsync
+			docker exec -it openssh-server /bin/bash -c "apk update; apk add rsync"
 		;;
 		"${commands[1]}")
 			[[ "${container}" ]] && docker container rm -f "$container" >/dev/null


### PR DESCRIPTION
# Description

Point of running such server is to provide ability to rsync data in and out but rsync package is not installed by default. Lets add it.

# Implementation Details

- installing additional package to the docker instance

# Testing Procedure

- [x] Rsync test to the server

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
