### PR TITLE
Enable Auto start for Stirling-PDF after reboot

### DIFF
--- a/tools/modules/software/module_evcc.sh
+++ b/tools/modules/software/module_evcc.sh
@@ -50,7 +50,7 @@ function module_evcc () {
 					sleep 3
 				fi
 				if [ $i -eq 20 ] ; then
-					echo -e "\nTimed out waiting for ${title} to start, consult your container logs for more info (\`docker logs stirling-pdf\`)"
+					echo -e "\nTimed out waiting for ${title} to start, consult your container logs for more info (\`docker logs evcc\`)"
 					exit 1
 				fi
 			done

--- a/tools/modules/software/module_stirling.sh
+++ b/tools/modules/software/module_stirling.sh
@@ -42,6 +42,7 @@ function module_stirling () {
 			-e INSTALL_BOOK_AND_ADVANCED_HTML_OPS=false \
 			-e LANGS=en_GB \
 			--name stirling-pdf \
+			--restart unless-stopped \
 			stirlingtools/stirling-pdf:latest
 			for i in $(seq 1 20); do
 				if docker inspect -f '{{ index .Config.Labels "build_version" }}' stirling-pdf >/dev/null 2>&1 ; then


### PR DESCRIPTION
## **Description**
This PR enables the **Stirling-PDF** container to automatically start after a server reboot by modifying the `docker run` command to include `--restart unless-stopped`.

**Issue reference:**  
N/A (No specific issue linked)

## **Implementation Details**
- **Key changes introduced by this PR:**  
  - Added `--restart unless-stopped` to the `docker run` command for **Stirling-PDF**.  
  - Ensures the container automatically restarts after a server reboot or unexpected shutdown.  
  - Maintains service availability without manual intervention.  

- **Justification for the changes:**  
  - Without the `--restart unless-stopped` flag, the **Stirling-PDF** container does not automatically start when the server reboots.  
  - This change improves **reliability and uptime** by ensuring the service is always running unless explicitly stopped.  
  - Helps prevent downtime, making the service more **resilient and user-friendly**.  

- **Confirmation that no new external dependencies or modules have been introduced:**  
  - This PR only **modifies the Docker run command**.  
  - No additional software, libraries, or external dependencies were introduced.  
  - The existing **Stirling-PDF image** (`stirlingtools/stirling-pdf:latest`) remains unchanged.  

## **Documentation Summary**
- [x] **Metadata Included:** N/A (No metadata changes required)
- [x] **Document Generated:** N/A (No documentation update needed)

## **Testing Procedure**
- [x] **Test 1:**  
  - Rebooted the server.  
  - Confirmed that Stirling-PDF started automatically.

## **Checklist**
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have ensured that my changes do not introduce new warnings or errors.
- [x] No new external dependencies are included.
- [x] Changes have been tested and verified.
- [ ] I have included necessary metadata in the code, including associative arrays.
