### PR TITLE
Distro verification: Display warning for 10 seconds and auto continue

### DIFF
--- a/tools/modules/functions/check_distro_status.sh
+++ b/tools/modules/functions/check_distro_status.sh
@@ -29,15 +29,13 @@ function check_distro_status() {
 			else
 			BACKTITLE="Warning: The current OS ($DISTROID) is not supported or not listed"
 			set_colors 1
-			get_user_continue "Warning:
+			info_wait_continue "Warning:
 
 			The current OS ($DISTROID) is not a officially supported distro!
 
 			The tool might still work well, but be aware that issues may
 			not be accepted and addressed by the maintainers. However, you
 			are welcome to contribute fixes for any problems you encounter.
-
-			Would you like to continue?
 			" process_input
 			fi
 		;;

--- a/tools/modules/functions/config_interface.sh
+++ b/tools/modules/functions/config_interface.sh
@@ -357,13 +357,13 @@ function get_user_continue() {
 # Functions to display warning for 10 seconds with a gauge
 #
 module_options+=(
-        ["info_wait_autocontinue,author"]="@igorpecovnik"
-        ["info_wait_autocontinue,ref_link"]=""
-        ["info_wait_autocontinue,feature"]="info_wait_autocontinue"
-        ["info_wait_autocontinue,desc"]="Display a warning with a gauge for 10 seconds then continue"
-        ["info_wait_autocontinue,example"]=""
-        ["info_wait_autocontinue,doc_link"]=""
-        ["info_wait_autocontinue,status"]="Active"
+	["info_wait_autocontinue,author"]="@igorpecovnik"
+	["info_wait_autocontinue,ref_link"]=""
+	["info_wait_autocontinue,feature"]="info_wait_autocontinue"
+	["info_wait_autocontinue,desc"]="Display a warning with a gauge for 10 seconds then continue"
+	["info_wait_autocontinue,example"]=""
+	["info_wait_autocontinue,doc_link"]=""
+	["info_wait_autocontinue,status"]="Active"
 )
 function info_wait_continue() {
 	local message="$1"

--- a/tools/modules/functions/config_interface.sh
+++ b/tools/modules/functions/config_interface.sh
@@ -367,7 +367,7 @@ module_options+=(
 )
 function info_wait_continue() {
 	local message="$1"
-        local next_action="$2"
+	local next_action="$2"
 	{
 	for ((i=0; i<=100; i+=10)); do
 		sleep 1

--- a/tools/modules/functions/config_interface.sh
+++ b/tools/modules/functions/config_interface.sh
@@ -352,6 +352,30 @@ function get_user_continue() {
 	fi
 }
 
+
+#
+# Functions to display warning for 10 seconds with a gauge
+#
+module_options+=(
+        ["info_wait_autocontinue,author"]="@igorpecovnik"
+        ["info_wait_autocontinue,ref_link"]=""
+        ["info_wait_autocontinue,feature"]="info_wait_autocontinue"
+        ["info_wait_autocontinue,desc"]="Display a warning with a gauge for 10 seconds then continue"
+        ["info_wait_autocontinue,example"]=""
+        ["info_wait_autocontinue,doc_link"]=""
+        ["info_wait_autocontinue,status"]="Active"
+)
+function info_wait_continue() {
+	local message="$1"
+        local next_action="$2"
+	{
+	for ((i=0; i<=100; i+=10)); do
+		sleep 1
+		echo $i
+	done
+	} | $DIALOG --gauge "$message" 15 80 0
+}
+
 menu_options+=(
 	["get_user_continue,author"]="@Tearran"
 	["get_user_continue,ref_link"]=""


### PR DESCRIPTION
# Description

Gauge goes from 0 - 100 / 10 seconds and proceeds.

![image](https://github.com/user-attachments/assets/fe2db002-3c24-4d29-81a1-520552fd023a)

# Testing Procedure

- [x] Test run

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
