### PR TITLE
Derive "branch" and "linuxfamily" from currently installed kernel: fix for kernel hold / unhold

### DIFF
--- a/tools/modules/system/install_headers.sh
+++ b/tools/modules/system/install_headers.sh
@@ -19,7 +19,7 @@ function module_headers () {
 	if [[ -f /etc/armbian-release ]]; then
 		source /etc/armbian-release
 		# branch information is stored in armbian-release at boot time. When we change kernel branches, we need to re-read this and add it
-		update_branch_env
+		update_kernel_env
 		local install_pkg="linux-headers-${BRANCH}-${LINUXFAMILY}"
 	else
 		local install_pkg="linux-headers-$(uname -r | sed 's/'-$(dpkg --print-architecture)'//')"

--- a/tools/modules/system/manage_dtoverlays.sh
+++ b/tools/modules/system/manage_dtoverlays.sh
@@ -37,7 +37,7 @@ function manage_dtoverlays () {
 		fi
 
 		# Check the branch in case it is not available in /etc/armbian-release
-		update_branch_env
+		update_kernel_env
 
 		# Add support for rk3588 vendor kernel overlays which don't have overlay prefix mostly
 		builtin_overlays=""

--- a/tools/modules/system/module_armbian_firmware.sh
+++ b/tools/modules/system/module_armbian_firmware.sh
@@ -161,8 +161,10 @@ function module_armbian_firmware() {
 			local headers="$6"
 			local linuxfamily="$7"
 
-			# if branch is not defined, we use the one that is currently installed
-			[[ -z $BRANCH && -z $branch ]] && local branch="current"
+			# if branch or linuxfamily are not defined, we derive them from the currently installed kernel
+			local list_of_installed_kernels=$(dpkg -l | grep '^[hi]i' | grep linux-image)
+			[[ -z "${branch}" ]] && branch=$(echo "$list_of_installed_kernels" | awk '{print $2}' | cut -d'-' -f3)
+			[[ -z "${linuxfamily}" ]] && linuxfamily=$(echo "$list_of_installed_kernels" | awk '{print $2}' | cut -d'-' -f4)
 
 			# if repository is not defined, we use stable one
 			[[ -z $repository ]] && local repository="apt.armbian.com"


### PR DESCRIPTION
# Description

Derive "branch" and "linuxfamily" from currently installed kernel to complete the package names for hold/unhold.

"hold" and "unhold" are calling "show" with empty arguments for "branch" and "linuxfamily", so the actual values have to be calculated within the "show" function (like it is done for the "repository" function, but also including held-back packages in the grep filter).

In its current state, these variables are unset, leading to incomplete package names "linux-image--" and "linux-dtb--", so these packages can't be set to hold/unhold.

# Implementation Details

- [X] Key changes introduced by this PR: Fixes the kernel hold/unhold feature
- [X] Justification for the changes: Bugfix
- [X] Confirmation that no new external dependencies or modules have been introduced

# Documentation Summary

- [?] **Metadata Included:** : Does not apply afaict 
  _Did you include the metadata (associative arrays) in the code? Ensure that metadata for modules, jobs, and runtime has been updated appropriately._

- [?] **Document Generated:** : Does not apply afaict (but `armbian-config --doc` did not emit errors
  _Did you generate the updated documentation using `armbian-configng --doc`? Confirm if the command was run to update `README.md` and provide any relevant details._

# Testing Procedure

- [X] Marked/unmarked kernel hold for current and edge kernels, both for stable and rolling package sources.

# Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have ensured that my changes do not introduce new warnings or errors
- [X] No new external dependencies are included
- [X] Changes have been tested and verified
- [?] I have included necessary metadata in the code, including associative arrays
