### PR TITLE
Fileserver: fixing typo that broke rendering of documentation

### DIFF
--- a/tools/include/markdown/FIL001-footer.md
+++ b/tools/include/markdown/FIL001-footer.md
@@ -1,19 +1,20 @@
 === "Access to the web interface"
 
-The web interface is accessible via port **8095**:
+    The web interface is accessible via port **8095**:
 
-- URL: `http://<your.IP>:8095`
-- Username/Password: admin / admin
+    - URL: `http://<your.IP>:8095`
+    - Username/Password: admin / admin
 
 === "Directories"
 
-- Install directory: `/armbian/filebrowser`
-- Root directory: `/armbian/filebrowser/srv`
-- Database directory: `/armbian/filebrowser/database`
-- Configuration file: `/armbian/filebrowser/filebrowser.json`
-- Branding directory: `/armbian/filebrowser/branding`
+    - Install directory: `/armbian/filebrowser`
+    - Root directory: `/armbian/filebrowser/srv`
+    - Database directory: `/armbian/filebrowser/database`
+    - Configuration file: `/armbian/filebrowser/filebrowser.json`
+    - Branding directory: `/armbian/filebrowser/branding`
 
 === "View logs"
 
-```sh
-docker logs -f filebrowser
+    ```sh
+    docker logs -f filebrowser
+    ```


### PR DESCRIPTION
# Description

Fixing this:

![image](https://github.com/user-attachments/assets/949b1faa-b4e8-4a2d-9a2b-d541e2649658)

