### PR TITLE
Switch Netdata to host network for proper metrics and accessibility

### DIFF
--- a/tools/modules/software/module_netdata.sh
+++ b/tools/modules/software/module_netdata.sh
@@ -34,7 +34,7 @@ function module_netdata () {
 			docker run -d \
 			--name=netdata \
 			--pid=host \
-			--net=lsio \
+			--network=host \
 			-v "${NETDATA_BASE}/netdataconfig:/etc/netdata" \
 			-v "${NETDATA_BASE}/netdatalib:/var/lib/netdata" \
 			-v "${NETDATA_BASE}/netdatacache:/var/cache/netdata" \


### PR DESCRIPTION
# Description

Netdata was not accessible on port 19999 because it defined no port forwarding and was also missing host network metrics due to running in a user-defined bridge network (`--network=lsio`), which isolates the container from the host’s network stack.

Switched to `--network=host` to allow Netdata to bind directly to host ports and access full network and system metrics as per [the documentation](https://learn.netdata.cloud/docs/netdata-agent/installation/docker)

# Testing Procedure

- [x] Re-launched the container with `network=host` and confirmed that it's now accessible on port 19999 and "sees" the whole host's network.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
