### PR TITLE
Bugfix: Pinning is also needed otherwise kernel doesn't downgrade

### DIFF
--- a/tools/modules/functions/set_runtime_variables.sh
+++ b/tools/modules/functions/set_runtime_variables.sh
@@ -52,7 +52,7 @@ function set_runtime_variables() {
 	[[ -f /etc/armbian-distribution-status ]] && DISTRO_STATUS="/etc/armbian-distribution-status"
 
 	DISTRO=$(lsb_release -is)
-	DISTROID=$(lsb_release -sc || grep "VERSION=" /etc/os-release | grep -oP '(?<=\().*(?=\))')
+	DISTROID=$(lsb_release -sc 2> /dev/null || grep "VERSION=" /etc/os-release | grep -oP '(?<=\().*(?=\))')
 	KERNELID=$(uname -r)
 	[[ -z "${ARMBIAN// /}" ]] && ARMBIAN="$DISTRO $DISTROID"
 


### PR DESCRIPTION
# Description

- kernel switching needs repo pinning.
- small styling fixes

# Testing Procedure

- [x] Tested rolling / stable / kernel switch

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
