### PR TITLE
standardize naming in Kernel/firmware upgrades

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -59,7 +59,7 @@ sudo armbian-config
 
   - ### OS updates and distribution upgrades
     - ### Enable Armbian firmware upgrades
-    - ### Disable Armbian kernel upgrades
+    - ### Disable Armbian firmware upgrades
     - ### Switch system to rolling packages repository
     - ### Switch system to stable packages repository
     - ### Enable automating Docker container base images updating
@@ -412,7 +412,7 @@ Outputs:
 	--cmd MOTD01 - Adjust welcome screen (motd)
     Updates - OS updates and distribution upgrades
 	--cmd UPD001 - Enable Armbian firmware upgrades
-	--cmd UPD002 - Disable Armbian kernel upgrades
+	--cmd UPD002 - Disable Armbian firmware upgrades
 	--cmd ROLLIN - Switch system to rolling packages repository
 	--cmd STABLE - Switch system to stable packages repository
 	--cmd WTC001 - Enable automating Docker container base images updating

--- a/tools/json/config.system.json
+++ b/tools/json/config.system.json
@@ -468,7 +468,7 @@
                             "id": "UPD001",
                             "description": "Enable Armbian firmware upgrades",
                             "short": "Firmware",
-                            "about": "This will enable Armbian kernel upgrades that are currently put on hold.",
+                            "about": "This will enable Armbian kernel/firmware upgrades that are currently put on hold.",
                             "command": [
                                 "module_armbian_firmware unhold"
                             ],
@@ -478,7 +478,7 @@
                         },
                         {
                             "id": "UPD002",
-                            "description": "Disable Armbian kernel upgrades",
+                            "description": "Disable Armbian firmware upgrades",
                             "about": "Disable Armbian kernel/firmware upgrades",
                             "command": [
                                 "module_armbian_firmware hold"


### PR DESCRIPTION
# Description

standardize naming in Kernel/firmware upgrades in UPD001 and UPD002

Issue reference:  #573 

# Implementation Details

Change label and documentation related to UPD002 that has kernel instead of firmware to make a single label to the end user. Only text was changed, not new dependecies to the code.

- [X] Key changes introduced by this PR
- [X] Justification for the changes
- [X] Confirmation that no new external dependencies or modules have been introduced

# Documentation Summary

- [ ] **Metadata Included:**  
no new metadata added.

- [X] **Document Generated:**  
 updated documentation accordingly.

# Testing Procedure

recompile configng and run

- [X] Test 1: check if label for UPD002 is changed. Result: label is changed.

# Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have ensured that my changes do not introduce new warnings or errors
- [X] No new external dependencies are included
- [X] Changes have been tested and verified
- [ ] I have included necessary metadata in the code, including associative arrays
