### PR TITLE
Fix kernel selection display for rockchip-rk3588 boards

### DIFF
--- a/tools/modules/system/module_armbian_firmware.sh
+++ b/tools/modules/system/module_armbian_firmware.sh
@@ -47,10 +47,15 @@ function module_armbian_firmware() {
 			local kernel_test_target=$(\
 				for kernel_test_target in ${KERNEL_TEST_TARGET//,/ }
 				do
-					echo "linux-image-${kernel_test_target}-${LINUXFAMILY}"
 					# Exception for Rockchip
-					if [[ -n "${kernel_test_target}" && "${BOARDFAMILY}" == "rockchip-rk3588" && "${kernel_test_target}" =~ ^(current|vendor|edge)$ ]]; then
-						echo "linux-image-${kernel_test_target}-rk35xx"
+					if [[ "${BOARDFAMILY}" == "rockchip-rk3588" ]]; then
+						if [[ "${kernel_test_target}" == "vendor" ]]; then
+							echo "linux-image-${kernel_test_target}-rk35xx"
+						elif [[ "${kernel_test_target}" =~ ^(current|edge)$ ]]; then
+							echo "linux-image-${kernel_test_target}-rockchip64"
+						fi
+					else
+						echo "linux-image-${kernel_test_target}-${LINUXFAMILY}"
 					fi
 				done
 				)


### PR DESCRIPTION
# Description

This commit fixes an issue where the kernel selection menu would display duplicate entries for vendor kernels and wouldn't list current and edge kernels for rockchip-rk3588 boards.

Before:
![image](https://github.com/user-attachments/assets/5ba61749-1113-447d-89ca-4b1d5cd53b98)

after: 
![image](https://github.com/user-attachments/assets/d081bdd2-e589-436e-b154-26259ab2ce3b)

Tested on Orange Pi 5 Max with Armbian 25.5.0-trunk.322.

# Testing Procedure

Used the modified armbian-config to get to the kernel selection display.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
