### PR TITLE
Add GPG key download for 3rd party distro

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ armbian-config
 Add Armbian repository and install the tool:
 
 ```bash
+wget -qO - https://apt.armbian.com/armbian.key | gpg --dearmor | \
+sudo tee /usr/share/keyrings/armbian.gpg > /dev/null
 echo "deb [signed-by=/usr/share/keyrings/armbian.gpg] \
 https://github.armbian.com/configng stable main" | \
 sudo tee /etc/apt/sources.list.d/armbian-development.list > /dev/null


### PR DESCRIPTION
# Description

When we are installing on a 3rd party OS, we need to supply key.

# Testing Procedure

- [x] Manually executed

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
