### PR TITLE
kernel: show rk3588 vendor kernel overlays in overlays section

### DIFF
--- a/tools/modules/functions/set_runtime_variables.sh
+++ b/tools/modules/functions/set_runtime_variables.sh
@@ -85,3 +85,13 @@ function set_runtime_variables() {
 
 }
 
+function update_branch_env() {
+	if [[ -z "${BRANCH}" && -f /etc/armbian-release ]]; then
+		BRANCH=$(dpkg -l | grep -E "linux-image" | grep -E "current|vendor|legacy|edge" | awk '{print $2}' | cut -d"-" -f3 | head -1)
+		if grep -q BRANCH /etc/armbian-release; then
+			[[ -n ${BRANCH} ]] && sed -i "s/BRANCH=.*/BRANCH=$BRANCH/g" /etc/armbian-release
+			else
+			[[ -n ${BRANCH} ]] && echo "BRANCH=$BRANCH" >> /etc/armbian-release
+		fi
+	fi
+}

--- a/tools/modules/system/install_headers.sh
+++ b/tools/modules/system/install_headers.sh
@@ -19,14 +19,7 @@ function module_headers () {
 	if [[ -f /etc/armbian-release ]]; then
 		source /etc/armbian-release
 		# branch information is stored in armbian-release at boot time. When we change kernel branches, we need to re-read this and add it
-		if [[ -z "${BRANCH}" ]]; then
-			BRANCH=$(dpkg -l | grep -E "linux-image" | grep -E "current|vendor|legacy|edge" | awk '{print $2}' | cut -d"-" -f3 | head -1)
-			if grep -q BRANCH /etc/armbian-release; then
-				[[ -n ${BRANCH} ]] && sed -i "s/BRANCH=.*/BRANCH=$BRANCH/g" /etc/armbian-release
-				else
-				[[ -n ${BRANCH} ]] && echo "BRANCH=$BRANCH" >> /etc/armbian-release
-			fi
-		fi
+		update_branch_env
 		local install_pkg="linux-headers-${BRANCH}-${LINUXFAMILY}"
 	else
 		local install_pkg="linux-headers-$(uname -r | sed 's/'-$(dpkg --print-architecture)'//')"

--- a/tools/modules/system/manage_dtoverlays.sh
+++ b/tools/modules/system/manage_dtoverlays.sh
@@ -35,6 +35,16 @@ function manage_dtoverlays () {
 		else
 			available_overlays=$(ls -1 ${overlaydir}/${overlay_prefix}*.dtbo | sed 's/^.*\('${overlay_prefix}'.*\)/\1/g' | sed 's/'${overlay_prefix}'-//g' | sed 's/.dtbo//g')
 		fi
+
+		# Check the branch in case it is not available in /etc/armbian-release
+		update_branch_env
+
+		# Add support for rk3588 vendor kernel overlays which don't have overlay prefix mostly
+		builtin_overlays=""
+		if [[ $BOARDFAMILY == "rockchip-rk3588" ]] && [[ $BRANCH == "vendor" ]]; then
+			builtin_overlays=$(ls -1 ${overlaydir}/*.dtbo | grep -v ${overlay_prefix} | sed 's#^'${overlaydir}'/##' | sed 's/.dtbo//g')
+		fi
+
 		for overlay in ${available_overlays}; do
 			local status="OFF"
 			grep '^overlays' ${overlayconf} | grep -qw ${overlay} && status=ON


### PR DESCRIPTION
# Description

Show rk3588 vendor kernel overlays which don't have prefix in overlay selection section.
Issue reference:  
Related documentation:

# Implementation Details

_Provide a detailed description of the implementation. Include the following:_

- [ ] Key changes introduced by this PR
- [ ] Justification for the changes
- [ ] Confirmation that no new external dependencies or modules have been introduced

# Documentation Summary

- [ ] **Metadata Included:**  
  _Did you include the metadata (associative arrays) in the code? Ensure that metadata for modules, jobs, and runtime has been updated appropriately._

- [ ] **Document Generated:**  
  _Did you generate the updated documentation using `armbian-configng --doc`? Confirm if the command was run to update `README.md` and provide any relevant details._

# Testing Procedure

_Describe the tests you ran to verify your changes. Provide relevant details about your test configuration._

- [x] Tested and confirmed working.

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have ensured that my changes do not introduce new warnings or errors
- [ ] No new external dependencies are included
- [ ] Changes have been tested and verified
- [ ] I have included necessary metadata in the code, including associative arrays
