### PR TITLE
Remove OMV after test install

### DIFF
--- a/tests/omv.conf
+++ b/tests/omv.conf
@@ -8,4 +8,5 @@ testcase() {(
 	./bin/armbian-config --api module_omv install
 	sudo systemctl start openmediavault-engined.service
 	sudo systemctl is-active --quiet openmediavault-engined.service
+	./bin/armbian-config --api module_omv remove
 )}


### PR DESCRIPTION
# Description

OMV install is quite heavy, so lets remove it after install.

Improve reliability of testing.

