### PR TITLE
Move wireguard to software section VPN

### DIFF
--- a/tools/json/config.network.json
+++ b/tools/json/config.network.json
@@ -87,49 +87,6 @@
                     ]
                 },
                 {
-                    "id": "WRG001",
-                    "description": "WireGuard VPN client / server",
-                    "short": "WireGuard",
-                    "command": [
-                        "module_wireguard install"
-                    ],
-                    "status": "Enabled",
-                    "author": "@armbian",
-                    "condition": "! module_wireguard status"
-                },
-                {
-                    "id": "WRG002",
-                    "description": "WireGuard remove",
-                    "about": "This operation will remove WireGuard",
-                    "command": [
-                        "module_wireguard remove"
-                    ],
-                    "status": "Enabled",
-                    "author": "@armbian",
-                    "condition": "module_wireguard status"
-                },
-                {
-                    "id": "WRG003",
-                    "description": "WireGuard clients QR codes",
-                    "command": [
-                        "module_wireguard qrcode"
-                    ],
-                    "status": "Enabled",
-                    "author": "@armbian",
-                    "condition": "module_wireguard status"
-                },
-                {
-                    "id": "WRG004",
-                    "description": "WireGuard purge with data folder",
-                    "about": "This operation will purge WireGuard with data folder",
-                    "command": [
-                        "module_wireguard purge"
-                    ],
-                    "status": "Enabled",
-                    "author": "@armbian",
-                    "condition": "module_wireguard status"
-                },
-                {
                     "id": "BLU001",
                     "description": "Install Bluetooth support",
                     "command": [

--- a/tools/json/config.software.json
+++ b/tools/json/config.software.json
@@ -2090,10 +2090,53 @@
                 },
                 {
                     "id": "VPN",
-                    "description": "VPN tools",
+                    "description": "Virtual Private Network tools",
                     "sub": [
                         {
-                            "id": "VPN001",
+                            "id": "WRG001",
+                            "description": "WireGuard VPN client / server",
+                            "short": "WireGuard",
+                            "command": [
+                                "module_wireguard install"
+                            ],
+                            "status": "Enabled",
+                            "author": "@armbian",
+                            "condition": "! module_wireguard status"
+                        },
+                        {
+                            "id": "WRG002",
+                            "description": "WireGuard remove",
+                            "about": "This operation will remove WireGuard",
+                            "command": [
+                                "module_wireguard remove"
+                            ],
+                            "status": "Enabled",
+                            "author": "@armbian",
+                            "condition": "module_wireguard status"
+                        },
+                        {
+                            "id": "WRG003",
+                            "description": "WireGuard clients QR codes",
+                            "command": [
+                                "module_wireguard qrcode"
+                            ],
+                            "status": "Enabled",
+                            "author": "@armbian",
+                            "condition": "module_wireguard status"
+                        },
+                        {
+                            "id": "WRG004",
+                            "description": "WireGuard purge with data folder",
+                            "about": "This operation will purge WireGuard with data folder",
+                            "command": [
+                                "module_wireguard purge"
+                            ],
+                            "status": "Enabled",
+                            "author": "@armbian",
+                            "condition": "module_wireguard status"
+                        },
+                        {
+                            "id": "ZTR001",
                             "description": "ZeroTier connect devices over your own private network in the world.",
                             "command": [
                                 "see_menu module_zerotier"


### PR DESCRIPTION
# Description

Relocating from armbian-config to software section. No changes.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
