### PR TITLE
Bugfix: allow switching from rockchip edge / current to vendor

### DIFF
--- a/tools/modules/system/module_armbian_firmware.sh
+++ b/tools/modules/system/module_armbian_firmware.sh
@@ -46,8 +46,8 @@ function module_armbian_firmware() {
 				do
 					echo "linux-image-${kernel_test_target}-${LINUXFAMILY}"
 					# Exception for Rockchip
-					if [[ -n "${kernel_test_target}" && "${LINUXFAMILY}" == "rk35xx" && "${kernel_test_target}" =~ ^(current|edge)$ ]]; then
-						echo "linux-image-${kernel_test_target}-rockchip64"
+					if [[ -n "${kernel_test_target}" && "${BOARDFAMILY}" == "rockchip-rk3588" && "${kernel_test_target}" =~ ^(current|vendor|edge)$ ]]; then
+						echo "linux-image-${kernel_test_target}-rk35xx"
 					fi
 				done
 				)


### PR DESCRIPTION
# Description

Switching back to vendor was not working. 

# Testing Procedure

- [x] Switched from CURRENT to VENDOR kernel on RK3588 board

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
