### PR TITLE
manage_overlayfs: Keep the default value of overlayroot_cfgdisk

### DIFF
--- a/tools/modules/system/manage_overlayfs.sh
+++ b/tools/modules/system/manage_overlayfs.sh
@@ -15,7 +15,6 @@ function manage_overlayfs() {
 		pkg_install -o Dpkg::Options::="--force-confold" overlayroot cryptsetup cryptsetup-bin
 		[[ ! -f /etc/overlayroot.conf ]] && cp /etc/overlayroot.conf.dpkg-new /etc/overlayroot.conf
 		sed -i "s/^overlayroot=.*/overlayroot=\"tmpfs\"/" /etc/overlayroot.conf
-		sed -i "s/^overlayroot_cfgdisk=.*/overlayroot_cfgdisk=\"enabled\"/" /etc/overlayroot.conf
 	else
 		overlayroot-chroot rm /etc/overlayroot.conf > /dev/null 2>&1
 		pkg_remove overlayroot cryptsetup cryptsetup-bin


### PR DESCRIPTION
"enabled" is not a valid value for the option. Aside for "disabled", here are examples from /etc/overlayroot.conf:

    overlayroot_cfgdisk="LABEL=OROOTCFG"
    overlayroot_cfgdisk="/dev/vdb"


# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
