### PR TITLE
Add generic "Helper" software help module

### DIFF
--- a/2
+++ b/2
@@ -1,0 +1,1 @@
+enabled

--- a/tools/modules/functions/helper_help_module.sh
+++ b/tools/modules/functions/helper_help_module.sh
@@ -1,15 +1,15 @@
 module_options+=(
-	["_help_module,author"]="@Tearran"
-	["_help_module,maintainer"]="@Tearran"
-	["_help_module,feature"]="_help_module"
-	["_help_module,example"]="<Title> <Module Name> <For Invalid command (true)>"
-	["_help_module,desc"]="Imaging Editor installation and management (gimp inkscape)."
-	["_help_module,status"]="Active"
-	["_help_module,group"]="Internet"
-	["_help_module,arch"]="x86-64 arm64 armhf"
+	["_software_help_module,author"]="@Tearran"
+	["_software_help_module,maintainer"]="@Tearran"
+	["_software_help_module,feature"]="_software_help_module"
+	["_software_help_module,example"]="<Title> <Module Name> <For Invalid command (true)>"
+	["_software_help_module,desc"]="Imaging Editor installation and management (gimp inkscape)."
+	["_software_help_module,status"]="Active"
+	["_software_help_module,group"]="Internet"
+	["_software_help_module,arch"]="x86-64 arm64 armhf"
 )
 #
-_help_module(){
+_software_help_module(){
 
 
 	local title="$1"
@@ -18,7 +18,7 @@ _help_module(){
     # Check if title or self is missing
 	if [[ -z "$title" || "$self" == "" ]]; then
 		echo "Error: Missing inputs for function. Provide both <Title> and <Module Name>."
-		echo -e "Example: ./bin/armbian-config --api _help_module \"Samba services\" module_samba"
+		echo -e "Example: ./bin/armbian-config --api _software_help_module \"Samba services\" module_samba"
 		return 1
 	fi
 	# Convert the example string to an array

--- a/tools/modules/functions/helper_help_module.sh
+++ b/tools/modules/functions/helper_help_module.sh
@@ -15,7 +15,7 @@ _software_help_module(){
 	local title="$1"
 	local self="$2"
 
-    # Check if title or self is missing
+	# Check if title or self is missing
 	if [[ -z "$title" || "$self" == "" ]]; then
 		echo "Error: Missing inputs for function. Provide both <Title> and <Module Name>."
 		echo -e "Example: ./bin/armbian-config --api _software_help_module \"Samba services\" module_samba"

--- a/tools/modules/functions/helper_help_module.sh
+++ b/tools/modules/functions/helper_help_module.sh
@@ -1,0 +1,39 @@
+module_options+=(
+	["_help_module,author"]="@Tearran"
+	["_help_module,maintainer"]="@Tearran"
+	["_help_module,feature"]="_help_module"
+	["_help_module,example"]="<Title> <Module Name> <For Invalid command (true)>"
+	["_help_module,desc"]="Imaging Editor installation and management (gimp inkscape)."
+	["_help_module,status"]="Active"
+	["_help_module,group"]="Internet"
+	["_help_module,arch"]="x86-64 arm64 armhf"
+)
+#
+_help_module(){
+
+
+	local title="$1"
+	local self="$2"
+
+    # Check if title or self is missing
+	if [[ -z "$title" || "$self" == "" ]]; then
+		echo "Error: Missing inputs for function. Provide both <Title> and <Module Name>."
+		echo -e "Example: ./bin/armbian-config --api _help_module \"Samba services\" module_samba"
+		return 1
+	fi
+	# Convert the example string to an array
+	local commands
+	IFS=' ' read -r -a commands <<< "${module_options["$self,example"]}"
+
+	[[ "$3" == "true" ]] && echo "Invalid command. Try one of: ${module_options["$self,example"]}"
+	echo -e "\nUsage: $self <command>"
+	echo -e "Commands: ${module_options["$self,example"]}"
+	echo "Available commands:"
+	# Loop through all commands (starting from index 1)
+	for ((i = 1; i < ${#commands[@]}; i++)); do
+		printf "\t%-10s - %s %s\n" "${commands[i]}" "${commands[i]}" "$title"
+		#echo -e "\t${commands[i]}\t- Manage ${commands[i]} $title."
+	done
+	echo
+
+}

--- a/tools/modules/software/module_samba.sh
+++ b/tools/modules/software/module_samba.sh
@@ -11,50 +11,8 @@ module_options+=(
 	["module_samba,arch"]="x86-64 arm64 armhf"
 )
 
-function module_samba() {
-	local title="samba"
-	local condition
-	condition=$(command -v smbd)
-
-	# Set the interface for dialog tools
-	set_interface
-
-	# Convert the example string to an array
-	local commands
-	IFS=' ' read -r -a commands <<< "${module_options["module_samba,example"]}"
-
-	case "$1" in
-		"${commands[0]}"|"")
-		## help/menu options for the module
-		echo -e "\nUsage: ${module_options["module_samba,feature"]} <command>"
-		# Full list of commands to referance is printed
-		echo -e "Commands: ${module_options["module_samba,example"]}"
-		echo "Available commands:"
-		# Unlike the for mentioned `echo -e "Commands: ${module_options["module_samba,example"]}"``
-		# comprehenive referance the Avalible commands are commands considered useable in UI/UX
-		# intened use below.
-		if [[ -z "$condition" ]]; then
-			echo -e "\t${commands[1]}\t- ${commands[1]} $title."
-		else
-			if srv_active smbd; then
-			echo -e "\t${commands[2]}\t- ${commands[2]} $title service."
-			echo -e "\t${commands[3]}\t- ${commands[3]} $title from starting on boot."
-			else
-			echo -e "\t${commands[4]}\t- ${commands[4]} $title to start on boot."
-			echo -e "\t${commands[5]}\t- ${commands[5]} $title. service."
-			fi
-			echo -e "\t${commands[6]}\t- ${commands[6]} $title. $title."
-			# Note: Comment to hide advanced option from menu
-			# while remaining avalible for advance options --api flag
-			echo -e "\t${commands[8]}\t- $title ${commands[8]} conf"
-			echo -e "\t${commands[9]}\t- $title ${commands[9]}."
-		fi
-		echo
-		;;
-		"${commands[1]}")
-		# install samba
-		pkg_install samba
-		# Check if /etc/samba/smb.conf exists
+_check_samba_config(){
+	# Check if /etc/samba/smb.conf exists
 		if [[ ! -f "/etc/samba/smb.conf" ]]; then
 			if [[ -f "/usr/share/samba/smb.conf" ]]; then
 				cp "/usr/share/samba/smb.conf" "/etc/samba/smb.conf"
@@ -62,66 +20,60 @@ function module_samba() {
 				echo "Warning: Missing configuration file. Use the <configure> option."
 			fi
 		fi
+}
 
-		echo "Samba installed successfully."
-		;;
-		"${commands[2]}")
-		## added subshell to prevent srv_disable exiting befor removing is complete.
-		srv_disable smbd
-		pkg_remove samba
-		echo "$title remove complete."
-		;;
-		"${commands[3]}")
-		srv_start smbd
-		echo "Samba service started."
-		;;
-		"${commands[4]}")
-		srv_stop smbd
-		echo "Samba service stopped."
-		;;
-		"${commands[5]}")
-		srv_enable smbd
-		echo "Samba service enabled."
-		;;
-		"${commands[6]}")
-		srv_disable smbd
-		echo "Samba service disabled."
-		;;
-		"${commands[7]}"|"${commands[8]}")
-		echo "Using package default configuration..."
+_set_samba_default(){
+# Check if the default Samba configuration file and directory exist
+	if [[ -f "/usr/share/samba/smb.conf" && -d "/etc/samba" ]]; then
+		echo "Found default configuration and target directory."
+		cp /usr/share/samba/smb.conf /etc/samba/smb.conf
+		echo "Default configuration copied to /etc/samba/smb.conf."
+	else
+		# Provide more specific error messages
+		if [[ ! -f "/usr/share/samba/smb.conf" ]]; then
+		echo "Error: Default configuration file /usr/share/samba/smb.conf not found."
+		fi
+		if [[ ! -d "/etc/samba" ]]; then
+		echo "Error: Target directory /etc/samba does not exist."
+		fi
+		return 1
+	fi
+}
 
-		# Check if the default Samba configuration file and directory exist
-		if [[ -f "/usr/share/samba/smb.conf" && -d "/etc/samba" ]]; then
-			echo "Found default configuration and target directory."
-			cp /usr/share/samba/smb.conf /etc/samba/smb.conf
-			echo "Default configuration copied to /etc/samba/smb.conf."
-		else
-			# Provide more specific error messages
-			if [[ ! -f "/usr/share/samba/smb.conf" ]]; then
-			echo "Error: Default configuration file /usr/share/samba/smb.conf not found."
-			fi
-			if [[ ! -d "/etc/samba" ]]; then
-			echo "Error: Target directory /etc/samba does not exist."
-			fi
-			return 1
-		fi
-		;;
-		"${commands[9]}")
-		## check samba status
-		if srv_active smbd; then
-			echo "active."
-			return 0
-		elif ! srv_enabled smbd; then
-			echo "inactive"
-			return 1
-		else
-			echo "Samba service is in an unknown state."
-			return 1
-		fi
-		;;
-		*)
-		# Full list of commands to referance is printed
-		echo "Invalid command. Try: '${module_options["module_samba,example"]}'"
-		;;
+_pipe_service_state(){
+	local title="$1"
+			## check samba status
+	if srv_active $title ; then
+		echo "active."
+		return 0
+	elif ! srv_enabled $title ; then
+		echo "inactive"
+		return 1
+	else
+		echo "$title service is in an unknown state."
+		return 1
+	fi
+}
+
+function module_samba() {
+	local title="samba"
+	local feature="module_samba"
+	local condition
+	condition=$(command -v smbd)
+	# Convert the example string to an array
+	local commands
+	IFS=' ' read -r -a commands <<< "${module_options["module_samba,example"]}"
+
+	case "$1" in
+		"${commands[0]}") _software_help_module "$title" "$feature" ;;
+		"${commands[1]}") pkg_install samba && _check_samba_config ;;
+		"${commands[2]}") srv_disable smbd && pkg_remove samba ;;
+		"${commands[3]}") srv_start smbd ;;
+		"${commands[4]}") srv_stop smbd ;;
+		"${commands[5]}") srv_enable smbd ;;
+		"${commands[6]}") srv_disable smbd ;;
+		"${commands[7]}"|"${commands[8]}") _set_samba_default ;;
+		"${commands[9]}") _pipe_service_state smbd ;;
+		*) _software_help_module "Samba services" module_samba true ;;
 	esac
 }


### PR DESCRIPTION
This pull request introduces significant refactoring and enhancements to the `module_samba` function and adds a new helper function `_software_help_module`. The changes aim to modularize the code, improve maintainability, and enhance error handling. Below is a summary of the most important changes:

### New functionality and helper function addition:
* Added a new `_software_help_module` function in `tools/modules/functions/helper_help_module.sh` to provide detailed usage instructions and error handling for software modules. This function supports dynamic help generation based on module options.

### Refactoring of `module_samba`:
* Modularized the `module_samba` function in `tools/modules/software/module_samba.sh` by extracting logic into smaller helper functions (`_check_samba_config`, `_set_samba_default`, and `_pipe_service_state`) for better readability and maintainability. [[1]](diffhunk://#diff-bd35f2241870c733836c1cc3358f66145a22cac529dbcf896c3869a157df9618L14-R14) [[2]](diffhunk://#diff-bd35f2241870c733836c1cc3358f66145a22cac529dbcf896c3869a157df9618R23-R25) [[3]](diffhunk://#diff-bd35f2241870c733836c1cc3358f66145a22cac529dbcf896c3869a157df9618L108-R77)
* Simplified the main `case` statement in `module_samba` by delegating help and command handling to `_software_help_module` and other extracted functions.

### Code cleanup:
* Removed redundant comments and unused code from the `module_samba` function to streamline the implementation. [[1]](diffhunk://#diff-bd35f2241870c733836c1cc3358f66145a22cac529dbcf896c3869a157df9618L14-R14) [[2]](diffhunk://#diff-bd35f2241870c733836c1cc3358f66145a22cac529dbcf896c3869a157df9618R23-R25)

### Minor configuration update:
* Added an `enabled` flag in file `2`, possibly to indicate a default state or activation status.

# How was this tested
use as a help message
`./bin/armbian-config --api _software_help_module "samba" module_samba`
or 
` ./bin/armbian-config --api module_samba help`
```
The current Armbian 25.2.3 stable (bookworm) is supported.

Usage: module_samba <command>
Commands: help install remove start stop enable disable configure default status
Available commands:
        install    - install samba
        remove     - remove samba
        start      - start samba
        stop       - stop samba
        enable     - enable samba
        disable    - disable samba
        configure  - configure samba
        default    - default samba
        status     - status samba
```
use for `Invalid command` option
` ./bin/armbian-config --api _software_help_module "cockpit" module_cockpit`
```
./bin/armbian-config --api _software_help_module "cockpit" module_cockpit true
The current Armbian 25.2.3 stable (bookworm) is supported.
```
`Invalid command. Try one of: help install remove start stop enable disable status check` <---
```
Usage: module_cockpit <command>
Commands: help install remove start stop enable disable status check
Available commands:
        install    - install cockpit
        remove     - remove cockpit
        start      - start cockpit
        stop       - stop cockpit
        enable     - enable cockpit
        disable    - disable cockpit
        status     - status cockpit
        check      - check cockpit



````