### PR TITLE
Do not disable cgroupsv2 on Home Assistant installation

### DIFF
--- a/tools/modules/software/module_haos.sh
+++ b/tools/modules/software/module_haos.sh
@@ -89,9 +89,9 @@ function module_haos() {
 
 			if [[ -f /boot/firmware/cmdline.txt ]]; then
 				# Raspberry Pi
-				sed -i '/./ s/$/ systemd.unified_cgroup_hierarchy=0 apparmor=1 security=apparmor/' /boot/firmware/cmdline.txt
+				sed -i '/./ s/$/ apparmor=1 security=apparmor/' /boot/firmware/cmdline.txt
 			elif [[ -f /boot/armbianEnv.txt ]]; then
-				echo "extraargs=systemd.unified_cgroup_hierarchy=0 apparmor=1 security=apparmor" >> "/boot/armbianEnv.txt"
+				echo "extraargs=apparmor=1 security=apparmor" >> "/boot/armbianEnv.txt"
 			fi
 			sleep 5
 			for s in {1..50};do
@@ -134,9 +134,9 @@ function module_haos() {
 			fi
 			rm -f /usr/local/bin/supervisor_fix.sh
 			rm -f /etc/systemd/system/supervisor-fix.service
-			sed -i "s/ systemd.unified_cgroup_hierarchy=0 apparmor=1 security=apparmor//" /boot/armbianEnv.txt
+			sed -i "s/ apparmor=1 security=apparmor//" /boot/armbianEnv.txt
 			# Raspberry Pi
-			sed -i "s/ systemd.unified_cgroup_hierarchy=0 apparmor=1 security=apparmor//" /boot/firmware/cmdline.txt
+			sed -i "s/ apparmor=1 security=apparmor//" /boot/firmware/cmdline.txt
 			srv_daemon_reload
 			# restore os-release
 			sed -i "s/^PRETTY_NAME=\".*/PRETTY_NAME=\"${VENDOR} ${REVISION} ($VERSION_CODENAME)\"/g" "/etc/os-release"


### PR DESCRIPTION
# Description

As of Home Assistant Supervisor release [2024.12.0](https://github.com/home-assistant/supervisor/releases/tag/2024.12.0), support for CGroup v2 has been added. Since it's my understanding that older version of the installer (1.6.0 currently in the repository) install the latest version of HomeAssistant and its supervisor, we can safely remove this.

This update removes the explicit disabling of `systemd.unified_cgroup_hierarchy=0`, aligning with the switch to cgroupsv2 introduced in installer release [3.0.0](https://github.com/home-assistant/supervised-installer/releases/tag/3.0.0).

See this [supervised-installer ](https://github.com/home-assistant/supervised-installer/issues/372) issue for more context.

I also noticed it's set [in this file ](https://github.com/armbian/os/blob/main/userpatches/extensions/ha.sh) here but I don't really know when this is executed.

# Testing Procedure

- [x] Disabled it on my own install and it works. Logs are clear and `docker stats` now provide memory usage information.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
