### PR TITLE
Change to different method of getting changed files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,14 +21,14 @@ jobs:
          uses: actions/checkout@v4
 
        - name: Get changed files
-         id: changed-files
-         uses: tj-actions/changed-files@v45
+         id: files
+         uses: UplandJacob/retrieve-changed-files@v4
 
        - name: "Show which files we check"
          shell: bash {0}
          run: |
            echo "# Checked files:" >> $GITHUB_STEP_SUMMARY
-           echo "${{ steps.changed-files.outputs.all_changed_files }}" | sed "s/ /\n/g" >> $GITHUB_STEP_SUMMARY
+           echo "${{ steps.files.outputs.all }}" | sed "s/ /\n/g" >> $GITHUB_STEP_SUMMARY
 
        - name: Environment variables
          run: sudo -E bash -c set
@@ -37,8 +37,8 @@ jobs:
          shell: bash {0}
          run: |
 
-           if [[ -n "${{ steps.changed-files.outputs.all_changed_files }}" ]]; then
-               FILES="${{ steps.changed-files.outputs.all_changed_files }}"
+           if [[ -n "${{ steps.files.outputs.all }}" ]]; then
+               FILES="${{ steps.files.outputs.all }}"
                for file in $FILES; do
                    if grep -qE "^#\!/.*bash" $file; then
                        shellcheck --severity=error $file || ret=$?

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -30,13 +30,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v45
-        with:
-          files: |
-              tests/*.conf
+        id: files
+        uses: UplandJacob/retrieve-changed-files@v4
 
-      - name: "Make JSON ${{ steps.changed-files.outputs.all_changed_files }}"
+      - name: "Make JSON ${{ steps.files.outputs.all }}"
         id: json
         run: |
 
@@ -45,8 +42,8 @@ jobs:
           # define OS variants where we can run test install
           images=("bookworm" "jammy" "noble")
           # read tests cases
-          if [[ -n "${{ steps.changed-files.outputs.all_changed_files }}" ]]; then
-              tests=($(grep -rwl ${{ steps.changed-files.outputs.all_changed_files }} -e "ENABLED=true" | cut -d":" -f1))
+          if [[ -n "${{ steps.files.outputs.all }}" ]]; then
+              tests=($(grep -rwl "${{ steps.files.outputs.all }}" -e "ENABLED=true" | cut -d":" -f1))
               else
               tests=($(grep -rwl tests/*.conf -e "ENABLED=true" | cut -d":" -f1))
           fi


### PR DESCRIPTION
# Description

Addressing security issue: https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/

# Testing Procedure

- [x] Tested at PR

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
