### PR TITLE
Module Docker: Check if SUDO_USER variable is defined

### DIFF
--- a/tools/modules/software/module_docker.sh
+++ b/tools/modules/software/module_docker.sh
@@ -44,7 +44,7 @@ function module_docker() {
 					fi
 
 					groupadd docker 2>/dev/null || true
-					usermod -aG docker $SUDO_USER
+					[[ -n "${SUDO_USER}" ]] && usermod -aG docker "${SUDO_USER}"
 					systemctl enable docker.service > /dev/null 2>&1
 					systemctl enable containerd.service > /dev/null 2>&1
 					systemctl start docker.service > /dev/null 2>&1


### PR DESCRIPTION
# Description

When we run this as a root, this variable is undefined and it errors out.

# Checklist

- [x] I have ensured that my changes do not introduce new warnings or errors
