### PR TITLE
Default module implementation

### DIFF
--- a/tools/modules/functions/module_default.sh
+++ b/tools/modules/functions/module_default.sh
@@ -62,12 +62,12 @@ module_default_help()
 Usage: module_$module <action> [options...]
 
 Where <action> is one of:
-    disable     Disable service(s) for $module.
-    enable      Enable service(s) for $module.
-    help        Show this help screen.
-    install     Install package(s) for $module.
-    remove      Remove package(s) for $module.
-    status      Check $module status (installed and/or enabled)."
+	disable     Disable service(s) for $module.
+	enable      Enable service(s) for $module.
+	help        Show this help screen.
+	install     Install package(s) for $module.
+	remove      Remove package(s) for $module.
+	status      Check $module status (installed and/or enabled)."
 
 	# remove "install" and "remove" lines, if the module doesn't install anything (eg, service-only module)
 	[[ -n "$packages" ]] || text=`grep -Pve " (install|remove) " <<< "$text"`

--- a/tools/modules/functions/module_default.sh
+++ b/tools/modules/functions/module_default.sh
@@ -1,0 +1,106 @@
+# module_default.sh
+
+module_options+=(
+	["module_default,author"]="@dimitry-ishenko"
+	["module_default,desc"]="Default module implementation"
+	["module_default,example"]="disable enable help install remove status"
+	["module_default,feature"]="module_default"
+)
+
+module_default()
+{
+	local action="$1" modules="$2" packages="$3" services="$4"
+	shift 4
+
+	case "$action" in
+		enable)  _module_default_invoke "$action" "$modules" "$services" "$@";;
+		disable) _module_default_invoke "$action" "$modules" "$services" "$@";;
+		help)    _module_default_invoke "$action" "$modules" "$modules" "$packages" "$services" "$@";;
+		install) _module_default_invoke "$action" "$modules" "$packages" "$@";;
+		remove)  _module_default_invoke "$action" "$modules" "$packages" "$@";;
+		status)  _module_default_invoke "$action" "$modules" "$packages" "$services" "$@";;
+		*)       _module_default_invoke "$action" "$modules" "$packages" "$services" "$@";;
+	esac
+}
+
+_module_default_invoke()
+{
+	local action="$1" modules="$2"
+	shift 2
+
+	for module in $modules default; do
+		local fn="module_${module}_${action}"
+		if [[ $(type -t "$fn") == "function" ]]; then
+			"$fn" "$@"
+			return 0
+		fi
+	done
+
+	echo "Unknown action '$action'"
+	return 1
+}
+
+module_default_disable()
+{
+	local services="$1"
+	echo "Disabling $services..."
+	srv_disable $services
+}
+
+module_default_enable()
+{
+	local services="$1"
+	echo "Enabling $services..."
+	srv_enable $services
+}
+
+module_default_help()
+{
+	local module=($1) packages="$2" services="$3" extra="$4"
+
+	local text="
+Usage: module_$module <action> [options...]
+
+Where <action> is one of:
+    disable     Disable service(s) for $module.
+    enable      Enable service(s) for $module.
+    help        Show this help screen.
+    install     Install package(s) for $module.
+    remove      Remove package(s) for $module.
+    status      Check $module status (installed and/or enabled)."
+
+	# remove "install" and "remove" lines, if the module doesn't install anything (eg, service-only module)
+	[[ -n "$packages" ]] || text=`grep -Pve " (install|remove) " <<< "$text"`
+
+	# remove "enable" and "disable" lines, if the module doesn't have any services (eg, software-only module)
+	[[ -n "$services" ]] || text=`grep -Pve " (enable|disable) " <<< "$text"`
+
+	# remove the "status" line, if the modules doesn't have status (eg, internal module
+	# that doesn't install any packages and doesn't have any services)
+	[[ -n "$packages$services" ]] || text=`grep -Pv " status " <<< "$text"`
+
+	echo "$text"
+	[[ -z "$extra" ]] || echo "$extra"
+	echo
+}
+
+module_default_install()
+{
+	local packages="$1"
+	echo "Installing $packages..."
+	pkg_install $packages
+}
+
+module_default_remove()
+{
+	local packages="$1"
+	echo "Removing $packages..."
+	pkg_remove $packages
+}
+
+module_default_status()
+{
+	local packages="$1" services="$2"
+	[[ -z "$services" ]] || srv_enabled $services || return 1
+	[[ -z "$packages" ]] || pkg_installed $packages
+}


### PR DESCRIPTION
# Description

This module adds default implementation of several functions frequently used by other modules. With this module we can greatly reduce boiler-plate which is currently repeated in many other modules.

For example, to create a simple module that installs midnight commander (mc) now takes only a few lines:
```bash
module_mc()
{
	local module="mc" packages="mc" services=""
	module_default $1 "$module" "$packages" "$services"
}
```
You can test it as follows:
```
admin@uefi-x86:~$ armbian-config --api module_mc help

Usage: module_mc <action> [options...]

Where <action> is one of:
    help        Show this help screen.
    install     Install package(s) for mc.
    remove      Remove package(s) for mc.
    status      Check mc status (installed and/or enabled).

```

If your package actives one or more services, they will be handled by `module_default` as well. So, we can create a module that installs systemd-container:
```bash
module_systemd_container()
{
	local module="systemd_container" packages="systemd-container" services="machines.target"
	module_default $1 "$module" "$packages" "$services"
}
```
And, use it as follows:
```
admin@uefi-x86:~$ armbian-config --api module_systemd_container help

Usage: module_systemd_container <action> [options...]

Where <action> is one of:
    disable     Disable service(s) for systemd_container.
    enable      Enable service(s) for systemd_container.
    help        Show this help screen.
    install     Install package(s) for systemd_container.
    remove      Remove package(s) for systemd_container.
    status      Check systemd_container status (installed and/or enabled).
```

If you need to override default behavior, it can be done as follows:

```
module_systemd_container_install()
{
	module_default_install "$@"

	# additional post-installation actions
	local packages="$1"
	...
}
```

You can likewise override any other action (disable, enable, help, install, remove, status).

You can also add your own actions:

```
module_mc_configure()
{
	local packages="$1" services="$2"
	shift 2
	...
}
```

Issue reference:  #529 #533

# Implementation Details

- [x] Key changes introduced by this PR

This approach not only removes a lot of duplicated boiler-plate, but also completely changes how modules are written. Instead of having one giant monolith case/esac function, which is hard to read and follow, you are a number of small self-contained functions that perform each individual action.

This design also allows us to create higher level helpers that work on top of `module_default` and delegate some of the functions to it. For example, I see there is a number of packages that run inside docker. We can create another module called `module_default_docker` that will perform some of the common functions done by these packages (eg, installing the docker).

- [x] Justification for the changes

Greatly reduces code duplication and boiler-plate. Enforces modularity and encapsulation.

- [x] Confirmation that no new external dependencies or modules have been introduced

# Documentation Summary

- [x] **Metadata Included:**  
  _Did you include the metadata (associative arrays) in the code? Ensure that metadata for modules, jobs, and runtime has been updated appropriately._

- [ ] **Document Generated:**  
  _Did you generate the updated documentation using `armbian-configng --doc`? Confirm if the command was run to update `README.md` and provide any relevant details._

None.

# Testing Procedure

See above.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
