### PR TITLE
Network config: Show the "disable hotspot" dialog only if there is an active hotspot on the selected interface.

### DIFF
--- a/tools/modules/network/network_config.sh
+++ b/tools/modules/network/network_config.sh
@@ -40,7 +40,7 @@ function network_config() {
 		if [[ "$adapter" == w* ]]; then
 
 			LIST=()
-			if srv_active hostapd; then
+			if srv_active hostapd && grep -q "^interface=$adapter" "/etc/hostapd/hostapd.conf"; then
 				LIST+=("stop" "Disable access point")
 			else
 				LIST=("sta" "Connect to access point")


### PR DESCRIPTION


# Description
Currently, if there is more than a single wireless interface, say wlan0 and wlan1, and I've setup a hotspot on wlan0 and want to connect as a client using wlan1, selecting wlan1 on the script will still show a dialogue with the option to disable the hotspot instead of allowing me to do as I please with it(`ap` or `sta`).

Now this solution introduces another problem which is that the script currently does not support setting up more than a single access point(doing so will overwrite the previously defined `/etc/hostapd/hostapd.conf`), we could instead disable the "become an access point" option in the `else` branch for now and this could be tackled individually in another PR in the future if desired.


Issue reference:  -
Related documentation: -

# Implementation Details
The proposed fix is simply to grep `/etc/hostapd/hostapd.conf` for `interface=$adapter` to check if it's the selected adapter that's set up as a hotspot. By any means it's not a robust solution(e.g one could have more .conf files) and I am open to considering proposed alternatives, but since the script itself uses said file, it will work for `armbian-config` created access points.

# Documentation Summary

- [ ] **Metadata Included:**  
  _Did you include the metadata (associative arrays) in the code? Ensure that metadata for modules, jobs, and runtime has been updated appropriately._

- [ ] **Document Generated:**  
  _Did you generate the updated documentation using `armbian-configng --doc`? Confirm if the command was run to update `README.md` and provide any relevant details._

# Testing Procedure
I modified `/usr/lib/armbian-config/config.network.sh` directly to test if it works as expected.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
- [ ] I have included necessary metadata in the code, including associative arrays
