### PR TITLE
Bugfix: api always return false when DEBUG is not used

### DIFF
--- a/bin/armbian-config
+++ b/bin/armbian-config
@@ -165,4 +165,6 @@ case "$1" in
     ;;
 esac
 
-[[ -n "$DEBUG" && -n $tools_dir ]] && set_checkpoint show
+if [[ -n "$DEBUG" && -n $tools_dir ]]; then
+	set_checkpoint show
+fi


### PR DESCRIPTION
# Description

This return false in case none of them are defined:
`[[ -n "$DEBUG" && -n $tools_dir ]] && set_checkpoint show`

Fix:
if [[ -n "$DEBUG" && -n $tools_dir ]]; then
	set_checkpoint show
fi

# Testing Procedure

- [ ] Tested with` bin/armbian-config --api pkg_update; echo $?` it return true now

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have ensured that my changes do not introduce new warnings or errors
- [ ] No new external dependencies are included
- [ ] Changes have been tested and verified
- [ ] I have included necessary metadata in the code, including associative arrays
