### PR TITLE
"Updates" menu not shown

### DIFF
--- a/tools/modules/system/release_upgrade.sh
+++ b/tools/modules/system/release_upgrade.sh
@@ -26,11 +26,9 @@ release_upgrade(){
 	fi
 
 	local upgrade=$(for j in $filter; do
-		for i in $(grep "^${distroid}" /etc/armbian-distribution-status | cut -d";" -f2 | cut -d"=" -f1 | sed "s/,/ /g"); do
-			if [[ $i == $j ]]; then
-				echo $i
-			fi
-		done
+		if [[ $distroid == $j ]]; then
+			echo $j
+		fi
 	done | tail -1)
 
 	if [[ -z "${upgrade}" ]]; then

--- a/tools/modules/system/release_upgrade.sh
+++ b/tools/modules/system/release_upgrade.sh
@@ -26,7 +26,7 @@ release_upgrade(){
 	fi
 
 	local upgrade=$(for j in $filter; do
-		for i in $(grep "^${distroid}" /etc/armbian-distribution-status | cut -d";" -f2 | cut -d"=" -f2 | sed "s/,/ /g"); do
+		for i in $(grep "^${distroid}" /etc/armbian-distribution-status | cut -d";" -f2 | cut -d"=" -f1 | sed "s/,/ /g"); do
 			if [[ $i == $j ]]; then
 				echo $i
 			fi


### PR DESCRIPTION
# Description
The menuentry "Updates" (under "System") is not displayed, even though the actual distro (bookworm) is supported.
This is caused by comparing the current distroid to a wrong part of the entries in `/etc/armbian-distribution-status`.

# Implementation Details
The first patch corrects the wrong field taken from `/etc/armbian-distribution-status` (the "cut" command should return the text before the "=", not the part after that).

The second patch removes the loop, which extracts the distroids from `/etc/armbian-distribution-status` again.
As $filter already contains a list of supported distroids, it should be sufficient to just compare each entry from $filter to $distroid without extracting them again from /etc/armbian-distribution-status.

I am not sure about the additional cut/sed operations in that loop ("cut" removing the part before ";" and "sed" replacing commas with spaces - neither ";" or "," appear in my `/etc/armbian-distribution-status`). If there is a reason for them (I didn't find a syntax definition for `/etc/armbian-distribution-status`), it might be better to omit the second patch (and just include the first patch to correct the field addressed by "cut").

(These fixes do not introduce any new dependencies/modules)

# Documentation Summary
- [ ] **Metadata Included:**  
- [ ] **Document Generated:**  

Both do not apply for these small changes AFAICS.

# Testing Procedure
On Armbian bookworm, execute "armbian-config" and open the "System" menu.
Without the patch, the "Updates" menu is missing.
With the patch, the "Updates" menu is available.

# Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have ensured that my changes do not introduce new warnings or errors
- [X] No new external dependencies are included
- [X] Changes have been tested and verified
- [ ] I have included necessary metadata in the code, including associative arrays
(not necessary for these changes)
