### PR TITLE
Armbian rsyncd: fix port used in the module

### DIFF
--- a/tools/modules/system/module_armbian_rsyncd.sh
+++ b/tools/modules/system/module_armbian_rsyncd.sh
@@ -7,7 +7,7 @@ module_options+=(
 	["module_armbian_rsyncd,doc_link"]=""
 	["module_armbian_rsyncd,group"]="DevTools"
 	["module_armbian_rsyncd,status"]="Active"
-	["module_armbian_rsyncd,port"]="22"
+	["module_armbian_rsyncd,port"]="873"
 	["module_armbian_rsyncd,arch"]=""
 )
 


### PR DESCRIPTION
# Description

Fixing wrong port declaration in the module config.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code