### PR TITLE
CI: add GitHub Action to detect duplicate module ports

### DIFF
--- a/.github/workflows/validate-json.yml
+++ b/.github/workflows/validate-json.yml
@@ -144,3 +144,50 @@ jobs:
           else
             echo "✅ No duplicate IDs found." >> $GITHUB_STEP_SUMMARY
           fi
+
+  check-duplicate-module-ports:
+    name: Check Duplicate Ports modules/**/*.sh
+    runs-on: ubuntu-latest
+    needs: checkout
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          path: config
+
+      - name: Check for duplicate port values in module_options
+        shell: bash
+        run: |
+          declare -A port_map
+          declare -A port_locations
+          has_duplicates=0
+
+          mapfile -t files < <(find config/tools/modules/ -type f -name '*.sh')
+          for file in "${files[@]}"; do
+            while IFS= read -r line; do
+              if [[ "$line" =~ \[\"([^,]+),port\"\]=[\"\']?([0-9]+)[\"\']? ]]; then
+                module="${BASH_REMATCH[1]}"
+                port="${BASH_REMATCH[2]}"
+                if [[ -n "${port_map[$port]}" ]]; then
+                  has_duplicates=1
+                  port_map[$port]=$((port_map[$port]+1))
+                  port_locations[$port]="${port_locations[$port]}, $file"
+                else
+                  port_map[$port]=1
+                  port_locations[$port]="$file"
+                fi
+              fi
+            done < "$file"
+          done
+
+          if [[ $has_duplicates -eq 1 ]]; then
+            echo "## ❌ Duplicate ports found in tools/modules/*.sh:" >> $GITHUB_STEP_SUMMARY
+            for port in "${!port_map[@]}"; do
+              if [[ ${port_map[$port]} -gt 1 ]]; then
+                echo "- Port \`$port\` appears ${port_map[$port]} times in: ${port_locations[$port]}" >> $GITHUB_STEP_SUMMARY
+              fi
+            done
+            exit 1
+          else
+            echo "✅ No duplicate port values found in module_options." >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/validate-json.yml
+++ b/.github/workflows/validate-json.yml
@@ -146,7 +146,7 @@ jobs:
           fi
 
   check-duplicate-module-ports:
-    name: Check Duplicate Ports modules/**/*.sh
+    name: Check Duplicate Ports
     runs-on: ubuntu-latest
     needs: checkout
     steps:


### PR DESCRIPTION
# Description

This pull request adds a new GitHub Actions job to automatically check for duplicate port values defined in `module_options` across all .sh files in `tools/modules/` and its sub-directories.

🔍 What it does:

- Scans all .sh files under tools/modules/**
- Looks for entries in the form ["module_name,port"]="1234"
- Identifies and reports any duplicate port values
- Fails the check if duplicates are found, with details in the GitHub Actions summary

🎯 Purpose:

Helps prevent port conflicts in module definitions by enforcing unique port assignments at CI level.

# Testing Procedure

- [x] Tested at PR

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
