### PR TITLE
Desktop install bugfix: we need to keep old configs when installing packages

### DIFF
--- a/tools/modules/system/module_desktop.sh
+++ b/tools/modules/system/module_desktop.sh
@@ -45,15 +45,15 @@ function module_desktop() {
 			case "$de" in
 				gnome)
 					echo "/usr/sbin/gdm3" > /etc/X11/default-display-manager
-					pkg_install ${PACKAGES}
-					pkg_install ${PACKAGES_UNINSTALL}
-					pkg_install gdm3
+					pkg_install -o Dpkg::Options::="--force-confold" ${PACKAGES}
+					pkg_install -o Dpkg::Options::="--force-confold" ${PACKAGES_UNINSTALL}
+					pkg_install -o Dpkg::Options::="--force-confold" gdm3
 				;;
 				kde-neon)
 					echo "/usr/sbin/sddm" > /etc/X11/default-display-manager
-					pkg_install ${PACKAGES}
-					pkg_install ${PACKAGES_UNINSTALL}
-					pkg_install kde-standard
+					pkg_install -o Dpkg::Options::="--force-confold" ${PACKAGES}
+					pkg_install -o Dpkg::Options::="--force-confold" ${PACKAGES_UNINSTALL}
+					pkg_install -o Dpkg::Options::="--force-confold" kde-standard
 				;;
 				*)
 					echo "/usr/sbin/lightdm" > /etc/X11/default-display-manager


### PR DESCRIPTION
# Description

Installation of Gnome hangs in some cases.

# Testing Procedure

- [x] Test install

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
