### PR TITLE
Activate the specified network interface, before applying IP stack

### DIFF
--- a/tools/modules/network/module_network_simple.sh
+++ b/tools/modules/network/module_network_simple.sh
@@ -235,7 +235,7 @@ function module_simple_network() {
 			$((${#list[@]}/2 + 10 )) 50 $((${#list[@]}/2 + 1)) "${list[@]}" 3>&1 1>&2 2>&3)
 			if [[ $? -eq 0 ]]; then
 				if $DIALOG --title "Action for ${adapter}" --yes-button "Configure" --no-button "Drop" --yesno "$1" 5 60; then
-					:
+					ip link set ${adapter} up
 				else
 					sed -i -e 'H;x;/^\(  *\)\n\1/{s/\n.*//;x;d;}' \
 					-e 's/.*//;x;/'${adapter}'/{s/^\( *\).*/ \1/;x;d;}' /etc/netplan/${yamlfile}.yaml


### PR DESCRIPTION
# Description

This will prevent erroring out as some devices are not up by default.

Issue reference:  https://github.com/armbian/build/pull/7750

# Testing Procedure

- [x] Tested setting up with interface forced down

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
