### PR TITLE
Armbian internal: GitHub runners deployment script

### DIFF
--- a/tools/modules/system/module_armbian_runners.sh
+++ b/tools/modules/system/module_armbian_runners.sh
@@ -1,55 +1,76 @@
-#declare -A module_options
 module_options+=(
 	["module_armbian_runners,author"]="@igorpecovnik"
 	["module_armbian_runners,feature"]="module_armbian_runners"
 	["module_armbian_runners,desc"]="Manage self hosted runners"
-	["module_armbian_runners,example"]="install remove status help"
+	["module_armbian_runners,example"]="install remove remove_online purge help"
 	["module_armbian_runners,port"]=""
 	["module_armbian_runners,status"]="Active"
 	["module_armbian_runners,arch"]=""
 )
+
 #
 # Module Armbian self hosted Github runners
 #
 function module_armbian_runners () {
+
 	local title="runners"
 	local condition=$(which "$title" 2>/dev/null)
 
-	local gh_token=$2
-	local runner_name="${3:-armbian}"
-	local start="${4:-01}"
-	local stop="${5:-01}"
-	local label_primary="${6:-alfa}"
-	local label_secondary="${7:-fast,images}"
-	local organisation="${8:-armbian}"
-	local owner="${9}"
-	local repository="${10}"
+	# read parameters from command install
+	local parameter
+	IFS=' ' read -r -a parameter <<< "${1}"
+	for feature in gh_token runner_name start stop label_primary label_secondary organisation owner repository; do
+	for selected in ${parameter[@]}; do
+		IFS='=' read -r -a split <<< "${selected}"
+		[[ ${split[0]} == $feature ]] && eval "$feature=${split[1]}"
+		done
+	done
+
+	# default values if not defined
+	local gh_token="${gh_token}"
+	local runner_name="${runner_name:-armbian}"
+	local start="${start:-01}"
+	local stop="${stop:-01}"
+	local label_primary="${label_primary:-alfa}"
+	local label_secondary="${label_secondary:-fast,images}"
+	local organisation="${organisation:-armbian}"
+	local owner="${owner}"
+	local repository="${repository}"
 
 	# we can generate per org or per repo
 	local registration_url="${organisation}"
 	local prefix="orgs"
 	if [[ -n "${owner}" && -n "${repository}" ]]; then
-   		registration_url="${owner}/${repository}"
-    	prefix=repos
+		registration_url="${owner}/${repository}"
+		prefix=repos
 	fi
 
 	local commands
 	IFS=' ' read -r -a commands <<< "${module_options["module_armbian_runners,example"]}"
 
-	case "$1" in
+	case "${parameter[0]}" in
+
 		"${commands[0]}")
-			#pkg_installed docker-ce || module_docker install
+
+			if [[ -z $gh_token ]]; then
+				echo "Error: Github token is mandatory"
+				${module_options["module_armbian_runners,feature"]} ${commands[6]}
+				exit 1
+			fi
+
+			# Docker preinstall is needed for our build framework
+			pkg_installed docker-ce || module_docker install
 			pkg_update
-			pkg_install libxml2-utils jq curl
+			pkg_install jq curl libicu-dev
 
 			# download latest runner package
 			local temp_dir=$(mktemp -d)
-			local LATEST=$(curl -sL https://github.com/actions/runner/releases/ \
-			| xmllint -html -xpath '//a[contains(@href, "release")]/text()' - 2> /dev/null \
-			| grep -P '^v' | head -n1 | sed "s/v//g")
-			curl --create-dir --output-dir ${temp_dir} -o \
+			trap '{ rm -rf -- "$temp_dir"; }' EXIT
+			[[ "$ARCH" == "x86_64" ]] && local arch=x64 || local arch=arm64
+			local LATEST=$(curl -sL https://api.github.com/repos/actions/runner/tags | jq -r '.[0].zipball_url' | rev | cut -d"/" -f1 | rev | sed "s/v//g")
+			curl --progress-bar --create-dir --output-dir ${temp_dir} -o \
 			actions-runner-linux-${ARCH}-${LATEST}.tar.gz -L \
-			https://github.com/actions/runner/releases/download/v${LATEST}/actions-runner-linux-${ARCH}-${LATEST}.tar.gz
+			https://github.com/actions/runner/releases/download/v${LATEST}/actions-runner-linux-${arch}-${LATEST}.tar.gz
 
 			# make runners each under its own user
 			for i in $(seq -w $start $stop)
@@ -58,62 +79,66 @@ function module_armbian_runners () {
 				-X POST \
 				-H "Accept: application/vnd.github+json" \
 				-H "Authorization: Bearer ${gh_token}"\
-	  			-H "X-GitHub-Api-Version: 2022-11-28" \
-	  			https://api.github.com/${prefix}/${registration_url}/actions/runners/registration-token | jq -r .token)
+				-H "X-GitHub-Api-Version: 2022-11-28" \
+				https://api.github.com/${prefix}/${registration_url}/actions/runners/registration-token | jq -r .token)
+
+				${module_options["module_armbian_runners,feature"]} ${commands[1]} ${runner_name}
 
 				adduser --quiet --disabled-password --shell /bin/bash \
 				--home /home/actions-runner-${i} --gecos "actions-runner-${i}" actions-runner-${i}
-	
+
 				# add to sudoers
 				if ! sudo grep -q "actions-runner-${i}" /etc/sudoers; then
-        	    	echo "actions-runner-${i} ALL=(ALL) NOPASSWD: ALL" | sudo tee -a /etc/sudoers
-        		fi
+					echo "actions-runner-${i} ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+				fi
 				usermod -aG docker actions-runner-${i}
 				tar xzf ${temp_dir}/actions-runner-linux-${ARCH}-${LATEST}.tar.gz -C /home/actions-runner-${i}
 				chown -R actions-runner-${i}:actions-runner-${i} /home/actions-runner-${i}
 
-	        	# 1st runner has different labels
-    	    	local label=$label_secondary
-        		if [[ "$i" == "${START}" ]]; then
+				# 1st runner has different labels
+				local label=$label_secondary
+				if [[ "$i" == "${start}" ]]; then
 					local label=$label_primary
 				fi
 
 				runuser -l actions-runner-${i} -c \
 				"./config.sh --url https://github.com/${registration_url} \
 				--token ${token} --labels ${label} --name ${runner_name}-${i} --unattended"
-				sh -c "cd /home/actions-runner-${i} ; \
-				sudo ./svc.sh install actions-runner-${i} 2>/dev/null; \
-				sudo ./svc.sh start actions-runner-${i} >/dev/null"
-			done
-			echo "$start $stop $label_primary $label_secondary $organisation"
-		;;
-		"${commands[1]}")
-			for i in $(seq -w $start $stop); do
-				# delete if previous already exists
-				if id "actions-runner-${i}" >/dev/null 2>&1; then
-					runner_delete "$NAME-${i}"
-					runner_home=$(getent passwd "actions-runner-${i}" | cut -d: -f6)
-					sh -c "cd ${runner_home} ; \
-					sudo ./svc.sh stop actions-runner-${i} >/dev/null; \
-					sudo ./svc.sh uninstall actions-runner-${i} >/dev/null"
-					sudo userdel -r -f actions-runner-${i} 2>/dev/null
-					sudo groupdel actions-runner-${i} 2>/dev/null
-					sudo sed -i "/^actions-runner-${i}.*/d" /etc/sudoers
-					sudo rm -rf "${runner_home}"
+				if [[ -f /home/actions-runner-${i}/svc.sh ]]; then
+					sh -c "cd /home/actions-runner-${i} ; \
+					sudo ./svc.sh install actions-runner-${i} 2>/dev/null; \
+					sudo ./svc.sh start actions-runner-${i} >/dev/null"
 				fi
 			done
+
+		;;
+		"${commands[1]}")
+			# delete if previous already exists
+			if id "actions-runner-${i}" >/dev/null 2>&1; then
+				echo "Removing runner ${i} on GitHub"
+				${module_options["module_armbian_runners,feature"]} ${commands[2]} "$2-${i}"
+				echo "Removing runner ${i} locally"
+				runner_home=$(getent passwd "actions-runner-${i}" | cut -d: -f6)
+				if [[ -f "${runner_home}/svc.sh" ]]; then
+					sh -c "cd ${runner_home} ; sudo ./svc.sh stop actions-runner-${i} >/dev/null; sudo ./svc.sh uninstall actions-runner-${i} >/dev/null"
+				fi
+				userdel -r -f actions-runner-${i} 2>/dev/null
+				groupdel actions-runner-${i} 2>/dev/null
+				sed -i "/^actions-runner-${i}.*/d" /etc/sudoers
+				rm -rf "${runner_home}"
+			fi
 		;;
 		"${commands[2]}")
-			DELETE=$1
+			DELETE=$2
 			x=1
 			while [ $x -le 9 ] # need to do it different as it can be more then 9 pages
 			do
 			RUNNER=$(
 			curl -s -L \
-	  		-H "Accept: application/vnd.github+json" \
-	  		-H "Authorization: Bearer ${gh_token}" \
-	  		-H "X-GitHub-Api-Version: 2022-11-28" \
-	  		https://api.github.com/${prefix}/${registration_url}/actions/runners\?page\=${x} \
+			-H "Accept: application/vnd.github+json" \
+			-H "Authorization: Bearer ${gh_token}" \
+			-H "X-GitHub-Api-Version: 2022-11-28" \
+			https://api.github.com/${prefix}/${registration_url}/actions/runners\?page\=${x} \
 			| jq -r '.runners[] | .id, .name' | xargs -n2 -d'\n' | sed -e 's/ /,/g')
 
 			while IFS= read -r DATA; do
@@ -133,19 +158,36 @@ function module_armbian_runners () {
 			x=$(( $x + 1 ))
 			done
 		;;
+		"${commands[3]}")
+			if [[ -z $gh_token ]]; then
+				echo "Error: Github token is mandatory"
+				${module_options["module_armbian_runners,feature"]} ${commands[6]}
+				exit 1
+			fi
+			for i in $(seq -w $start $stop); do
+				${module_options["module_armbian_runners,feature"]} ${commands[1]} ${runner_name}
+			done
+		;;
 		"${commands[6]}")
-			echo -e "\nUsage: ${module_options["module_armbian_runners,feature"]} <command>"
-			echo -e "Commands:  ${module_options["module_armbian_runners,example"]}"
-			echo "Available commands:"
-			echo -e "\tinstall\t- Install $title."
-			echo -e "\t\t  token [runner_name] [start] [stop] [labels_primary] [labels_secondary] [organisation]/[owner repository]"
-			echo -e "\tremove\t- Remove $title."
-			echo -e "\tstatus\t- Installation status $title."
-			echo
+			echo -e "\nUsage: ${module_options["module_armbian_runners,feature"]} <command> [switches]"
+			echo -e "Commands:  install purge"
+			echo -e "Available commands:\n"
+			echo -e "\tinstall\t\t- Install or reinstall $title."
+			echo -e "\tpurge\t\t- Purge $title."
+			echo -e "\nAvailable switches:\n"
+			echo -e "\tgh_token\t- token with rights to admin runners."
+			echo -e "\trunner_name\t- name of the runner (series)."
+			echo -e "\tstart\t\t- start of serie (01)."
+			echo -e "\tstop\t\t- stop (01)."
+			echo -e "\tlabel_primary\t- runner tags for first runner (alfa)."
+			echo -e "\tlabel_secondary\t- runner tags for all others (images)."
+			echo -e "\torganisation\t- GitHub organisation name (armbian)."
+			echo -e "\towner\t\t- GitHub owner."
+			echo -e "\trepository\t- GitHub repository (if adding only for repo)."
+			echo ""
 		;;
 		*)
 			${module_options["module_armbian_runners,feature"]} ${commands[6]}
 		;;
 	esac
 }
-#module_armbian_runners "$1" "$2" "$3" "$4" "$5" "$6" "$7" "$8" "$9" "$10"

--- a/tools/modules/system/module_armbian_runners.sh
+++ b/tools/modules/system/module_armbian_runners.sh
@@ -1,4 +1,4 @@
-declare -A module_options
+#declare -A module_options
 module_options+=(
 	["module_armbian_runners,author"]="@igorpecovnik"
 	["module_armbian_runners,feature"]="module_armbian_runners"
@@ -148,4 +148,4 @@ function module_armbian_runners () {
 		;;
 	esac
 }
-module_armbian_runners "$1" "$2" "$3" "$4" "$5" "$6" "$7" "$8" "$9" "$10"
+#module_armbian_runners "$1" "$2" "$3" "$4" "$5" "$6" "$7" "$8" "$9" "$10"

--- a/tools/modules/system/module_armbian_runners.sh
+++ b/tools/modules/system/module_armbian_runners.sh
@@ -1,0 +1,151 @@
+declare -A module_options
+module_options+=(
+	["module_armbian_runners,author"]="@igorpecovnik"
+	["module_armbian_runners,feature"]="module_armbian_runners"
+	["module_armbian_runners,desc"]="Manage self hosted runners"
+	["module_armbian_runners,example"]="install remove status help"
+	["module_armbian_runners,port"]=""
+	["module_armbian_runners,status"]="Active"
+	["module_armbian_runners,arch"]=""
+)
+#
+# Module Armbian self hosted Github runners
+#
+function module_armbian_runners () {
+	local title="runners"
+	local condition=$(which "$title" 2>/dev/null)
+
+	local gh_token=$2
+	local runner_name="${3:-armbian}"
+	local start="${4:-01}"
+	local stop="${5:-01}"
+	local label_primary="${6:-alfa}"
+	local label_secondary="${7:-fast,images}"
+	local organisation="${8:-armbian}"
+	local owner="${9}"
+	local repository="${10}"
+
+	# we can generate per org or per repo
+	local registration_url="${organisation}"
+	local prefix="orgs"
+	if [[ -n "${owner}" && -n "${repository}" ]]; then
+   		registration_url="${owner}/${repository}"
+    	prefix=repos
+	fi
+
+	local commands
+	IFS=' ' read -r -a commands <<< "${module_options["module_armbian_runners,example"]}"
+
+	case "$1" in
+		"${commands[0]}")
+			#pkg_installed docker-ce || module_docker install
+			pkg_update
+			pkg_install libxml2-utils jq curl
+
+			# download latest runner package
+			local temp_dir=$(mktemp -d)
+			local LATEST=$(curl -sL https://github.com/actions/runner/releases/ \
+			| xmllint -html -xpath '//a[contains(@href, "release")]/text()' - 2> /dev/null \
+			| grep -P '^v' | head -n1 | sed "s/v//g")
+			curl --create-dir --output-dir ${temp_dir} -o \
+			actions-runner-linux-${ARCH}-${LATEST}.tar.gz -L \
+			https://github.com/actions/runner/releases/download/v${LATEST}/actions-runner-linux-${ARCH}-${LATEST}.tar.gz
+
+			# make runners each under its own user
+			for i in $(seq -w $start $stop)
+			do
+				local token=$(curl -s \
+				-X POST \
+				-H "Accept: application/vnd.github+json" \
+				-H "Authorization: Bearer ${gh_token}"\
+	  			-H "X-GitHub-Api-Version: 2022-11-28" \
+	  			https://api.github.com/${prefix}/${registration_url}/actions/runners/registration-token | jq -r .token)
+
+				adduser --quiet --disabled-password --shell /bin/bash \
+				--home /home/actions-runner-${i} --gecos "actions-runner-${i}" actions-runner-${i}
+	
+				# add to sudoers
+				if ! sudo grep -q "actions-runner-${i}" /etc/sudoers; then
+        	    	echo "actions-runner-${i} ALL=(ALL) NOPASSWD: ALL" | sudo tee -a /etc/sudoers
+        		fi
+				usermod -aG docker actions-runner-${i}
+				tar xzf ${temp_dir}/actions-runner-linux-${ARCH}-${LATEST}.tar.gz -C /home/actions-runner-${i}
+				chown -R actions-runner-${i}:actions-runner-${i} /home/actions-runner-${i}
+
+	        	# 1st runner has different labels
+    	    	local label=$label_secondary
+        		if [[ "$i" == "${START}" ]]; then
+					local label=$label_primary
+				fi
+
+				runuser -l actions-runner-${i} -c \
+				"./config.sh --url https://github.com/${registration_url} \
+				--token ${token} --labels ${label} --name ${runner_name}-${i} --unattended"
+				sh -c "cd /home/actions-runner-${i} ; \
+				sudo ./svc.sh install actions-runner-${i} 2>/dev/null; \
+				sudo ./svc.sh start actions-runner-${i} >/dev/null"
+			done
+			echo "$start $stop $label_primary $label_secondary $organisation"
+		;;
+		"${commands[1]}")
+			for i in $(seq -w $start $stop); do
+				# delete if previous already exists
+				if id "actions-runner-${i}" >/dev/null 2>&1; then
+					runner_delete "$NAME-${i}"
+					runner_home=$(getent passwd "actions-runner-${i}" | cut -d: -f6)
+					sh -c "cd ${runner_home} ; \
+					sudo ./svc.sh stop actions-runner-${i} >/dev/null; \
+					sudo ./svc.sh uninstall actions-runner-${i} >/dev/null"
+					sudo userdel -r -f actions-runner-${i} 2>/dev/null
+					sudo groupdel actions-runner-${i} 2>/dev/null
+					sudo sed -i "/^actions-runner-${i}.*/d" /etc/sudoers
+					sudo rm -rf "${runner_home}"
+				fi
+			done
+		;;
+		"${commands[2]}")
+			DELETE=$1
+			x=1
+			while [ $x -le 9 ] # need to do it different as it can be more then 9 pages
+			do
+			RUNNER=$(
+			curl -s -L \
+	  		-H "Accept: application/vnd.github+json" \
+	  		-H "Authorization: Bearer ${gh_token}" \
+	  		-H "X-GitHub-Api-Version: 2022-11-28" \
+	  		https://api.github.com/${prefix}/${registration_url}/actions/runners\?page\=${x} \
+			| jq -r '.runners[] | .id, .name' | xargs -n2 -d'\n' | sed -e 's/ /,/g')
+
+			while IFS= read -r DATA; do
+				RUNNER_ID=$(echo $DATA | cut -d"," -f1)
+				RUNNER_NAME=$(echo $DATA | cut -d"," -f2)
+				# deleting a runner
+				if [[ $RUNNER_NAME == ${DELETE} ]]; then
+					echo "Delete existing: $RUNNER_NAME"
+					curl -s -L \
+					-X DELETE \
+					-H "Accept: application/vnd.github+json" \
+					-H "Authorization: Bearer ${gh_token}"\
+					-H "X-GitHub-Api-Version: 2022-11-28" \
+					https://api.github.com/${prefix}/${registration_url}/actions/runners/${RUNNER_ID}
+				fi
+			done <<< $RUNNER
+			x=$(( $x + 1 ))
+			done
+		;;
+		"${commands[6]}")
+			echo -e "\nUsage: ${module_options["module_armbian_runners,feature"]} <command>"
+			echo -e "Commands:  ${module_options["module_armbian_runners,example"]}"
+			echo "Available commands:"
+			echo -e "\tinstall\t- Install $title."
+			echo -e "\t\t  token [runner_name] [start] [stop] [labels_primary] [labels_secondary] [organisation]/[owner repository]"
+			echo -e "\tremove\t- Remove $title."
+			echo -e "\tstatus\t- Installation status $title."
+			echo
+		;;
+		*)
+			${module_options["module_armbian_runners,feature"]} ${commands[6]}
+		;;
+	esac
+}
+module_armbian_runners "$1" "$2" "$3" "$4" "$5" "$6" "$7" "$8" "$9" "$10"


### PR DESCRIPTION
# Description

We have several scripts that are used only for internal processes. This script is not interesting for end users, so it doesn't need to have menu entry. I put it into the system folder but for the future we might have this separately. 

Install two runners with name "runner.
`armbian-config --api module_armbian_runners install gh_token=TOKEN runner_name=runner stop=02`

Purge them:
`armbian-config --api module_armbian_runners purge gh_token=TOKEN runner_name=runner stop=02`

```
Usage: module_armbian_runners <command> [switches]
Commands:  install purge
Available commands:

	install		- Install or reinstall runners.
	purge		- Purge runners.

Available switches:

	gh_token	- token with rights to admin runners.
	runner_name	- name of the runner (series).
	start		- start of serie (01).
	stop		- stop (01).
	label_primary	- runner tags for first runner (alfa).
	label_secondary	- runner tags for all others (images).
	organisation	- GitHub organisation name (armbian).
	owner		- GitHub owner.
	repository	- GitHub repository (if adding only for repo).

```

Issue reference:  Refference: https://github.com/armbian/scripts/blob/main/generate-runners/deploy.sh

# Implementation Details

- install docker
- prepare os, install runner(s)

# Testing Procedure

- [x] Install and remove

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
