### PR TITLE
Update manage_dtoverlays.sh (rk3588)

### DIFF
--- a/tools/modules/system/manage_dtoverlays.sh
+++ b/tools/modules/system/manage_dtoverlays.sh
@@ -41,7 +41,7 @@ function manage_dtoverlays () {
 
 		# Add support for rk3588 vendor kernel overlays which don't have overlay prefix mostly
 		builtin_overlays=""
-		if [[ $BOARDFAMILY == "rockchip-rk3588" ]] && [[ $BRANCH == "vendor" ]]; then
+		if [[ $BOARDFAMILY == "rockchip-rk3588" || $BOARDFAMILY == "rk3588" ]] && [[ $BRANCH == "vendor" ]]; then
 			builtin_overlays=$(ls -1 ${overlaydir}/*.dtbo | grep -v ${overlay_prefix} | sed 's#^'${overlaydir}'/##' | sed 's/.dtbo//g')
 		fi
 

--- a/tools/modules/system/manage_dtoverlays.sh
+++ b/tools/modules/system/manage_dtoverlays.sh
@@ -41,7 +41,7 @@ function manage_dtoverlays () {
 
 		# Add support for rk3588 vendor kernel overlays which don't have overlay prefix mostly
 		builtin_overlays=""
-		if [[ $BOARDFAMILY == "rockchip-rk3588" || $BOARDFAMILY == "rk3588" ]] && [[ $BRANCH == "vendor" ]]; then
+		if [[ "$BOARDFAMILY" == "rockchip-rk3588" || "$BOARDFAMILY" == "rk3588" ]] && [[ "$BRANCH" == "vendor" ]]; then
 			builtin_overlays=$(ls -1 ${overlaydir}/*.dtbo | grep -v ${overlay_prefix} | sed 's#^'${overlaydir}'/##' | sed 's/.dtbo//g')
 		fi
 

--- a/tools/modules/system/manage_dtoverlays.sh
+++ b/tools/modules/system/manage_dtoverlays.sh
@@ -42,7 +42,7 @@ function manage_dtoverlays () {
 		# Add support for rk3588 vendor kernel overlays which don't have overlay prefix mostly
 		builtin_overlays=""
 		if [[ "$BOARDFAMILY" == "rockchip-rk3588" || "$BOARDFAMILY" == "rk3588" ]] && [[ "$BRANCH" == "vendor" ]]; then
-			builtin_overlays=$(ls -1 ${overlaydir}/*.dtbo | grep -v ${overlay_prefix} | sed 's#^'${overlaydir}'/##' | sed 's/.dtbo//g')
+		    builtin_overlays=$(ls -1 ${overlaydir}/*.dtbo | grep -v ${overlay_prefix} | sed -E 's#^'${overlaydir}'/(rockchip-rk3588-|rk3588-)##' | sed 's/.dtbo//g')
 		fi
 
 		for overlay in ${available_overlays}; do


### PR DESCRIPTION
This pull request includes a small change to the `tools/modules/system/manage_dtoverlays.sh` file. The change modifies the condition for adding support for rk3588 vendor kernel overlays to include both "rockchip-rk3588" and "rk3588" in the `BOARDFAMILY` variable. 

* [`tools/modules/system/manage_dtoverlays.sh`](diffhunk://#diff-396702bf28d43fe4748d858a6fae3ee66db538e65730f7f903bf4cb5363b2502L44-R44): Updated the condition to check for `BOARDFAMILY` values "rockchip-rk3588" or "rk3588" for vendor kernel overlays.
