### PR TITLE
Update to manage_dtoverlays.sh for overlay_prefix handling (revised)

### DIFF
--- a/tools/modules/system/manage_dtoverlays.sh
+++ b/tools/modules/system/manage_dtoverlays.sh
@@ -64,6 +64,9 @@ function manage_dtoverlays () {
 			grep '^overlays' ${overlayconf} | grep -qw ${overlay} && status=ON
 			# Raspberry Pi
 			grep '^dtoverlay' ${overlayconf} | grep -qw ${overlay} && status=ON
+   			# handle case where overlay_prefix is part of overlay name
+	  		candidate=$(echo $overlay | sed "s/^$overlay_prefix"-"//g")
+			grep '^overlays' ${overlayconf} | grep -qw ${candidate} && status=ON
 			options+=( "$overlay" "" "$status")
 		done
 		selection=$($DIALOG --title "Manage devicetree overlays" --cancel-button "Back" \
@@ -74,6 +77,10 @@ function manage_dtoverlays () {
 			0)
 				changes="true"
 				newoverlays=$(echo $selection | sed 's/"//g')
+				# handle case where overlay_prefix is part of overlay name
+				newoverlays=$(echo $newoverlays | sed "s/^$overlay_prefix"-"//" \
+						| sed "s/ $overlay_prefix"-"/ /g")
+				newoverlays=$(echo $newoverlays | tr -s ' ') #trim extra spaces, if any
 				# Raspberry Pi
 				if [[ "${LINUXFAMILY}" == "bcm2711" ]]; then
 					# Remove any existing Armbian config block

--- a/tools/modules/system/manage_dtoverlays.sh
+++ b/tools/modules/system/manage_dtoverlays.sh
@@ -66,7 +66,8 @@ function manage_dtoverlays () {
 			grep '^dtoverlay' ${overlayconf} | grep -qw ${overlay} && status=ON
    			# handle case where overlay_prefix is part of overlay name
 	 		if [[ -n $overlay_prefix ]]; then
-				candidate="${overlay#$overlay_prefix}"
+				candidate="${overlay#$overlay_prefix}" 
+    				candidate="${candidate#'-'}" # remove any trailing hyphen 
 			else
 				candidate="$overlay"
 			fi
@@ -89,7 +90,7 @@ function manage_dtoverlays () {
 					if [[ -n $overlay_prefix && $ov == "$overlay_prefix"* ]]; then
 						ov="${ov#$overlay_prefix}"
 					fi
-	 				# remove '-' from beginning of ov, if any
+	 				# remove '-' hyphen from beginning of ov, if any
 	  				ov="${ov#-}"
 					newoverlays+="$ov "
 				done


### PR DESCRIPTION
# Description
Pull request #614 updated per coderabbit comments / suggestions.

Addresses issues #612 and #592 where overlays are not applied because the overlay_prefix gets included in the overlay name that is written to the _overlays=_ line in armbianEnv.txt .

# Implementation Details
- [X] Key changes introduced by this PR
* Subtract _overlay_prefix_ from names in _newoverlays_ before checking _newoverlays_ against _overlay_ name from arbmianEnv.txt
* Subtract _overlay_prefix_ from _overlay_ before writing to armbianEnv.txt
- [X] Justification for the changes
Overlays do not load if _prefix_ is set in armbianEnv.txt because the prefix is repeated on the overlay name.
- [X] No new external dependencies or modules have been introduced

# Documentation Summary

- [X] **Metadata Included:**  
no updates or additions required

- [X] **Document Generated:**  
none generated

# Testing Procedure
- [X] Test 1: Description and results
- Test run on Libre Renegade. armbianEnv.txt has _prefix_ set to _rockchip_
- Ran armbian-config and selected "rockchip-rk3328-i2c0" from available overlays. Saved and rebooted.

- Verifed that overlay name in armbianEnv.txt was set to _rk3328-i2c0_
- Verified that overlay was applied by seeing i2c-0 device appear in /dev.
- Ran armbian-config and verified that  kept the "*" (ON) status

- [X] Test 2: Description and results
- Same as Test 1 with a second overlay selected.
- Verified correct names in armbianEnv.txt and that both overlays applied correctly.
- Ran ambian-config and verifed correct "*" (ON) status for both overlays

- [X] Test 3: Description and results
- Ran armbian-config and deselected the _rockchip-rk3328-i2c0_ overlay. Saved and rebooted.
- Verified that the i2c0 was removed from armbianEnv.txt but the other overlay remained.
- Ran armbian-config and verified the "*" (ON) status was remove from the i2c0 overlay.
- Verified that the module was no longer applied. (i2c-0 device no longer in /dev)

# Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have ensured that my changes do not introduce new warnings or errors
- [X] No new external dependencies are included
- [X] Changes have been tested and verified
- [X] I have included any necessary metadata in the code, including associative arrays