### PR TITLE
Disabled menu titles for Desktop Environments

### DIFF
--- a/tests/gnome_desktop.conf
+++ b/tests/gnome_desktop.conf
@@ -1,4 +1,4 @@
-ENABLED=true
+ENABLED=false
 RELEASE="bookworm:jammy:noble"
 TESTNAME="Gnome"
 

--- a/tests/xfce_desktop.conf
+++ b/tests/xfce_desktop.conf
@@ -1,4 +1,4 @@
-ENABLED=true
+ENABLED=false
 RELEASE="bookworm:jammy:noble"
 TESTNAME="XFCE"
 

--- a/tools/json/config.software.json
+++ b/tools/json/config.software.json
@@ -334,6 +334,7 @@
                 {
                     "id": "Desktops",
                     "description": "Desktop Environments",
+                    "status": "Disabled",
                     "sub": [
                         {
                             "id": "XFCE",


### PR DESCRIPTION
# Description

This pull request includes a small change to the `tools/json/config.software.json` file. The change sets the status of the "Desktops" category to "Disabled".

Reference issue #484


* [`tools/json/config.software.json`](diffhunk://#diff-c6a5fd88d889da7957334a5e80722428f2dc9984462b4e515ae1026acc93e9ceR337): Added a "status" field with the value "Disabled" to the "Desktops" category.

<img width="652" alt="{6002EBCB-BABB-4A45-9BCA-2A57A837348E}" src="https://github.com/user-attachments/assets/3baadb70-3b12-4db0-9198-ae744c1140a7" />



>NOTE:
This disables the menu and help entries, the option is still available though the advanced --api option

```bash
/workspaces/configng (484-bug-disable-de-menu) $ sudo ./bin/armbian-config --api module_desktop help
```
Shows 
```

Usage: module_desktop <command>
Commands:  install remove disable enable status auto manual login help
Available commands:
        install - Generate packages for test.
        remove  -  Generate packages for test.
        disable - Generate packages for test.
        enable  -  Generate packages for test.
        status  -  Generate packages for test.

Available switches:

        kvmprefix       - Name prefix (default = kvmtest)
```