### PR TITLE
[bug-fix] device tree overlay #592

### DIFF
--- a/tools/modules/system/manage_dtoverlays.sh
+++ b/tools/modules/system/manage_dtoverlays.sh
@@ -18,6 +18,34 @@ function manage_dtoverlays () {
 	# check if user agree to enter this area
 	local changes="false"
 	local overlayconf="/boot/armbianEnv.txt"
+	newoverlays=$(echo $selection | sed 's/"//g')
+
+	# Add this code:
+	# Strip overlay_prefix from each overlay name if it's already present
+	if [[ -n "$overlay_prefix" ]]; then
+		# Convert space-separated list to array
+		IFS=' ' read -r -a overlay_array <<< "$newoverlays"
+		processed_overlays=()
+		
+		for overlay in "${overlay_array[@]}"; do
+			# Check if overlay starts with the prefix
+			if [[ "$overlay" == "$overlay_prefix"* ]]; then
+				# Strip the prefix plus any separator (- or _)
+				processed_overlay="${overlay#"$overlay_prefix"}"
+				processed_overlay="${processed_overlay#[-_]}"
+				processed_overlays+=("$processed_overlay")
+			else
+				# Keep as is if no prefix
+				processed_overlays+=("$overlay")
+			fi
+		done
+		
+		# Convert back to space-separated list
+		newoverlays=$(IFS=' '; echo "${processed_overlays[*]}")
+	fi
+
+# Then continue with the existing code:
+
 	if [[ "${LINUXFAMILY}" == "bcm2711" ]]; then
 		# Raspberry Pi has different name
 		local overlaydir=$(find /boot/dtb/ -maxdepth 1 -type d \( -name "overlay" -o -name "overlays" \) | head -n1)


### PR DESCRIPTION
#592 #542

This pull request introduces a change to the `manage_dtoverlays` function in `tools/modules/system/manage_dtoverlays.sh` to improve the handling of device tree overlays. Specifically, it adds logic to process and strip a defined `overlay_prefix` from overlay names if present.

### Enhancements to overlay processing:

* [`tools/modules/system/manage_dtoverlays.sh`](diffhunk://#diff-396702bf28d43fe4748d858a6fae3ee66db538e65730f7f903bf4cb5363b2502R21-R48): Added logic to strip the `overlay_prefix` (if defined) from each overlay name in the `newoverlays` list. This includes converting the space-separated list into an array, processing each overlay to remove the prefix and any separator (`-` or `_`), and converting the processed array back into a space-separated list.