### PR TITLE
Fix sanitize

### DIFF
--- a/bin/armbian-config
+++ b/bin/armbian-config
@@ -83,30 +83,26 @@ case "$1" in
 
     "--cmd")
         INPUTMODE="cmd"
-        shift
-        case "$1" in
+        case "$2" in
             ""|"help")
                 see_cmd_list
             ;;
             *)
-                args=$(sanitize_input "$@")
-                execute_command "$args"
+                cmd=$(sanitize "$2") || die
+                execute_command "$cmd"
             ;;
         esac
     ;;
 
     "--api")
-        shift
-        case "$1" in
+        case "$2" in
             ""|"help")
                 see_use
             ;;
             *)
-                option="$1"
-                shift
-                args=$(sanitize_input "$@")
-                # echo -e "\"$option\" \"$args\""
-                "$option" "$args"
+                fn=$(sanitize "$2") || die
+                shift 2
+                "$fn" "$@"
             ;;
         esac
 	;;

--- a/bin/armbian-config
+++ b/bin/armbian-config
@@ -15,7 +15,7 @@ trap "exit" INT TERM
 script_dir="$(dirname "$0")"
 
 [[ -d "$script_dir/../tools" ]] && tools_dir="$script_dir/../tools"
-[[ ! -d "$script_dir/../lib" && -n "$tools_dir" ]] && echo -e "Please run\nbash "$tools_dir/config-assemble.sh" to build the lib directory\n" && exit 1 
+[[ ! -d "$script_dir/../lib" && -n "$tools_dir" ]] && die -e "Please run\nbash "$tools_dir/config-assemble.sh" to build the lib directory\n"
 
 # 'whiptail' is a simple dialog box utility that works well with Bash. It doesn't have all the features of some other dialog box utilities, but it does everything we need for this script.
 [[ -x "$(command -v whiptail)" ]] && DIALOG="whiptail"
@@ -123,11 +123,8 @@ case "$1" in
         )
         main_value="${1#main=}"
         main_value="${main_map[$main_value]}"
+        [ -z "$main_value" ] && die "Error: Invalid List $1"
 
-        if [ -z "$main_value" ]; then
-            echo "Error: Invalid List $1"
-            exit 1
-        fi
         declare -A select_map
         # map name to menu number
         select_map=(
@@ -139,10 +136,8 @@ case "$1" in
         )
         select_value="${2#selection=}"
         select_value="${select_map[$select_value]}"
-        if [ -z "$select_value" ]; then
-            echo "Error: Invalid Option $2"
-            exit 1
-        fi
+        [ -z "$select_value" ] && die "Error: Invalid Option $2"
+
         echo "$main_value""$select_value"
         execute_command "$main_value""$select_value"
 	;;

--- a/bin/armbian-config
+++ b/bin/armbian-config
@@ -56,17 +56,13 @@ echo "Loaded Software helpers..." #| show_infobox ;
 source "$lib_dir/config.runtime.sh"
 echo "Loaded Runtime conditions..." #| show_infobox ;
 
-clear
-
 case "$1" in
-"--help")
-	if [[ -n "$2" ]]; then
-		see_cmd_list "$2"
-		echo ""
-		exit 0
-	fi
-
-	echo "Usage:  armbian-config --[option]
+    "--help")
+        if [[ -n "$2" ]]; then
+            see_cmd_list "$2"
+            echo ""
+        else
+            echo "Usage:  armbian-config --[option]
      Options:
      --help [category]   Use [category] to filter specific menu options.
      --cmd  [option]     Run a command from the menu (simple)
@@ -78,90 +74,89 @@ case "$1" in
      armbian-config --cmd help 
      armbian-config --api help
 "
-	exit 0
-	;;
-"--doc")
-	generate_readme
-	exit 0
-	;;
-"--cmd")
-	INPUTMODE="cmd"
-	shift
-	if [[ -z "$1" || "$1" == "help" ]]; then
-		see_cmd_list
-		exit 0
-	fi
+        fi
+    ;;
 
-	args=$(sanitize_input "$@")
-	execute_command "$args"
-	exit 0
-	;;
-"--api")
-	shift
-	if [[ -z "$1" || "$1" == "help" ]]; then
-		see_use
-		exit 0
-	fi
-	option="$1"
-	shift
-	args=$(sanitize_input "$@")
-	# echo -e "\"$option\" \"$args\""
-	"$option" "$args"
-	exit 0
-	;;
-"main=help" | "main=Help")
-	see_cli_legacy
-	echo ""
-	exit 0
-	;;
-"main="*)
-	declare -A main_map
-	main_map=(
-		# map name to menu category
-		["System"]="S"
-		["Software"]="I"
-		["Network"]="N"
-		["Localisation"]="L"
-	)
-	main_value="${1#main=}"
-	main_value="${main_map[$main_value]}"
+    "--doc")
+        generate_readme
+    ;;
 
-	if [ -z "$main_value" ]; then
-		echo "Error: Invalid List $1"
-		exit 1
-	fi
-	declare -A select_map
-	# map name to menu number
-	select_map=(
-		["Headers"]="04"
-		["Headers_install"]="04"
-		["Headers_remove"]="05"
-		["Firmware"]="06"
-		["Nightly"]="07"
-	)
-	select_value="${2#selection=}"
-	select_value="${select_map[$select_value]}"
-	if [ -z "$select_value" ]; then
-		echo "Error: Invalid Option $2"
-		exit 1
-	fi
-	echo "$main_value""$select_value"
-	execute_command "$main_value""$select_value"
-	exit 0
+    "--cmd")
+        INPUTMODE="cmd"
+        shift
+        case "$1" in
+            ""|"help")
+                see_cmd_list
+            ;;
+            *)
+                args=$(sanitize_input "$@")
+                execute_command "$args"
+            ;;
+        esac
+    ;;
+
+    "--api")
+        shift
+        case "$1" in
+            ""|"help")
+                see_use
+            ;;
+            *)
+                option="$1"
+                shift
+                args=$(sanitize_input "$@")
+                # echo -e "\"$option\" \"$args\""
+                "$option" "$args"
+            ;;
+        esac
 	;;
+
+    "main=help" | "main=Help")
+        see_cli_legacy
+        echo ""
+	;;
+
+    "main="*)
+        declare -A main_map
+        main_map=(
+            # map name to menu category
+            ["System"]="S"
+            ["Software"]="I"
+            ["Network"]="N"
+            ["Localisation"]="L"
+        )
+        main_value="${1#main=}"
+        main_value="${main_map[$main_value]}"
+
+        if [ -z "$main_value" ]; then
+            echo "Error: Invalid List $1"
+            exit 1
+        fi
+        declare -A select_map
+        # map name to menu number
+        select_map=(
+            ["Headers"]="04"
+            ["Headers_install"]="04"
+            ["Headers_remove"]="05"
+            ["Firmware"]="06"
+            ["Nightly"]="07"
+        )
+        select_value="${2#selection=}"
+        select_value="${select_map[$select_value]}"
+        if [ -z "$select_value" ]; then
+            echo "Error: Invalid Option $2"
+            exit 1
+        fi
+        echo "$main_value""$select_value"
+        execute_command "$main_value""$select_value"
+	;;
+
+    *)
+        # Generate the top menu with the modified Object data
+        set_colors 4
+        generate_top_menu "$json_data"
+
+        # Show about this tool on exit
+        about_armbian_configng
+    ;;
 esac
-
-
-#
-# Generate the top menu with the modified Object data
-set_colors 4
-generate_top_menu "$json_data"
-
-#
-# Exit the script with a success status code
-
-#
-# Show about this tool on exit
-about_armbian_configng
-
-exit 0

--- a/bin/armbian-config
+++ b/bin/armbian-config
@@ -149,12 +149,6 @@ case "$1" in
 	execute_command "$main_value""$select_value"
 	exit 0
 	;;
-*)
-	if [[ $EUID != 0 ]]; then
-		echo -e "error: Exiting \nTry: 'sudo armbian-config'\n or: 'armbian-config --help' for More info\n\n"
-		exit 0
-	fi
-	;;
 esac
 
 

--- a/tests/CON005.conf
+++ b/tests/CON005.conf
@@ -1,8 +1,8 @@
 ENABLED=true
 RELEASE="bookworm:noble"
 
-function testcase {
-	./bin/armbian-config --api module_portainer remove
+testcase() {(
+	set -e
+	./bin/armbian-config --api module_portainer install
 	./bin/armbian-config --api module_portainer status
-	echo $?
-}
+)}

--- a/tests/DAT001.conf
+++ b/tests/DAT001.conf
@@ -1,7 +1,8 @@
 ENABLED=false
 
-function testcase {
+testcase() {(
+	set -e
 	./bin/armbian-config --api module_mariadb install
 	./bin/armbian-config --api module_mariadb status
 	docker container ls -a
-}
+)}

--- a/tests/HAB001.conf
+++ b/tests/HAB001.conf
@@ -1,7 +1,8 @@
 ENABLED=true
 RELEASE="bookworm"
 
-function testcase {
+function testcase {(
+	set -e
 	./bin/armbian-config --api module_openhab install
 	systemctl is-active --quiet openhab.service
-}
+)}

--- a/tests/HAS001.conf
+++ b/tests/HAS001.conf
@@ -1,6 +1,8 @@
 ENABLED=false
 RELEASE="bookworm"
 
-function testcase {
+testcase() {(
+	set -e
 	./bin/armbian-config --api module_haos install
-}
+	./bin/armbian-config --api module_haos status
+)}

--- a/tests/MAN001.conf
+++ b/tests/MAN001.conf
@@ -1,9 +1,9 @@
 ENABLED=true
 RELEASE="bookworm:noble" # run on specific or leave empty to run on all
 
-function testcase {
-	./bin/armbian-config --api module_cockpit remove
+testcase() {(
+	set -e
+	./bin/armbian-config --api module_cockpit remove || true
 	./bin/armbian-config --api module_cockpit install
-	[ -f /usr/bin/cockpit-bridge ]
-}
-
+	[[ -f /usr/bin/cockpit-bridge ]]
+)}

--- a/tests/MON001.conf
+++ b/tests/MON001.conf
@@ -1,10 +1,11 @@
 ENABLED=true
 RELEASE="bookworm:noble"
 
-function testcase {
-	./bin/armbian-config --api module_uptimekuma remove
+testcase() {(
+	set -e
+	./bin/armbian-config --api module_uptimekuma remove || true
 	./bin/armbian-config --api module_uptimekuma install
 	./bin/armbian-config --api module_uptimekuma status
 	./bin/armbian-config --api module_uptimekuma remove
-	./bin/armbian-config --api module_uptimekuma status
-}
+	! ./bin/armbian-config --api module_uptimekuma status
+)}

--- a/tests/NAV001.conf
+++ b/tests/NAV001.conf
@@ -1,11 +1,10 @@
 ENABLED=true
 RELEASE="bookworm:noble"
 
-function testcase {
+testcase() {(
+	set -e
 	./bin/armbian-config --api module_navidrome remove
 	./bin/armbian-config --api module_navidrome install
 	container=$(docker container ls -a | mawk '/navidrome?( |$)/{print $1}')
-	if [[ -z "${container}" ]]; then
-		exit 1
-	fi
-}
+	[[ -n "$container" ]]
+)}

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,6 @@
 # Unit tests
 
-If function testcase returns 0, test is succesful. Put the code there.
+If the function `testcase()` returns 0, the test is succesful. Put the code there.
 
 - name of the the file is function ID.conf
 - ENABLED=false|true
@@ -8,12 +8,29 @@ If function testcase returns 0, test is succesful. Put the code there.
 
 Example:
 
-```
+```sh
 ENABLED=true
 RELEASE="bookworm:noble"
 
-function testcase {
-        ./bin/armbian-config --api module_cockpit install
-        [ -f /usr/bin/cockpit-bridge ]
+testcase() {
+    ./bin/armbian-config --api module_cockpit install
+    [ -f /usr/bin/cockpit-bridge ]
 }
 ```
+
+If you have multiple test conditions inside `testcase()` and you want the test
+to exit on the first failed statement, you can use the following technique:
+
+```sh
+testcase() {(
+    set -e
+      ./bin/armbian-config --api pkg_install   neovim
+      ./bin/armbian-config --api pkg_installed neovim
+      ./bin/armbian-config --api pkg_remove    neovim
+    ! ./bin/armbian-config --api pkg_installed neovim
+)}
+```
+
+Note the additional pair of `()` and the `set -e` command inside function body.
+These will cause test conditions to run inside a subshell with the -e option
+enabled (exit immediately if a pipeline returns non-zero status).

--- a/tools/modules/functions/config_interface.sh
+++ b/tools/modules/functions/config_interface.sh
@@ -489,27 +489,27 @@ see_current_apt() {
 	fi
 }
 
+module_options+=(
+	["sanitize,author"]="@Tearran"
+	["sanitize,desc"]="Make sure param contains only valid chars"
+	["sanitize,example"]="sanitize 'foo_bar_42'"
+	["sanitize,feature"]="sanitize"
+	["sanitize,status"]="Interface"
+)
+
+sanitize() {
+	[[ "$1" =~ ^[a-zA-Z0-9_=]+$ ]] && echo "$1" || die "Invalid argument: $1"
+}
 
 module_options+=(
-	["sanitize_input,author"]="@Tearran"
-	["sanitize_input,ref_link"]=""
-	["sanitize_input,feature"]="sanitize_input"
-	["sanitize_input,desc"]="sanitize input cli"
-	["sanitize_input,example"]="sanitize_input"
-	["sanitize_input,status"]="Review"
+	["die,author"]="@dimitry-ishenko"
+	["die,desc"]="Exit with error code 1, optionally printing a message to stderr"
+	["die,example"]="run_critical_function || die 'The world is about to end'"
+	["die,feature"]="die"
+	["die,status"]="Interface"
 )
-#
-# sanitize input cli
-#
-sanitize_input() {
-	local sanitized_input=()
-	for arg in "$@"; do
-		if [[ $arg =~ ^[a-zA-Z0-9_=]+$ ]]; then
-			sanitized_input+=("$arg")
-		else
-			echo "Invalid argument: $arg"
-			exit 1
-		fi
-	done
-	echo "${sanitized_input[@]}"
+
+die() {
+	(( $# )) && echo "$@" >&2
+	exit 1
 }


### PR DESCRIPTION
# Description

Fixes `sanitize_input` command used with the `--api` and `--cmd` options.

Issue reference:  Closes #324.

# Implementation Details

_Provide a detailed description of the implementation. Include the following:_

- [x] Key changes introduced by this PR

Replaced `sanitize_input` function with simplified version called `sanitize`. Sanitation is only done on the first argument (which is a function name in case of `--api`, or a command name in case of `--cmd`).

_UPDATE:_ The final commit fixes some flawed tests, whose failure was masked by explicit `exit 0` statements in `armbian-config`.

- [x] Justification for the changes

See #324 for more details.

- [x] Confirmation that no new external dependencies or modules have been introduced

# Testing Procedure

_Describe the tests you ran to verify your changes. Provide relevant details about your test configuration._

```
./bin/armbian-config --cmd DEV-001 # FAILED
./bin/armbian-config --cmd DEV001
./bin/armbian-config --cmd DEV002

./bin/armbian-config --api pkg-install vim-airline # FAILED
./bin/armbian-config --api pkg_install vim-airline
./bin/armbian-config --api pkg_remove vim-airline
```

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
