### PR TITLE
feat: Use deb822 APT sources

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -289,7 +289,14 @@ sudo apt install armbian-config
 	sudo wget https://apt.armbian.com/armbian.key -O key
 	sudo gpg --dearmor < key | sudo tee /usr/share/keyrings/armbian.gpg > /dev/null
 	sudo chmod go+r /usr/share/keyrings/armbian.gpg
-	sudo echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/armbian.gpg] http://apt.armbian.com $(lsb_release -cs) main  $(lsb_release -cs)-utils  $(lsb_release -cs)-desktop" | sudo tee /etc/apt/sources.list.d/armbian.list
+	cat <<- EOF | sudo tee /etc/apt/sources.list.d/armbian.sources
+	Types: deb
+	URIs: https://apt.armbian.com
+	Suites: $(lsb_release -cs)
+	Components: main $(lsb_release -cs)-utils $(lsb_release -cs)-desktop
+	Architectures: $(dpkg --print-architecture)
+	Signed-By: /usr/share/keyrings/armbian.gpg
+	EOF
 	sudo apt update
 	sudo apt install armbian-config
 }
@@ -1029,4 +1036,3 @@ Install and test Development deb:
 ~~~
 
 </details>
-

--- a/tools/modules/docs/config.docs.sh
+++ b/tools/modules/docs/config.docs.sh
@@ -22,7 +22,7 @@ function generate_readme() {
 
 	echo -e "Sorting data\nUpdating documentation" # current_date ;
 
-	cat << EOF > "$script_dir/../DOCUMENTATION.md"
+	cat << EOF_DOC > "$script_dir/../DOCUMENTATION.md"
 
 # Armbian Configuration Utility
 
@@ -49,7 +49,14 @@ sudo apt install armbian-config
 	sudo wget https://apt.armbian.com/armbian.key -O key
 	sudo gpg --dearmor < key | sudo tee /usr/share/keyrings/armbian.gpg > /dev/null
 	sudo chmod go+r /usr/share/keyrings/armbian.gpg
-	sudo echo "deb [arch=\$(dpkg --print-architecture) signed-by=/usr/share/keyrings/armbian.gpg] http://apt.armbian.com \$(lsb_release -cs) main  \$(lsb_release -cs)-utils  \$(lsb_release -cs)-desktop" | sudo tee /etc/apt/sources.list.d/armbian.list
+	echo << EOF | sudo tee /etc/apt/sources.list.d/armbian.sources
+	Types: deb
+	URIs: https://apt.armbian.com
+	Suites: $(lsb_release -cs)
+	Components: main $(lsb_release -cs)-utils $(lsb_release -cs)-desktop
+	Architectures: $(dpkg --print-architecture)
+	Signed-By: /usr/share/keyrings/armbian.gpg
+	EOF
 	sudo apt update
 	sudo apt install armbian-config
 }
@@ -159,7 +166,7 @@ Install and test Development deb:
 
 </details>
 
-EOF
+EOF_DOC
 
 }
 
@@ -564,4 +571,3 @@ EOF
 	# $script_name main=Software selection=Avahi            -  Install Avahi mDNS/DNS-SD daemon:
 
 }
-

--- a/tools/modules/system/module_armbian_firmware.sh
+++ b/tools/modules/system/module_armbian_firmware.sh
@@ -259,7 +259,7 @@ function module_armbian_firmware() {
 			local repository=$2
 			local status=$3
 
-			if grep -q 'apt.armbian.com' /etc/apt/sources.list.d/armbian.list; then
+			if grep -q 'apt.armbian.com' /etc/apt/sources.list.d/armbian.sources; then
 				if [[ "$repository" == "rolling" && "$status" == "status" ]]; then
 					return 1
 				elif [[ "$status" == "status" ]]; then
@@ -267,7 +267,7 @@ function module_armbian_firmware() {
 				fi
 				# performs list change & update if this is needed
 				if [[ "$repository" == "rolling" ]]; then
-					sed -i "s/http:\/\/[^ ]*/http:\/\/beta.armbian.com/" /etc/apt/sources.list.d/armbian.list
+					sed -iE "s/https?:\/\/[^ ]*/https:\/\/beta.armbian.com/" /etc/apt/sources.list.d/armbian.sources
 					pkg_update
 				fi
 			else
@@ -278,7 +278,7 @@ function module_armbian_firmware() {
 				fi
 				# performs list change & update if this is needed
 				if [[ "$repository" == "stable" ]]; then
-					sed -i "s/http:\/\/[^ ]*/http:\/\/apt.armbian.com/" /etc/apt/sources.list.d/armbian.list
+					sed -iE "s/https?:\/\/[^ ]*/https:\/\/apt.armbian.com/" /etc/apt/sources.list.d/armbian.sources
 					pkg_update
 				fi
 			fi

--- a/tools/modules/system/module_armbian_firmware.sh
+++ b/tools/modules/system/module_armbian_firmware.sh
@@ -259,7 +259,12 @@ function module_armbian_firmware() {
 			local repository=$2
 			local status=$3
 
-			if grep -q 'apt.armbian.com' /etc/apt/sources.list.d/armbian.sources; then
+			local sources_files=()
+			for file in "/etc/apt/sources.list.d/armbian.list" "/etc/apt/sources.list.d/armbian.sources"; do
+				[[ -e "$file" ]] && sources_files+=("$file")
+			done
+
+			if grep -q 'apt.armbian.com' "${sources_files[@]}"; then
 				if [[ "$repository" == "rolling" && "$status" == "status" ]]; then
 					return 1
 				elif [[ "$status" == "status" ]]; then
@@ -267,7 +272,7 @@ function module_armbian_firmware() {
 				fi
 				# performs list change & update if this is needed
 				if [[ "$repository" == "rolling" ]]; then
-					sed -iE "s/https?:\/\/[^ ]*/https:\/\/beta.armbian.com/" /etc/apt/sources.list.d/armbian.sources
+					sed -E -i "s/ https?:\/\/[a-z0-9-]+\.armbian\.com\/( |$)/ https:\/\/beta.armbian.com\/\1/" "${sources_files[@]}"
 					pkg_update
 				fi
 			else
@@ -278,7 +283,7 @@ function module_armbian_firmware() {
 				fi
 				# performs list change & update if this is needed
 				if [[ "$repository" == "stable" ]]; then
-					sed -iE "s/https?:\/\/[^ ]*/https:\/\/apt.armbian.com/" /etc/apt/sources.list.d/armbian.sources
+					sed -E -i "s/ https?:\/\/[a-z0-9-]+\.armbian\.com\/( |$)/ https:\/\/apt.armbian.com\/\1/" "${sources_files[@]}"
 					pkg_update
 				fi
 			fi

--- a/tools/modules/system/release_upgrade.sh
+++ b/tools/modules/system/release_upgrade.sh
@@ -40,7 +40,7 @@ release_upgrade(){
 		[[ -f /etc/apt/sources.list.d/debian.sources ]] && sed -i "s/$distroid/$upgrade/g" /etc/apt/sources.list.d/debian.sources
 		[[ -f /etc/apt/sources.list ]] && sed -i "s/$distroid/$upgrade/g" /etc/apt/sources.list
 		[[ "${upgrade}" == "testing" ]] && upgrade="sid" # our repo and everything is tied to sid
-		[[ -f /etc/apt/sources.list.d/armbian.list ]] && sed -i "s/$distroid/$upgrade/g" /etc/apt/sources.list.d/armbian.list
+		[[ -f /etc/apt/sources.list.d/armbian.sources ]] && sed -i "s/$distroid/$upgrade/g" /etc/apt/sources.list.d/armbian.sources
 		pkg_update
 		apt_upgrade -o Dpkg::Options::="--force-confold" --without-new-pkgs
 		apt_full_upgrade -o Dpkg::Options::="--force-confold"


### PR DESCRIPTION
> This PR and the related PRs will require discussion or RFC before merging, particularly around handling migration of existing installations.

See main PR: https://github.com/armbian/build/pull/7790

- Replace `armbian.list` with `armbian.sources`. This holds the same information in a newer format, deb822.
- Replace HTTP with HTTPS for Armbian repositories.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [ ] Changes have been tested and verified
- [ ] I have included necessary metadata in the code, including associative arrays
