### PR TITLE
ZFS: define architecture for ZFS module

### DIFF
--- a/tools/modules/system/module_zfs.sh
+++ b/tools/modules/system/module_zfs.sh
@@ -5,7 +5,7 @@ module_options+=(
 	["module_zfs,example"]="install remove status kernel_max zfs_version zfs_installed_version help"
 	["module_zfs,port"]=""
 	["module_zfs,status"]="Active"
-	["module_zfs,arch"]=""
+	["module_zfs,arch"]="x86-64 arm64"
 )
 #
 # Module OpenZFS


### PR DESCRIPTION
# Description

ZFS is not recommended to install on armhf, so lets define this in the module, even this functionality is not yet enabled.

# Testing Procedure

Installation on 32b arch prompt for possible corruption, so we need to prepare this to disable function when this will be present.

# Checklist

- [x] My code follows the style guidelines of this project