### PR TITLE
Add WireGuard Client Support and LAN Routing 

### DIFF
--- a/tools/include/markdown/WRG001-footer.md
+++ b/tools/include/markdown/WRG001-footer.md
@@ -1,3 +1,51 @@
+=== "Server"
+
+    1. Launch `armbian-config --cmd WRG001`.
+
+    2. When prompted, enter a comma-separated list of peer names (e.g., laptop,phone,router).
+
+    3. Peer configuration files will be created in
+
+        ```
+        /armbian/wireguard/config/wg_confs/peer_laptop.conf
+        ```
+    4. Scan the QR code (for mobile) or transfer .conf to your client system.
+
+    5. Connect the client using the configuration.
+
+=== "Client"
+
+    1. Launch `armbian-config --cmd WRG002`.
+
+    2. You will be asked to edit or paste a valid WireGuard configuration.
+
+    3. Provide the client configuration in this format:
+
+    ```sh
+    [Interface]
+    Address = 10.13.13.2/32
+    PrivateKey = <your-private-key>
+    DNS = 1.1.1.1
+
+    [Peer]
+    PublicKey = <server-public-key>
+    Endpoint = your.server.com:51820
+    AllowedIPs = 0.0.0.0/0
+    PersistentKeepalive = 25
+    ```
+
+    4. The configuration will be saved to:
+
+        ```
+        /armbian/wireguard/config/wg_confs/client.conf
+        ```
+
+    5. When prompted, enter the local LAN subnets you wish to route via VPN (e.g., `10.0.10.0/24,192.168.0.0/16`).
+
+    6. The VPN container will be started and routing rules will be generated accordingly.
+
+    7. Routing will be restored automatically on boot via systemd service.
+
 === "Access to the server from internet"
 
     Remember to open/forward the port 51820 (UDP) through NAT on your router.
@@ -12,15 +60,3 @@
     ```sh
     docker logs -f wireguard
     ```
-
-# Install server and enable private network on a client
-
-1. Install Wireguard server
-2. It will asks you for peer keywords. It will make a profile for each peer
-3. Download client to your PC, server or mobile phone. Scan OR code or copy credentials to the client.
-
-Enjoy private network! Its that easy.
-
-More informations:
-
-<https://docs.linuxserver.io/images/docker-wireguard/>

--- a/tools/json/config.software.json
+++ b/tools/json/config.software.json
@@ -1,2291 +1,2302 @@
 {
-  "menu": [
-    {
-      "id": "Software",
-      "description": "Run/Install 3rd party applications",
-      "sub": [
+    "menu": [
         {
-          "id": "Armbian",
-          "description": "Armbian infrastructure services",
-          "sub": [
-            {
-              "id": "ART001",
-              "description": "Router for repository mirror automation",
-              "short": "CDN router",
-              "module": "module_generic",
-              "command": [
-                "module_armbianrouter install"
-              ],
-              "status": "Stable",
-              "author": "@efectn",
-              "condition": "! module_armbianrouter status"
-            },
-            {
-              "id": "ART002",
-              "description": "Remove CDN router",
-              "command": [
-                "module_armbianrouter remove"
-              ],
-              "status": "Stable",
-              "author": "@efectn",
-              "condition": "module_armbianrouter status"
-            },
-            {
-              "id": "GHR001",
-              "description": "GitHub runners for Armbian automation",
-              "short": "GH runners",
-              "module": "module_generic",
-              "command": [
-                "module_armbian_runners install"
-              ],
-              "status": "Stable",
-              "author": "@efectn",
-              "condition": "! module_armbian_runners status"
-            },
-            {
-              "id": "GHR002",
-              "description": "Remove GitHub runners for Armbian automation",
-              "command": [
-                "module_armbian_runners remove"
-              ],
-              "status": "Stable",
-              "author": "@efectn",
-              "condition": "module_armbian_runners status"
-            },
-            {
-              "id": "RSD001",
-              "description": "Rsyncd server",
-              "short": "Rsyncd server",
-              "module": "module_generic",
-              "command": [
-                "module_armbian_rsyncd install"
-              ],
-              "status": "Stable",
-              "author": "@igorpecovnik",
-              "condition": "! module_armbian_rsyncd status"
-            },
-            {
-              "id": "RSD002",
-              "description": "Remove Armbian rsyncd server",
-              "command": [
-                "module_armbian_rsyncd remove"
-              ],
-              "status": "Stable",
-              "author": "@igorpecovnik",
-              "condition": "module_armbian_rsyncd status"
-            }
-          ]
-        },
-        {
-          "id": "Backup",
-          "description": "Backup solutions for your data",
-          "sub": [
-            {
-              "id": "DPL001",
-              "description": "Duplicati install",
-              "short": "Duplicati",
-              "module": "module_duplicati",
-              "about": "This operation will install Duplicati backup software",
-              "command": [
-                "module_duplicati install"
-              ],
-              "status": "Stable",
-              "author": "@igorpecovnik",
-              "condition": "! module_duplicati status"
-            },
-            {
-              "id": "DPL002",
-              "description": "Duplicati remove",
-              "about": "This operation will remove Duplicati backup software",
-              "command": [
-                "module_duplicati remove"
-              ],
-              "status": "Stable",
-              "author": "@igorpecovnik",
-              "condition": "module_duplicati status"
-            },
-            {
-              "id": "DPL003",
-              "description": "Duplicati purge with data folder",
-              "about": "This operation will purge Duplicati data and remove the software",
-              "command": [
-                "module_duplicati purge"
-              ],
-              "status": "Stable",
-              "author": "@igorpecovnik",
-              "condition": "module_duplicati status"
-            }
-          ]
-        },
-        {
-          "id": "Benchy",
-          "description": "System benchmaking and diagnostics",
-          "command": [
-            "see_monitoring"
-          ],
-          "status": "Disabled",
-          "author": "@armbian",
-          "condition": "[ -f /usr/bin/armbianmonitor ]"
-        },
-        {
-          "id": "Containers",
-          "description": "Docker containerization and KVM virtual machines",
-          "sub": [
-            {
-              "id": "CON001",
-              "description": "Docker minimal",
-              "short": "Docker",
-              "module": "module_docker",
-              "about": "This operation will install Docker Minimal.",
-              "command": [
-                "module_docker install minimal"
-              ],
-              "status": "Stable",
-              "author": "@schwar3kat",
-              "condition": "! module_docker status docker-ce"
-            },
-            {
-              "id": "CON002",
-              "description": "Docker engine",
-              "about": "This operation will install Docker Engine.",
-              "command": [
-                "module_docker install engine"
-              ],
-              "status": "Stable",
-              "author": "@schwar3kat",
-              "condition": "! module_docker status docker-compose-plugin"
-            },
-            {
-              "id": "CON003",
-              "description": "Docker remove",
-              "about": "This operation will purge Docker.",
-              "command": [
-                "module_docker remove"
-              ],
-              "status": "Stable",
-              "author": "@schwar3kat",
-              "condition": "module_docker status docker-ce"
-            },
-            {
-              "id": "CON004",
-              "description": "Docker purge with all images, containers, and volumes",
-              "about": "This operation will delete all Docker images, containers, and volumes.",
-              "command": [
-                "module_docker purge"
-              ],
-              "status": "Stable",
-              "author": "@schwar3kat",
-              "condition": "module_docker status docker-ce"
-            },
-            {
-              "id": "POR001",
-              "description": "Portainer container management platform",
-              "short": "Portainer",
-              "module": "module_portainer",
-              "prompt": "This operation will install Portainer container management platform.",
-              "command": [
-                "module_portainer install"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "! module_portainer status"
-            },
-            {
-              "id": "POR002",
-              "description": "Portainer remove",
-              "prompt": "This operation will remove Portainer container management platform.",
-              "command": [
-                "module_portainer remove"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_portainer status"
-            },
-            {
-              "id": "POR003",
-              "description": "Portainer purge with with data folder",
-              "prompt": "This operation will remove Portainer container management platform.",
-              "command": [
-                "module_portainer remove"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_portainer status"
-            }
-          ]
-        },
-        {
-          "id": "DNS",
-          "description": "Network-wide ad blockers servers",
-          "sub": [
-            {
-              "id": "ADG001",
-              "description": "AdGuardHome DNS sinkhole",
-              "short": "AdGuardHome",
-              "module": "module_adguardhome",
-              "command": [
-                "module_adguardhome install"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "! module_adguardhome status"
-            },
-            {
-              "id": "ADG002",
-              "description": "AdGuardHome remove",
-              "command": [
-                "module_adguardhome remove"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_adguardhome status"
-            },
-            {
-              "id": "ADG003",
-              "description": "AdGuardHome purge with data folder",
-              "command": [
-                "module_adguardhome remove"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_adguardhome status"
-            },
-            {
-              "id": "PIH001",
-              "description": "Pi-hole DNS ad blocker",
-              "short": "Pi-hole",
-              "module": "module_pi_hole",
-              "command": [
-                "module_pi_hole install"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "! module_pi_hole status"
-            },
-            {
-              "id": "PIH002",
-              "description": "Pi-hole change web admin password",
-              "command": [
-                "module_pi_hole password"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_pi_hole status"
-            },
-            {
-              "id": "PIH003",
-              "description": "Pi-hole remove",
-              "command": [
-                "module_pi_hole remove"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_pi_hole status"
-            },
-            {
-              "id": "PIH004",
-              "description": "Pi-hole purge with data folder",
-              "command": [
-                "module_pi_hole remove"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_pi_hole status"
-            },
-            {
-              "id": "UNB001",
-              "description": "Unbound caching DNS resolver",
-              "short": "Unbound",
-              "module": "module_unbound",
-              "command": [
-                "module_unbound install"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "! module_unbound status"
-            },
-            {
-              "id": "UNB002",
-              "description": "Unbound remove",
-              "command": [
-                "module_unbound remove"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_unbound status"
-            },
-            {
-              "id": "UNB003",
-              "description": "Unbound purge with data folder",
-              "command": [
-                "module_unbound remove"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_unbound status"
-            }
-          ]
-        },
-        {
-          "id": "Database",
-          "description": "SQL database servers and web interface managers",
-          "sub": [
-            {
-              "id": "DAT001",
-              "description": "Mariadb SQL database server",
-              "short": "Mariadb",
-              "module": "module_mariadb",
-              "command": [
-                "module_mariadb install"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "! module_mariadb status"
-            },
-            {
-              "id": "DAT002",
-              "description": "Mariadb remove",
-              "command": [
-                "module_mariadb remove"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_mariadb status"
-            },
-            {
-              "id": "DAT003",
-              "description": "Mariadb purge with data folder",
-              "command": [
-                "module_mariadb purge"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_mariadb status"
-            },
-            {
-              "id": "MYA001",
-              "description": "phpMyAdmin web interface manager",
-              "short": "phpMyAdmin",
-              "module": "module_phpmyadmin",
-              "command": [
-                "module_phpmyadmin install"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "! module_phpmyadmin status"
-            },
-            {
-              "id": "MYA002",
-              "description": "phpMyAdmin remove",
-              "command": [
-                "module_phpmyadmin remove"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_phpmyadmin status"
-            },
-            {
-              "id": "MYA003",
-              "description": "phpMyAdmin purge with data folder",
-              "command": [
-                "module_phpmyadmin purge"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_phpmyadmin status"
-            },
-            {
-              "id": "PGSQL1",
-              "description": "PostgreSQL install",
-              "short": "PostgreSQL",
-              "module": "module_postgres",
-              "about": "This operation will install PostgreSQL, an advanced relational database server",
-              "command": [
-                "module_postgres install"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "! module_postgres status"
-            },
-            {
-              "id": "PGSQL2",
-              "description": "PostgreSQL remove",
-              "about": "This operation will remove the PostgreSQL container",
-              "command": [
-                "module_postgres remove"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_postgres status"
-            },
-            {
-              "id": "PGSQL3",
-              "description": "PostgreSQL purge with data folder",
-              "about": "This operation will purge PostgreSQL data and remove the container",
-              "command": [
-                "module_postgres purge"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_postgres status"
-            },
-            {
-              "id": "REDIS1",
-              "description": "Redis install",
-              "short": "Redis",
-              "module": "module_redis",
-              "about": "This operation will install Redis, a powerful in-memory key-value database",
-              "command": [
-                "module_redis install"
-              ],
-              "status": "Stable",
-              "author": "@igorpecovnik",
-              "condition": "! module_redis status"
-            },
-            {
-              "id": "REDIS2",
-              "description": "Redis remove",
-              "about": "This operation will remove Redis container",
-              "command": [
-                "module_redis remove"
-              ],
-              "status": "Stable",
-              "author": "@igorpecovnik",
-              "condition": "module_redis status"
-            },
-            {
-              "id": "REDIS3",
-              "description": "Redis purge with data folder",
-              "about": "This operation will purge Redis data and remove the container",
-              "command": [
-                "module_redis purge"
-              ],
-              "status": "Stable",
-              "author": "@igorpecovnik",
-              "condition": "module_redis status"
-            }
-          ]
-        },
-        {
-          "id": "Desktops",
-          "description": "Desktop Environments",
-          "status": "Disabled",
-          "sub": [
-            {
-              "id": "CINMDE",
-              "description": "Cinnamon desktop",
-              "status": "Disabled",
-              "sub": [
+            "id": "Software",
+            "description": "Run/Install 3rd party applications",
+            "sub": [
                 {
-                  "id": "CINM01",
-                  "description": "Cinnamon desktop Install",
-                  "command": [
-                    "manage_desktops 'cinnamon' 'install'"
-                  ],
-                  "status": "Stable",
-                  "author": "@igorpecovnik",
-                  "condition": "[ ! -f /usr/share/xsessions/cinnamon.desktop ] && [ ! -f /usr/share/xsessions/cinnamon2d.desktop ]"
+                    "id": "Armbian",
+                    "description": "Armbian infrastructure services",
+                    "sub": [
+                        {
+                            "id": "ART001",
+                            "description": "Router for repository mirror automation",
+                            "short": "CDN router",
+                            "module": "module_generic",
+                            "command": [
+                                "module_armbianrouter install"
+                            ],
+                            "status": "Stable",
+                            "author": "@efectn",
+                            "condition": "! module_armbianrouter status"
+                        },
+                        {
+                            "id": "ART002",
+                            "description": "Remove CDN router",
+                            "command": [
+                                "module_armbianrouter remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@efectn",
+                            "condition": "module_armbianrouter status"
+                        },
+                        {
+                            "id": "GHR001",
+                            "description": "GitHub runners for Armbian automation",
+                            "short": "GH runners",
+                            "module": "module_generic",
+                            "command": [
+                                "module_armbian_runners install"
+                            ],
+                            "status": "Stable",
+                            "author": "@efectn",
+                            "condition": "! module_armbian_runners status"
+                        },
+                        {
+                            "id": "GHR002",
+                            "description": "Remove GitHub runners for Armbian automation",
+                            "command": [
+                                "module_armbian_runners remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@efectn",
+                            "condition": "module_armbian_runners status"
+                        },
+                        {
+                            "id": "RSD001",
+                            "description": "Rsyncd server",
+                            "short": "Rsyncd server",
+                            "module": "module_generic",
+                            "command": [
+                                "module_armbian_rsyncd install"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "! module_armbian_rsyncd status"
+                        },
+                        {
+                            "id": "RSD002",
+                            "description": "Remove Armbian rsyncd server",
+                            "command": [
+                                "module_armbian_rsyncd remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_armbian_rsyncd status"
+                        }
+                    ]
                 },
                 {
-                  "id": "CINM02",
-                  "description": "Cinnamon desktop uninstall",
-                  "command": [
-                    "manage_desktops 'cinnamon' 'uninstall'"
-                  ],
-                  "status": "Stable",
-                  "author": "@igorpecovnik",
-                  "condition": "[ -f /usr/share/xsessions/cinnamon.desktop ] || [ -f /usr/share/xsessions/cinnamon2d.desktop ]"
+                    "id": "Backup",
+                    "description": "Backup solutions for your data",
+                    "sub": [
+                        {
+                            "id": "DPL001",
+                            "description": "Duplicati install",
+                            "short": "Duplicati",
+                            "module": "module_duplicati",
+                            "about": "This operation will install Duplicati backup software",
+                            "command": [
+                                "module_duplicati install"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "! module_duplicati status"
+                        },
+                        {
+                            "id": "DPL002",
+                            "description": "Duplicati remove",
+                            "about": "This operation will remove Duplicati backup software",
+                            "command": [
+                                "module_duplicati remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_duplicati status"
+                        },
+                        {
+                            "id": "DPL003",
+                            "description": "Duplicati purge with data folder",
+                            "about": "This operation will purge Duplicati data and remove the software",
+                            "command": [
+                                "module_duplicati purge"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_duplicati status"
+                        }
+                    ]
                 },
                 {
-                  "id": "CINM03",
-                  "description": "Enable autologin",
-                  "command": [
-                    "manage_desktops 'cinnamon' 'auto'"
-                  ],
-                  "status": "Stable",
-                  "author": "@igorpecovnik",
-                  "condition": "[ -f /usr/share/xsessions/cinnamon.desktop ] && [ ! -f /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf ]"
+                    "id": "Benchy",
+                    "description": "System benchmaking and diagnostics",
+                    "command": [
+                        "see_monitoring"
+                    ],
+                    "status": "Disabled",
+                    "author": "@armbian",
+                    "condition": "[ -f /usr/bin/armbianmonitor ]"
                 },
                 {
-                  "id": "CINM04",
-                  "description": "Disable autologin",
-                  "command": [
-                    "manage_desktops 'cinnamon' 'manual'"
-                  ],
-                  "status": "Stable",
-                  "author": "@igorpecovnik",
-                  "condition": "[ -f /usr/share/xsessions/cinnamon.desktop ] && [ -f /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf ]"
+                    "id": "Containers",
+                    "description": "Docker containerization and KVM virtual machines",
+                    "sub": [
+                        {
+                            "id": "CON001",
+                            "description": "Docker minimal",
+                            "short": "Docker",
+                            "module": "module_docker",
+                            "about": "This operation will install Docker Minimal.",
+                            "command": [
+                                "module_docker install minimal"
+                            ],
+                            "status": "Stable",
+                            "author": "@schwar3kat",
+                            "condition": "! module_docker status docker-ce"
+                        },
+                        {
+                            "id": "CON002",
+                            "description": "Docker engine",
+                            "about": "This operation will install Docker Engine.",
+                            "command": [
+                                "module_docker install engine"
+                            ],
+                            "status": "Stable",
+                            "author": "@schwar3kat",
+                            "condition": "! module_docker status docker-compose-plugin"
+                        },
+                        {
+                            "id": "CON003",
+                            "description": "Docker remove",
+                            "about": "This operation will purge Docker.",
+                            "command": [
+                                "module_docker remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@schwar3kat",
+                            "condition": "module_docker status docker-ce"
+                        },
+                        {
+                            "id": "CON004",
+                            "description": "Docker purge with all images, containers, and volumes",
+                            "about": "This operation will delete all Docker images, containers, and volumes.",
+                            "command": [
+                                "module_docker purge"
+                            ],
+                            "status": "Stable",
+                            "author": "@schwar3kat",
+                            "condition": "module_docker status docker-ce"
+                        },
+                        {
+                            "id": "POR001",
+                            "description": "Portainer container management platform",
+                            "short": "Portainer",
+                            "module": "module_portainer",
+                            "prompt": "This operation will install Portainer container management platform.",
+                            "command": [
+                                "module_portainer install"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "! module_portainer status"
+                        },
+                        {
+                            "id": "POR002",
+                            "description": "Portainer remove",
+                            "prompt": "This operation will remove Portainer container management platform.",
+                            "command": [
+                                "module_portainer remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_portainer status"
+                        },
+                        {
+                            "id": "POR003",
+                            "description": "Portainer purge with with data folder",
+                            "prompt": "This operation will remove Portainer container management platform.",
+                            "command": [
+                                "module_portainer remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_portainer status"
+                        }
+                    ]
+                },
+                {
+                    "id": "DNS",
+                    "description": "Network-wide ad blockers servers",
+                    "sub": [
+                        {
+                            "id": "ADG001",
+                            "description": "AdGuardHome DNS sinkhole",
+                            "short": "AdGuardHome",
+                            "module": "module_adguardhome",
+                            "command": [
+                                "module_adguardhome install"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "! module_adguardhome status"
+                        },
+                        {
+                            "id": "ADG002",
+                            "description": "AdGuardHome remove",
+                            "command": [
+                                "module_adguardhome remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_adguardhome status"
+                        },
+                        {
+                            "id": "ADG003",
+                            "description": "AdGuardHome purge with data folder",
+                            "command": [
+                                "module_adguardhome remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_adguardhome status"
+                        },
+                        {
+                            "id": "PIH001",
+                            "description": "Pi-hole DNS ad blocker",
+                            "short": "Pi-hole",
+                            "module": "module_pi_hole",
+                            "command": [
+                                "module_pi_hole install"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "! module_pi_hole status"
+                        },
+                        {
+                            "id": "PIH002",
+                            "description": "Pi-hole change web admin password",
+                            "command": [
+                                "module_pi_hole password"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_pi_hole status"
+                        },
+                        {
+                            "id": "PIH003",
+                            "description": "Pi-hole remove",
+                            "command": [
+                                "module_pi_hole remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_pi_hole status"
+                        },
+                        {
+                            "id": "PIH004",
+                            "description": "Pi-hole purge with data folder",
+                            "command": [
+                                "module_pi_hole remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_pi_hole status"
+                        },
+                        {
+                            "id": "UNB001",
+                            "description": "Unbound caching DNS resolver",
+                            "short": "Unbound",
+                            "module": "module_unbound",
+                            "command": [
+                                "module_unbound install"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "! module_unbound status"
+                        },
+                        {
+                            "id": "UNB002",
+                            "description": "Unbound remove",
+                            "command": [
+                                "module_unbound remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_unbound status"
+                        },
+                        {
+                            "id": "UNB003",
+                            "description": "Unbound purge with data folder",
+                            "command": [
+                                "module_unbound remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_unbound status"
+                        }
+                    ]
+                },
+                {
+                    "id": "Database",
+                    "description": "SQL database servers and web interface managers",
+                    "sub": [
+                        {
+                            "id": "DAT001",
+                            "description": "Mariadb SQL database server",
+                            "short": "Mariadb",
+                            "module": "module_mariadb",
+                            "command": [
+                                "module_mariadb install"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "! module_mariadb status"
+                        },
+                        {
+                            "id": "DAT002",
+                            "description": "Mariadb remove",
+                            "command": [
+                                "module_mariadb remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_mariadb status"
+                        },
+                        {
+                            "id": "DAT003",
+                            "description": "Mariadb purge with data folder",
+                            "command": [
+                                "module_mariadb purge"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_mariadb status"
+                        },
+                        {
+                            "id": "MYA001",
+                            "description": "phpMyAdmin web interface manager",
+                            "short": "phpMyAdmin",
+                            "module": "module_phpmyadmin",
+                            "command": [
+                                "module_phpmyadmin install"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "! module_phpmyadmin status"
+                        },
+                        {
+                            "id": "MYA002",
+                            "description": "phpMyAdmin remove",
+                            "command": [
+                                "module_phpmyadmin remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_phpmyadmin status"
+                        },
+                        {
+                            "id": "MYA003",
+                            "description": "phpMyAdmin purge with data folder",
+                            "command": [
+                                "module_phpmyadmin purge"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_phpmyadmin status"
+                        },
+                        {
+                            "id": "PGSQL1",
+                            "description": "PostgreSQL install",
+                            "short": "PostgreSQL",
+                            "module": "module_postgres",
+                            "about": "This operation will install PostgreSQL, an advanced relational database server",
+                            "command": [
+                                "module_postgres install"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "! module_postgres status"
+                        },
+                        {
+                            "id": "PGSQL2",
+                            "description": "PostgreSQL remove",
+                            "about": "This operation will remove the PostgreSQL container",
+                            "command": [
+                                "module_postgres remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_postgres status"
+                        },
+                        {
+                            "id": "PGSQL3",
+                            "description": "PostgreSQL purge with data folder",
+                            "about": "This operation will purge PostgreSQL data and remove the container",
+                            "command": [
+                                "module_postgres purge"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_postgres status"
+                        },
+                        {
+                            "id": "REDIS1",
+                            "description": "Redis install",
+                            "short": "Redis",
+                            "module": "module_redis",
+                            "about": "This operation will install Redis, a powerful in-memory key-value database",
+                            "command": [
+                                "module_redis install"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "! module_redis status"
+                        },
+                        {
+                            "id": "REDIS2",
+                            "description": "Redis remove",
+                            "about": "This operation will remove Redis container",
+                            "command": [
+                                "module_redis remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_redis status"
+                        },
+                        {
+                            "id": "REDIS3",
+                            "description": "Redis purge with data folder",
+                            "about": "This operation will purge Redis data and remove the container",
+                            "command": [
+                                "module_redis purge"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_redis status"
+                        }
+                    ]
+                },
+                {
+                    "id": "Desktops",
+                    "description": "Desktop Environments",
+                    "status": "Disabled",
+                    "sub": [
+                        {
+                            "id": "CINMDE",
+                            "description": "Cinnamon desktop",
+                            "status": "Disabled",
+                            "sub": [
+                                {
+                                    "id": "CINM01",
+                                    "description": "Cinnamon desktop Install",
+                                    "command": [
+                                        "manage_desktops 'cinnamon' 'install'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ ! -f /usr/share/xsessions/cinnamon.desktop ] && [ ! -f /usr/share/xsessions/cinnamon2d.desktop ]"
+                                },
+                                {
+                                    "id": "CINM02",
+                                    "description": "Cinnamon desktop uninstall",
+                                    "command": [
+                                        "manage_desktops 'cinnamon' 'uninstall'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ -f /usr/share/xsessions/cinnamon.desktop ] || [ -f /usr/share/xsessions/cinnamon2d.desktop ]"
+                                },
+                                {
+                                    "id": "CINM03",
+                                    "description": "Enable autologin",
+                                    "command": [
+                                        "manage_desktops 'cinnamon' 'auto'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ -f /usr/share/xsessions/cinnamon.desktop ] && [ ! -f /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf ]"
+                                },
+                                {
+                                    "id": "CINM04",
+                                    "description": "Disable autologin",
+                                    "command": [
+                                        "manage_desktops 'cinnamon' 'manual'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ -f /usr/share/xsessions/cinnamon.desktop ] && [ -f /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf ]"
+                                }
+                            ]
+                        },
+                        {
+                            "id": "GNOMDE",
+                            "description": "Gnome desktop",
+                            "sub": [
+                                {
+                                    "id": "GNME01",
+                                    "description": "Gnome desktop Install",
+                                    "command": [
+                                        "module_desktop 'install' 'de=gnome'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "! module_desktop status de=gnome"
+                                },
+                                {
+                                    "id": "GNME02",
+                                    "description": "Uninstall",
+                                    "command": [
+                                        "module_desktop 'remove' 'de=gnome'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "module_desktop status de=gnome"
+                                },
+                                {
+                                    "id": "GNME03",
+                                    "description": "Enable autologin",
+                                    "command": [
+                                        "module_desktop auto de=gnome"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "module_desktop status de=gnome && ! module_desktop login"
+                                },
+                                {
+                                    "id": "GNME04",
+                                    "description": "Disable autologin",
+                                    "command": [
+                                        "module_desktop manual de=gnome"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "module_desktop status de=gnome && module_desktop login"
+                                }
+                            ]
+                        },
+                        {
+                            "id": "I3WMDE",
+                            "description": "i3-wm desktop",
+                            "status": "Disabled",
+                            "sub": [
+                                {
+                                    "id": "I3WM01",
+                                    "description": "i3 desktop Install",
+                                    "command": [
+                                        "manage_desktops 'i3-wm' 'install'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ ! -f /usr/share/xsessions/i3.desktop ]"
+                                },
+                                {
+                                    "id": "I3WM02",
+                                    "description": "i3 desktop uninstall",
+                                    "command": [
+                                        "manage_desktops 'i3-wm' 'uninstall'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ -f /usr/share/xsessions/i3.desktop ]"
+                                },
+                                {
+                                    "id": "I3WM03",
+                                    "description": "Enable autologin",
+                                    "command": [
+                                        "manage_desktops 'i3-wm' 'auto'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ -f /usr/share/xsessions/i3.desktop ] && [ ! -f /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf ]"
+                                },
+                                {
+                                    "id": "I3WM04",
+                                    "description": "Disable autologin",
+                                    "command": [
+                                        "manage_desktops 'i3-wm' 'manual'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ -f /usr/share/xsessions/i3.desktop ] && [ -f /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf ]"
+                                }
+                            ]
+                        },
+                        {
+                            "id": "KDENEO",
+                            "description": "Kde-neon desktop",
+                            "status": "Disabled",
+                            "sub": [
+                                {
+                                    "id": "KDEN01",
+                                    "description": "Kde-neon desktop Install",
+                                    "command": [
+                                        "manage_desktops 'kde-neon' 'install'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ ! -f /usr/share/xsessions/gnome.desktop ]"
+                                },
+                                {
+                                    "id": "KDEN02",
+                                    "description": "Uninstall",
+                                    "command": [
+                                        "manage_desktops 'kde-neon' 'uninstall'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ -f /usr/share/xsessions/gnome.desktop ]"
+                                },
+                                {
+                                    "id": "KDEN03",
+                                    "description": "Enable autologin",
+                                    "command": [
+                                        "manage_desktops 'kde-neon' 'auto'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ -f /usr/share/xsessions/gnome.desktop ] && [ ! -f /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf ]"
+                                },
+                                {
+                                    "id": "KDEN04",
+                                    "description": "Disable autologin",
+                                    "command": [
+                                        "manage_desktops 'kde-neon' 'manual'"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "[ -f /usr/share/xsessions/gnome.desktop ] && [ -f /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf ]"
+                                }
+                            ]
+                        },
+                        {
+                            "id": "XFCEDE",
+                            "description": "XFCE desktop",
+                            "sub": [
+                                {
+                                    "id": "XFCE01",
+                                    "about": "Install XFCE:\n\nXfce is a lightweight desktop environment for UNIX-like operating systems. It aims to be fast and low on system resources, while still being visually appealing and user friendly.",
+                                    "description": "XFCE desktop Install",
+                                    "command": [
+                                        "module_desktop install de=xfce"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "! module_desktop status de=xfce"
+                                },
+                                {
+                                    "id": "XFCE02",
+                                    "description": "Uninstall",
+                                    "command": [
+                                        "module_desktop remove de=xfce"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "module_desktop status de=xfce"
+                                },
+                                {
+                                    "id": "XFCE03",
+                                    "description": "Enable autologin",
+                                    "command": [
+                                        "module_desktop auto de=xfce"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "module_desktop status de=xfce && ! module_desktop login"
+                                },
+                                {
+                                    "id": "XFCE04",
+                                    "description": "Disable autologin",
+                                    "command": [
+                                        "module_desktop manual de=xfce"
+                                    ],
+                                    "status": "Stable",
+                                    "author": "@igorpecovnik",
+                                    "condition": "module_desktop status de=xfce && module_desktop login"
+                                }
+                            ]
+                        },
+                        {
+                            "id": "Xapian",
+                            "description": "Improve application search speed",
+                            "command": [
+                                "update-apt-xapian-index -u; sleep 3"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "srv_active display-manager"
+                        }
+                    ]
+                },
+                {
+                    "id": "DevTools",
+                    "description": "Applications and tools for development",
+                    "sub": [
+                        {
+                            "id": "GIT001",
+                            "description": "Install tools for cloning and managing repositories (git)",
+                            "short": "Git CLI",
+                            "module": "module_generic",
+                            "command": [
+                                "get_user_continue \"This operation will install git.\n\nDo you wish to continue?\" process_input",
+                                "pkg_install git"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "! pkg_installed git"
+                        },
+                        {
+                            "id": "GIT002",
+                            "description": "Remove tools for cloning and managing repositories (git)",
+                            "command": [
+                                "get_user_continue \"This operation will remove git.\n\nDo you wish to continue?\" process_input",
+                                "pkg_remove git"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "pkg_installed git"
+                        }
+                    ]
+                },
+                {
+                    "id": "Downloaders",
+                    "description": "Download apps for movies, TV shows, music and subtitles",
+                    "sub": [
+                        {
+                            "id": "BAZ001",
+                            "description": "Bazarr automatic subtitles downloader for Sonarr and Radarr",
+                            "short": "Bazarr",
+                            "module": "module_bazarr",
+                            "about": "This operation will install Bazarr subtitles manager for Sonarr and Radarr",
+                            "command": [
+                                "module_bazarr install"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "! module_bazarr status"
+                        },
+                        {
+                            "id": "BAZ002",
+                            "description": "Bazarr remove",
+                            "about": "This operation will remove Bazarr subtitles manager for Sonarr and Radarr",
+                            "command": [
+                                "module_bazarr remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_bazarr status"
+                        },
+                        {
+                            "id": "BAZ003",
+                            "description": "Bazarr purge with data folder",
+                            "about": "This operation will purge Bazarr subtitles manager with data folder",
+                            "command": [
+                                "module_bazarr purge"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_bazarr status"
+                        },
+                        {
+                            "id": "DEL001",
+                            "description": "Deluge BitTorrent client",
+                            "short": "Deluge",
+                            "module": "module_deluge",
+                            "about": "This operation will install BitTorrent client",
+                            "command": [
+                                "module_deluge install"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "! module_deluge status"
+                        },
+                        {
+                            "id": "DEL002",
+                            "description": "Deluge remove",
+                            "about": "This operation will remove Deluge BitTorrent client",
+                            "command": [
+                                "module_deluge remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_deluge status"
+                        },
+                        {
+                            "id": "DEL003",
+                            "description": "Deluge purge with data folder",
+                            "about": "This operation will remove Deluge BitTorrent client data folder",
+                            "command": [
+                                "module_deluge purge"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_deluge status"
+                        },
+                        {
+                            "id": "DOW001",
+                            "description": "qBittorrent BitTorrent client ",
+                            "short": "qBittorrent",
+                            "module": "module_qbittorrent",
+                            "about": "This operation will install qBittorrent BitTorrent client",
+                            "command": [
+                                "module_qbittorrent install"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "! module_qbittorrent status"
+                        },
+                        {
+                            "id": "DOW002",
+                            "description": "qBittorrent remove",
+                            "about": "This operation will remove qBittorrent BitTorrent client",
+                            "command": [
+                                "module_qbittorrent remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_qbittorrent status"
+                        },
+                        {
+                            "id": "DOW003",
+                            "description": "qBittorrent purge with data folder",
+                            "about": "This operation will remove qBittorrent BitTorrent data folder",
+                            "command": [
+                                "module_qbittorrent purge"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_qbittorrent status"
+                        },
+                        {
+                            "id": "DOW025",
+                            "description": "Prowlarr index manager and proxy for PVR",
+                            "short": "Prowlarr",
+                            "module": "module_prowlarr",
+                            "about": "This operation will install Prowlarr",
+                            "command": [
+                                "module_prowlarr install"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "! module_prowlarr status"
+                        },
+                        {
+                            "id": "DOW026",
+                            "description": "Prowlarr remove",
+                            "about": "This operation will remove Prowlarr",
+                            "command": [
+                                "module_prowlarr remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_prowlarr status"
+                        },
+                        {
+                            "id": "DOW027",
+                            "description": "Prowlarr purge with data folder",
+                            "about": "This operation will purge Prowlarr with data folder",
+                            "command": [
+                                "module_prowlarr purge"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_prowlarr status"
+                        },
+                        {
+                            "id": "JEL001",
+                            "description": "Jellyseerr Jellyfin/Emby/Plex integration install",
+                            "short": "Jellyseerr",
+                            "module": "module_jellyseerr",
+                            "about": "This operation will install Jellyseerr",
+                            "command": [
+                                "module_jellyseerr install"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "! module_jellyseerr status"
+                        },
+                        {
+                            "id": "JEL002",
+                            "description": "Jellyseerr remove",
+                            "about": "This operation will remove Jellyseerr",
+                            "command": [
+                                "module_jellyseerr remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_jellyseerr status"
+                        },
+                        {
+                            "id": "JEL003",
+                            "description": "Jellyseerr purge with data folder",
+                            "about": "This operation will purge Jellyseerr with data folder",
+                            "command": [
+                                "module_jellyseerr purge"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_jellyseerr status ]]"
+                        },
+                        {
+                            "id": "LID001",
+                            "description": "Lidarr automatic music downloader",
+                            "short": "Lidarr",
+                            "module": "module_lidarr",
+                            "about": "This operation will install Lidarr music collection manager for Usenet and BitTorrent users",
+                            "command": [
+                                "module_lidarr install"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "! module_lidarr status"
+                        },
+                        {
+                            "id": "LID002",
+                            "description": "Lidarr remove",
+                            "about": "This operation will remove Lidarr",
+                            "command": [
+                                "module_lidarr remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_lidarr status"
+                        },
+                        {
+                            "id": "LID003",
+                            "description": "Lidarr purge with data folder",
+                            "about": "This operation will purge Lidarr with data folder",
+                            "command": [
+                                "module_lidarr purge"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_lidarr status"
+                        },
+                        {
+                            "id": "MDS001",
+                            "description": "Medusa automatic downloader for TV shows",
+                            "short": "Medusa",
+                            "module": "module_medusa",
+                            "about": "This operation will install Medusa TV shows downloader",
+                            "command": [
+                                "module_medusa install"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "! module_medusa status"
+                        },
+                        {
+                            "id": "MDS002",
+                            "description": "Medusa TV shows downloader remove",
+                            "about": "This operation will remove Medusa TV shows downloader",
+                            "command": [
+                                "module_medusa remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_medusa status"
+                        },
+                        {
+                            "id": "MDS003",
+                            "description": "Medusa TV shows downloader purge",
+                            "about": "This operation will purge Medusa TV shows data folder",
+                            "command": [
+                                "module_medusa purge"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_medusa status"
+                        },
+                        {
+                            "id": "RAD001",
+                            "description": "Radarr automatic downloader for movies",
+                            "short": "Radarr",
+                            "module": "module_radarr",
+                            "about": "This operation will install Radarr movie collection manager",
+                            "command": [
+                                "module_radarr install"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "! module_radarr status"
+                        },
+                        {
+                            "id": "RAD002",
+                            "description": "Radarr remove",
+                            "about": "This operation will remove Radarr movie collection manager",
+                            "command": [
+                                "module_radarr remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_radarr status"
+                        },
+                        {
+                            "id": "RAD003",
+                            "description": "Radarr purge with data folder",
+                            "about": "This operation will purge Radarr movie collection manager data folder",
+                            "command": [
+                                "module_radarr purge"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_radarr status"
+                        },
+                        {
+                            "id": "RDR001",
+                            "description": "Readarr automatic downloader for Ebooks",
+                            "short": "Readarr",
+                            "module": "module_readarr",
+                            "about": "This operation will install Readarr",
+                            "command": [
+                                "module_readarr install"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "! module_readarr status"
+                        },
+                        {
+                            "id": "RDR002",
+                            "description": "Readarr remove",
+                            "about": "This operation will remove Readarr",
+                            "command": [
+                                "module_readarr remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_readarr status"
+                        },
+                        {
+                            "id": "RDR003",
+                            "description": "Readarr purge with data folder",
+                            "about": "This operation will purge Readarr with data folder",
+                            "command": [
+                                "module_readarr purge"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_readarr status"
+                        },
+                        {
+                            "id": "SABN01",
+                            "description": "SABnzbd newsgroup downloader",
+                            "short": "SABnzbd",
+                            "module": "module_sabnzbd",
+                            "about": "This operation will install SABnzbd newsgroup downloader",
+                            "command": [
+                                "module_sabnzbd install"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "! module_sabnzbd status"
+                        },
+                        {
+                            "id": "SABN02",
+                            "description": "SABnzbd remove",
+                            "about": "This operation will remove SABnzbd newsgroup downloader",
+                            "command": [
+                                "module_sabnzbd remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_sabnzbd status"
+                        },
+                        {
+                            "id": "SABN03",
+                            "description": "SABnzbd purge with data folder",
+                            "about": "This operation will purge SABnzbd newsgroup data folder",
+                            "command": [
+                                "module_sabnzbd purge"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_sabnzbd status"
+                        },
+                        {
+                            "id": "SON001",
+                            "description": "Sonarr automatic downloader for TV shows",
+                            "short": "Sonarr",
+                            "module": "module_sonarr",
+                            "about": "This operation will install Sonarr PVR for Usenet and BitTorrent",
+                            "command": [
+                                "module_sonarr install"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "! module_sonarr status"
+                        },
+                        {
+                            "id": "SON002",
+                            "description": "Sonarr remove",
+                            "about": "This operation will remove Sonarr PVR for Usenet and BitTorrent",
+                            "command": [
+                                "module_sonarr remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_sonarr status"
+                        },
+                        {
+                            "id": "SON003",
+                            "description": "Sonarr purge with data folder",
+                            "about": "This operation will purge Sonarr PVR for Usenet and BitTorrent purge data folder",
+                            "command": [
+                                "module_sonarr purge"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_sonarr status"
+                        },
+                        {
+                            "id": "TRA001",
+                            "description": "Transmission BitTorrent client",
+                            "short": "Transmission",
+                            "module": "module_transmission",
+                            "about": "This operation will install Transmission BitTorrent client",
+                            "command": [
+                                "module_transmission install"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "! module_transmission status"
+                        },
+                        {
+                            "id": "TRA002",
+                            "description": "Transmission remove",
+                            "about": "This operation will remove Transmission BitTorrent client",
+                            "command": [
+                                "module_transmission remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_transmission status"
+                        },
+                        {
+                            "id": "TRA003",
+                            "description": "Transmission purge with data folder",
+                            "about": "This operation will remove Transmission BitTorrent client data folder",
+                            "command": [
+                                "module_transmission purge"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_transmission status"
+                        }
+                    ]
+                },
+                {
+                    "id": "Finance",
+                    "description": "Manage your finances",
+                    "sub": [
+                        {
+                            "id": "ABU001",
+                            "description": "Do your finances with Actual Budget",
+                            "short": "Actual Budget",
+                            "module": "module_actualbudget",
+                            "command": [
+                                "module_actualbudget install"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "! module_actualbudget status"
+                        },
+                        {
+                            "id": "ABU002",
+                            "description": "Actual Budget remove",
+                            "command": [
+                                "module_actualbudget remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_actualbudget status"
+                        },
+                        {
+                            "id": "ABU003",
+                            "description": "Actual Budget purge with data folder",
+                            "command": [
+                                "module_actualbudget purge"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_actualbudget status"
+                        }
+                    ]
+                },
+                {
+                    "id": "HomeAutomation",
+                    "description": "Home Automation for control home appliances",
+                    "sub": [
+                        {
+                            "id": "DOM001",
+                            "description": "Domoticz open source home automation",
+                            "short": "Domoticz",
+                            "module": "module_domoticz",
+                            "about": "This operation will install Domoticz.",
+                            "command": [
+                                "module_domoticz install"
+                            ],
+                            "status": "Preview",
+                            "author": "@igorpecovnik",
+                            "condition": "! module_domoticz status"
+                        },
+                        {
+                            "id": "DOM002",
+                            "description": "Domoticz remove",
+                            "about": "This operation will remove Domoticz.",
+                            "command": [
+                                "module_domoticz remove"
+                            ],
+                            "status": "Preview",
+                            "author": "@igorpecovnik",
+                            "condition": "module_domoticz status"
+                        },
+                        {
+                            "id": "DOM003",
+                            "description": "Domoticz purge with data folder",
+                            "about": "This operation will purge Domoticz.",
+                            "command": [
+                                "module_domoticz purge"
+                            ],
+                            "status": "Preview",
+                            "author": "@igorpecovnik",
+                            "condition": "module_domoticz status"
+                        },
+                        {
+                            "id": "EVCC01",
+                            "description": "EVCC - solar charging automation",
+                            "short": "EVCC",
+                            "module": "module_evcc",
+                            "about": "This operation will install solar charging automation.",
+                            "command": [
+                                "module_evcc install"
+                            ],
+                            "status": "Preview",
+                            "author": "@igorpecovnik",
+                            "condition": "! module_evcc status"
+                        },
+                        {
+                            "id": "EVCC02",
+                            "description": "EVCC - solar charging automation remove",
+                            "about": "This operation will remove solar charging automation.",
+                            "command": [
+                                "module_evcc remove"
+                            ],
+                            "status": "Preview",
+                            "author": "@igorpecovnik",
+                            "condition": "module_evcc status"
+                        },
+                        {
+                            "id": "EVCC03",
+                            "description": "EVCC purge with data folder",
+                            "about": "This operation will purge solar charging automation with data folder.",
+                            "command": [
+                                "module_evcc purge"
+                            ],
+                            "status": "Preview",
+                            "author": "@igorpecovnik",
+                            "condition": "module_evcc status"
+                        },
+                        {
+                            "id": "HAB001",
+                            "description": "openHAB empowering the smart home",
+                            "short": "openHAB",
+                            "module": "module_openhab",
+                            "about": "This operation will install openHAB.",
+                            "command": [
+                                "module_openhab install"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "! module_openhab status"
+                        },
+                        {
+                            "id": "HAB002",
+                            "description": "openHAB remove",
+                            "about": "This operation will purge openHAB.",
+                            "command": [
+                                "module_openhab remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_openhab status"
+                        },
+                        {
+                            "id": "HAB003",
+                            "description": "openHAB purge with data folder",
+                            "about": "This operation will purge openHAB.",
+                            "command": [
+                                "module_openhab purge"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_openhab status"
+                        },
+                        {
+                            "id": "HAS001",
+                            "description": "Home Assistant open source home automation",
+                            "short": "Home Assistant",
+                            "module": "module_haos",
+                            "about": "This operation will install Home Assistant.",
+                            "command": [
+                                "module_haos install"
+                            ],
+                            "status": "Preview",
+                            "author": "@igorpecovnik",
+                            "condition": "! module_haos status && grep -q bookworm /etc/os-release"
+                        },
+                        {
+                            "id": "HAS002",
+                            "description": "Home Assistant remove",
+                            "about": "This operation will remove Home Assistant.",
+                            "command": [
+                                "module_haos remove"
+                            ],
+                            "status": "Preview",
+                            "author": "@igorpecovnik",
+                            "condition": "module_haos status"
+                        },
+                        {
+                            "id": "HAS003",
+                            "description": "Home Assistant purge with data folder",
+                            "about": "This operation will purge Home Assistant.",
+                            "command": [
+                                "module_haos purge"
+                            ],
+                            "status": "Preview",
+                            "author": "@igorpecovnik",
+                            "condition": "module_haos status"
+                        }
+                    ]
+                },
+                {
+                    "id": "Management",
+                    "description": "Remote File & Management tools",
+                    "sub": [
+                        {
+                            "id": "CPT001",
+                            "description": "Cockpit web-based management tool",
+                            "short": "Cockpit",
+                            "module": "module_generic",
+                            "command": [
+                                "see_menu module_cockpit"
+                            ],
+                            "status": "Stable",
+                            "author": "@Tearran",
+                            "condition": ""
+                        },
+                        {
+                            "id": "HPG001",
+                            "description": "Install Homepage startpage / application dashboard",
+                            "short": "Homepage",
+                            "module": "module_homepage",
+                            "command": [
+                                "module_homepage install"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "! module_homepage status"
+                        },
+                        {
+                            "id": "HPG002",
+                            "description": "Remove Homepage",
+                            "command": [
+                                "module_homepage remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_homepage status"
+                        },
+                        {
+                            "id": "HPG003",
+                            "description": "Purge Homepage with data folder",
+                            "command": [
+                                "module_homepage purge"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_homepage status"
+                        },
+                        {
+                            "id": "NBOX01",
+                            "description": "NetBox infrastructure resource modeling install",
+                            "short": "NetBox",
+                            "module": "module_netbox",
+                            "about": "This operation will install NetBox, an infrastructure resource modeling (IPAM/DCIM) tool",
+                            "command": [
+                                "module_netbox install"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "! module_netbox status"
+                        },
+                        {
+                            "id": "NBOX02",
+                            "description": "NetBox remove",
+                            "about": "This operation will remove NetBox container",
+                            "command": [
+                                "module_netbox remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_netbox status"
+                        },
+                        {
+                            "id": "NBOX03",
+                            "description": "NetBox purge with data folder",
+                            "about": "This operation will purge NetBox data and remove the container",
+                            "command": [
+                                "module_netbox purge"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_netbox status"
+                        },
+                        {
+                            "id": "SMB001",
+                            "description": "SAMBA Remote File share",
+                            "short": "Samba",
+                            "module": "module_generic",
+                            "command": [
+                                "see_menu module_samba"
+                            ],
+                            "status": "Stable",
+                            "author": "@Tearran",
+                            "condition": ""
+                        },
+                        {
+                            "id": "WBM001",
+                            "description": "Webmin web-based management tool",
+                            "short": "Webmin",
+                            "module": "module_generic",
+                            "command": [
+                                "see_menu module_webmin"
+                            ],
+                            "status": "Stable",
+                            "author": "@Tearran",
+                            "condition": ""
+                        }
+                    ]
+                },
+                {
+                    "id": "Media",
+                    "description": "Media servers, organizers and editors",
+                    "sub": [
+                        {
+                            "id": "EMB001",
+                            "description": "Emby organizes video, music, live TV, and photos",
+                            "short": "Emby",
+                            "module": "module_embyserver",
+                            "about": "This operation will install Emby server.",
+                            "command": [
+                                "module_embyserver install"
+                            ],
+                            "status": "Stable",
+                            "author": "@schwar3kat",
+                            "condition": "! module_embyserver status"
+                        },
+                        {
+                            "id": "EMB002",
+                            "description": "Emby server remove",
+                            "about": "This operation will remove Emby server",
+                            "command": [
+                                "module_embyserver remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@schwar3kat",
+                            "condition": "module_embyserver status"
+                        },
+                        {
+                            "id": "EMB003",
+                            "description": "Emby server purge with data folder",
+                            "command": [
+                                "module_embyserver purge"
+                            ],
+                            "status": "Stable",
+                            "author": "@schwar3kat",
+                            "condition": "module_embyserver status"
+                        },
+                        {
+                            "id": "FIL001",
+                            "description": "Filebrowser provides a web-based file manager accessible via a browser",
+                            "short": "Filebrowser",
+                            "module": "module_filebrowser",
+                            "about": "This operation will install Filebrowser container.",
+                            "command": [
+                                "module_filebrowser install"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "! module_filebrowser status"
+                        },
+                        {
+                            "id": "FIL002",
+                            "description": "Filebrowser container remove",
+                            "about": "This operation will remove Filebrowser container.",
+                            "command": [
+                                "module_filebrowser remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_filebrowser status"
+                        },
+                        {
+                            "id": "FIL003",
+                            "description": "Filebrowser container purge with data folder",
+                            "command": [
+                                "module_filebrowser purge"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_filebrowser status"
+                        },
+                        {
+                            "id": "HPS001",
+                            "description": "Hastebin Paste Server",
+                            "short": "Hastebin",
+                            "module": "module_hastebin",
+                            "command": [
+                                "module_hastebin install"
+                            ],
+                            "status": "Stable",
+                            "author": "@efectn",
+                            "condition": "! module_hastebin status"
+                        },
+                        {
+                            "id": "HPS002",
+                            "description": "Hastebin remove",
+                            "command": [
+                                "module_hastebin remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@efectn",
+                            "condition": "module_hastebin status"
+                        },
+                        {
+                            "id": "HPS003",
+                            "description": "Hastebin purge with data folder",
+                            "command": [
+                                "module_hastebin purge"
+                            ],
+                            "status": "Stable",
+                            "author": "@efectn",
+                            "condition": "module_hastebin status"
+                        },
+                        {
+                            "id": "IMM001",
+                            "description": "Immich - high-performance self-hosted photo and video backup solution",
+                            "short": "Immich",
+                            "module": "module_immich",
+                            "about": "This operation will install Immich server with dependencies (PostgreSQL and Redis).",
+                            "command": [
+                                "module_immich install"
+                            ],
+                            "status": "Preview",
+                            "author": "@igorpecovnik",
+                            "condition": "! module_immich status"
+                        },
+                        {
+                            "id": "IMM002",
+                            "description": "Immich remove",
+                            "about": "This operation will remove the Immich container.",
+                            "command": [
+                                "module_immich remove"
+                            ],
+                            "status": "Preview",
+                            "author": "@igorpecovnik",
+                            "condition": "module_immich status"
+                        },
+                        {
+                            "id": "IMM003",
+                            "description": "Immich purge with data folder",
+                            "about": "This operation will remove Immich container and delete all its data.",
+                            "command": [
+                                "module_immich purge"
+                            ],
+                            "status": "Preview",
+                            "author": "@igorpecovnik",
+                            "condition": "module_immich status"
+                        },
+                        {
+                            "id": "JMS001",
+                            "description": "Jellyfin Media System",
+                            "short": "Jellyfin",
+                            "module": "module_jellyfin",
+                            "command": [
+                                "module_jellyfin install"
+                            ],
+                            "status": "Preview",
+                            "author": "@igorpecovnik",
+                            "condition": "! module_jellyfin status"
+                        },
+                        {
+                            "id": "JMS002",
+                            "description": "Jellyfin remove",
+                            "command": [
+                                "module_jellyfin remove"
+                            ],
+                            "status": "Preview",
+                            "author": "@igorpecovnik",
+                            "condition": "module_jellyfin status"
+                        },
+                        {
+                            "id": "JMS003",
+                            "description": "Jellyfin purge with data folder",
+                            "command": [
+                                "module_jellyfin purge"
+                            ],
+                            "status": "Preview",
+                            "author": "@igorpecovnik",
+                            "condition": "module_jellyfin status"
+                        },
+                        {
+                            "id": "MED001",
+                            "description": "Plex Media server",
+                            "about": "This operation will install Plex Media server.",
+                            "command": [
+                                "module_plexmediaserver install"
+                            ],
+                            "status": "Disabled",
+                            "author": "@schwar3kat",
+                            "condition": "! module_plexmediaserver status"
+                        },
+                        {
+                            "id": "MED002",
+                            "description": "Plex Media server remove",
+                            "about": "This operation will purge Plex Media server.",
+                            "command": [
+                                "module_plexmediaserver remove"
+                            ],
+                            "status": "Disabled",
+                            "author": "@schwar3kat",
+                            "condition": "module_plexmediaserver status"
+                        },
+                        {
+                            "id": "NAV001",
+                            "description": "Navidrome music server and streamer compatible with Subsonic/Airsonic",
+                            "short": "Navidrome",
+                            "module": "module_navidrome",
+                            "command": [
+                                "module_navidrome install"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "! module_navidrome status"
+                        },
+                        {
+                            "id": "NAV002",
+                            "description": "Navidrome remove",
+                            "command": [
+                                "module_navidrome remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_navidrome status"
+                        },
+                        {
+                            "id": "NAV003",
+                            "description": "Navidrome purge with data folder",
+                            "command": [
+                                "module_navidrome purge"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_navidrome status"
+                        },
+                        {
+                            "id": "NCT001",
+                            "description": "Nextcloud content collaboration platform",
+                            "short": "Nextcloud",
+                            "module": "module_nextcloud",
+                            "command": [
+                                "module_nextcloud install"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "! module_nextcloud status"
+                        },
+                        {
+                            "id": "NCT002",
+                            "description": "Nextcloud remove",
+                            "command": [
+                                "module_nextcloud remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_nextcloud status"
+                        },
+                        {
+                            "id": "NCT003",
+                            "description": "Nextcloud purge with data folder",
+                            "command": [
+                                "module_nextcloud purge"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_nextcloud status"
+                        },
+                        {
+                            "id": "OMV001",
+                            "description": "Deploy NAS using OpenMediaVault",
+                            "short": "OMV",
+                            "module": "module_omv",
+                            "about": "This operation will install OpenMediaVault on your system.",
+                            "command": [
+                                "module_omv install"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "! module_omv status"
+                        },
+                        {
+                            "id": "OMV002",
+                            "description": "OpenMediaVault remove",
+                            "about": "This operation will completely remove OpenMediaVault from your system.",
+                            "command": [
+                                "module_omv remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_omv status"
+                        },
+                        {
+                            "id": "OWC001",
+                            "description": "Owncloud share files and folders, easy and secure",
+                            "short": "Owncloud",
+                            "module": "module_owncloud",
+                            "command": [
+                                "module_owncloud install"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "! module_owncloud status"
+                        },
+                        {
+                            "id": "OWC002",
+                            "description": "Owncloud remove",
+                            "command": [
+                                "module_owncloud remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_owncloud status"
+                        },
+                        {
+                            "id": "OWC003",
+                            "description": "Owncloud purge with data folder",
+                            "command": [
+                                "module_owncloud purge"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_owncloud status"
+                        },
+                        {
+                            "id": "STC001",
+                            "description": "Syncthing continuous file synchronization",
+                            "short": "Syncthing",
+                            "module": "module_syncthing",
+                            "command": [
+                                "module_syncthing install"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "! module_syncthing status"
+                        },
+                        {
+                            "id": "STC002",
+                            "description": "Syncthing remove",
+                            "command": [
+                                "module_syncthing remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_syncthing status"
+                        },
+                        {
+                            "id": "STC003",
+                            "description": "Syncthing purge with data folder",
+                            "command": [
+                                "module_syncthing purge"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_syncthing status"
+                        },
+                        {
+                            "id": "STR001",
+                            "description": "Stirling PDF tools for viewing and editing PDF files",
+                            "short": "Stirling",
+                            "module": "module_stirling",
+                            "about": "This operation will install Stirling-PDF tools.",
+                            "command": [
+                                "module_stirling install"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "! module_stirling status"
+                        },
+                        {
+                            "id": "STR002",
+                            "description": "Stirling PDF remove",
+                            "about": "This operation will remove Stirling-PDF tools.",
+                            "command": [
+                                "module_stirling remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_stirling status"
+                        },
+                        {
+                            "id": "STR003",
+                            "description": "Stirling PDF purge with data folder",
+                            "about": "This operation will purge Stirling-PDF tools with data folder.",
+                            "command": [
+                                "module_stirling purge"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_stirling status"
+                        }
+                    ]
+                },
+                {
+                    "id": "Monitoring",
+                    "description": "Real-time monitoring, collecting metrics, up-time status",
+                    "sub": [
+                        {
+                            "id": "GRA001",
+                            "description": "Grafana data analytics",
+                            "short": "Grafana",
+                            "module": "module_grafana",
+                            "prompt": "This operation will install Grafana.",
+                            "command": [
+                                "module_grafana install"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "! module_grafana status"
+                        },
+                        {
+                            "id": "GRA002",
+                            "description": "Grafana remove",
+                            "prompt": "This operation will remove Grafana.",
+                            "command": [
+                                "module_grafana remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_grafana status"
+                        },
+                        {
+                            "id": "GRA003",
+                            "description": "Grafana purge with data folder",
+                            "about": "This operation will purge Grafana with data folder",
+                            "command": [
+                                "module_grafana purge"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_grafana status"
+                        },
+                        {
+                            "id": "NAX001",
+                            "description": "NetAlertX network scanner & notification framework",
+                            "short": "NetAlertX",
+                            "module": "module_netalertx",
+                            "prompt": "This operation will install NetAlertX.",
+                            "command": [
+                                "module_netalertx install"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "! module_netalertx status"
+                        },
+                        {
+                            "id": "NAX002",
+                            "description": "NetAlertX network scanner remove",
+                            "prompt": "This operation will remove NetAlertX.",
+                            "command": [
+                                "module_netalertx remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_netalertx status"
+                        },
+                        {
+                            "id": "NAX003",
+                            "description": "NetAlertX network scanner purge with data folder",
+                            "about": "This operation will purge NetAlertX with data folder",
+                            "command": [
+                                "module_netalertx purge"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_netalertx status"
+                        },
+                        {
+                            "id": "NTD001",
+                            "description": "Netdata - monitoring real-time metrics",
+                            "short": "Netdata",
+                            "module": "module_netdata",
+                            "about": "This operation will install Netdata",
+                            "command": [
+                                "module_netdata install"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "! module_netdata status"
+                        },
+                        {
+                            "id": "NTD002",
+                            "description": "Netdata remove",
+                            "about": "This operation will remove Netdata",
+                            "command": [
+                                "module_netdata remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_netdata status"
+                        },
+                        {
+                            "id": "NTD003",
+                            "description": "Netdata purge with data folder",
+                            "about": "This operation will purge Netdata with data folder",
+                            "command": [
+                                "module_netdata purge"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_netdata status"
+                        },
+                        {
+                            "id": "PRO001",
+                            "description": "Prometheus docker image",
+                            "short": "Prometheus",
+                            "module": "module_prometheus",
+                            "prompt": "This operation will install Prometheus.",
+                            "command": [
+                                "module_prometheus install"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "! module_prometheus status"
+                        },
+                        {
+                            "id": "PRO002",
+                            "description": "Prometheus remove",
+                            "prompt": "This operation will remove Prometheus.",
+                            "command": [
+                                "module_prometheus remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_prometheus status"
+                        },
+                        {
+                            "id": "PRO003",
+                            "description": "Prometheus purge with data folder",
+                            "about": "This operation will purge Prometheus with data folder",
+                            "command": [
+                                "module_prometheus purge"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_prometheus status"
+                        },
+                        {
+                            "id": "UPK001",
+                            "description": "Uptime Kuma self-hosted monitoring tool",
+                            "short": "Uptime Kuma",
+                            "module": "module_uptimekuma",
+                            "about": "This operation will install Uptime Kuma",
+                            "command": [
+                                "module_uptimekuma install"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "! module_uptimekuma status"
+                        },
+                        {
+                            "id": "UPK002",
+                            "description": "Uptime Kuma remove",
+                            "about": "This operation will remove Uptime Kuma",
+                            "command": [
+                                "module_uptimekuma remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_uptimekuma status"
+                        },
+                        {
+                            "id": "UPK003",
+                            "description": "Uptime Kuma purge with data folder",
+                            "about": "This operation will remove Uptime Kuma with data folder",
+                            "command": [
+                                "module_uptimekuma purge"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_uptimekuma status"
+                        }
+                    ]
+                },
+                {
+                    "id": "Netconfig",
+                    "description": "Console network tools for measuring load and bandwidth",
+                    "sub": [
+                        {
+                            "id": "AVH001",
+                            "description": "avahi-daemon hostname broadcast via mDNS",
+                            "short": "avahi-daemon",
+                            "module": "module_netbox",
+                            "prompt": "This operation will install avahi-daemon.",
+                            "command": [
+                                "pkg_install avahi-daemon libnss-mdns",
+                                "cp /usr/share/doc/avahi-daemon/examples/sftp-ssh.service /etc/avahi/services/",
+                                "cp /usr/share/doc/avahi-daemon/examples/ssh.service /etc/avahi/services/",
+                                "srv_restart avahi-daemon.service"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "! pkg_installed avahi-daemon"
+                        },
+                        {
+                            "id": "AVH002",
+                            "description": "avahi-daemon remove",
+                            "prompt": "This operation will remove avahi-daemon.",
+                            "command": [
+                                "srv_stop avahi-daemon avahi-daemon.socket",
+                                "pkg_remove avahi-daemon"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "pkg_installed avahi-daemon"
+                        },
+                        {
+                            "id": "IPR001",
+                            "description": "iperf3 bandwidth measuring tool",
+                            "short": "iperf3",
+                            "module": "module_netbox",
+                            "prompt": "This operation will install iperf3.",
+                            "command": [
+                                "pkg_install iperf3"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "! pkg_installed iperf3"
+                        },
+                        {
+                            "id": "IPR002",
+                            "description": "iperf3 remove",
+                            "prompt": "This operation will remove iperf3.",
+                            "command": [
+                                "pkg_remove iperf3"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "pkg_installed iperf3"
+                        },
+                        {
+                            "id": "IPT001",
+                            "description": "iptraf-ng IP LAN monitor",
+                            "short": "iptraf-ng",
+                            "module": "module_netbox",
+                            "prompt": "This operation will install iptraf-ng.",
+                            "command": [
+                                "pkg_install iptraf-ng"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "! pkg_installed iptraf-ng"
+                        },
+                        {
+                            "id": "IPT002",
+                            "description": "iptraf-ng remove",
+                            "prompt": "This operation will remove iptraf-ng.",
+                            "command": [
+                                "pkg_remove iptraf-ng"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "pkg_installed iptraf-ng"
+                        },
+                        {
+                            "id": "NLD001",
+                            "description": "nload - realtime console network usage monitor",
+                            "short": "nload",
+                            "module": "module_netbox",
+                            "prompt": "This operation will install nload.",
+                            "command": [
+                                "pkg_install nload"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "! pkg_installed nload"
+                        },
+                        {
+                            "id": "NLD002",
+                            "description": "nload - remove",
+                            "prompt": "This operation will remove nload.",
+                            "command": [
+                                "pkg_remove nload"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "pkg_installed nload"
+                        }
+                    ]
+                },
+                {
+                    "id": "Printing",
+                    "description": "Tools for printing and 3D printing",
+                    "sub": [
+                        {
+                            "id": "OCT001",
+                            "description": "OctoPrint web-based 3D printers management tool",
+                            "short": "OctoPrint",
+                            "module": "module_octoprint",
+                            "about": "This operation will install OctoPrint",
+                            "command": [
+                                "module_octoprint install"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "! module_octoprint status"
+                        },
+                        {
+                            "id": "OCT002",
+                            "description": "OctoPrint remove",
+                            "about": "This operation will remove OctoPrint",
+                            "command": [
+                                "module_octoprint remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_octoprint status"
+                        },
+                        {
+                            "id": "OCT003",
+                            "description": "OctoPrint purge with data folder",
+                            "about": "This operation will purge OctoPrint with data folder",
+                            "command": [
+                                "module_octoprint purge"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_octoprint status"
+                        }
+                    ]
+                },
+                {
+                    "id": "VPN",
+                    "description": "Virtual Private Network tools",
+                    "sub": [
+                        {
+                            "id": "WRG001",
+                            "description": "WireGuard VPN server",
+                            "short": "WireGuard",
+                            "module": "module_wireguard",
+                            "command": [
+                                "module_wireguard server"
+                            ],
+                            "status": "Enabled",
+                            "author": "@armbian",
+                            "condition": "! module_wireguard image"
+                        },
+                        {
+                            "id": "WRG002",
+                            "description": "WireGuard VPN client",
+                            "about": "This operation will add WireGuard client configuration",
+                            "command": [
+                                "module_wireguard client"
+                            ],
+                            "status": "Enabled",
+                            "author": "@armbian",
+                            "condition": "! module_wireguard servermode"
+                        },
+                        {
+                            "id": "WRG003",
+                            "description": "WireGuard remove",
+                            "about": "This operation will remove WireGuard",
+                            "command": [
+                                "module_wireguard remove"
+                            ],
+                            "status": "Enabled",
+                            "author": "@armbian",
+                            "condition": "module_wireguard image || module_wireguard container"
+                        },
+                        {
+                            "id": "WRG004",
+                            "description": "WireGuard VPN server QR codes for clients",
+                            "command": [
+                                "module_wireguard qrcode"
+                            ],
+                            "status": "Enabled",
+                            "author": "@armbian",
+                            "condition": "module_wireguard servermode"
+                        },
+                        {
+                            "id": "WRG005",
+                            "description": "WireGuard purge with data folder",
+                            "about": "This operation will purge WireGuard with data folder",
+                            "command": [
+                                "module_wireguard purge"
+                            ],
+                            "status": "Enabled",
+                            "author": "@armbian",
+                            "condition": "module_wireguard image"
+                        },
+                        {
+                            "id": "ZTR001",
+                            "description": "ZeroTier connect devices over your own private network in the world.",
+                            "short": "ZeroTier",
+                            "command": [
+                                "see_menu module_zerotier"
+                            ],
+                            "status": "Stable",
+                            "author": "@jnovos",
+                            "condition": ""
+                        }
+                    ]
+                },
+                {
+                    "id": "WebHosting",
+                    "description": "Web server, LEMP, reverse proxy, Let's Encrypt SSL",
+                    "sub": [
+                        {
+                            "id": "SWAG01",
+                            "description": "SWAG reverse proxy",
+                            "short": "SWAG",
+                            "module": "module_swag",
+                            "command": [
+                                "module_swag install"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "! module_swag status"
+                        },
+                        {
+                            "id": "SWAG02",
+                            "description": "SWAG reverse proxy .htpasswd set",
+                            "command": [
+                                "module_swag password"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_swag status"
+                        },
+                        {
+                            "id": "SWAG03",
+                            "description": "SWAG remove",
+                            "command": [
+                                "module_swag remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_swag status"
+                        },
+                        {
+                            "id": "SWAG04",
+                            "description": "SWAG purge with data folder",
+                            "command": [
+                                "module_swag purge"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_swag status"
+                        }
+                    ]
                 }
-              ]
-            },
-            {
-              "id": "GNOMDE",
-              "description": "Gnome desktop",
-              "sub": [
-                {
-                  "id": "GNME01",
-                  "description": "Gnome desktop Install",
-                  "command": [
-                    "module_desktop 'install' 'de=gnome'"
-                  ],
-                  "status": "Stable",
-                  "author": "@igorpecovnik",
-                  "condition": "! module_desktop status de=gnome"
-                },
-                {
-                  "id": "GNME02",
-                  "description": "Uninstall",
-                  "command": [
-                    "module_desktop 'remove' 'de=gnome'"
-                  ],
-                  "status": "Stable",
-                  "author": "@igorpecovnik",
-                  "condition": "module_desktop status de=gnome"
-                },
-                {
-                  "id": "GNME03",
-                  "description": "Enable autologin",
-                  "command": [
-                    "module_desktop auto de=gnome"
-                  ],
-                  "status": "Stable",
-                  "author": "@igorpecovnik",
-                  "condition": "module_desktop status de=gnome && ! module_desktop login"
-                },
-                {
-                  "id": "GNME04",
-                  "description": "Disable autologin",
-                  "command": [
-                    "module_desktop manual de=gnome"
-                  ],
-                  "status": "Stable",
-                  "author": "@igorpecovnik",
-                  "condition": "module_desktop status de=gnome && module_desktop login"
-                }
-              ]
-            },
-            {
-              "id": "I3WMDE",
-              "description": "i3-wm desktop",
-              "status": "Disabled",
-              "sub": [
-                {
-                  "id": "I3WM01",
-                  "description": "i3 desktop Install",
-                  "command": [
-                    "manage_desktops 'i3-wm' 'install'"
-                  ],
-                  "status": "Stable",
-                  "author": "@igorpecovnik",
-                  "condition": "[ ! -f /usr/share/xsessions/i3.desktop ]"
-                },
-                {
-                  "id": "I3WM02",
-                  "description": "i3 desktop uninstall",
-                  "command": [
-                    "manage_desktops 'i3-wm' 'uninstall'"
-                  ],
-                  "status": "Stable",
-                  "author": "@igorpecovnik",
-                  "condition": "[ -f /usr/share/xsessions/i3.desktop ]"
-                },
-                {
-                  "id": "I3WM03",
-                  "description": "Enable autologin",
-                  "command": [
-                    "manage_desktops 'i3-wm' 'auto'"
-                  ],
-                  "status": "Stable",
-                  "author": "@igorpecovnik",
-                  "condition": "[ -f /usr/share/xsessions/i3.desktop ] && [ ! -f /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf ]"
-                },
-                {
-                  "id": "I3WM04",
-                  "description": "Disable autologin",
-                  "command": [
-                    "manage_desktops 'i3-wm' 'manual'"
-                  ],
-                  "status": "Stable",
-                  "author": "@igorpecovnik",
-                  "condition": "[ -f /usr/share/xsessions/i3.desktop ] && [ -f /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf ]"
-                }
-              ]
-            },
-            {
-              "id": "KDENEO",
-              "description": "Kde-neon desktop",
-              "status": "Disabled",
-              "sub": [
-                {
-                  "id": "KDEN01",
-                  "description": "Kde-neon desktop Install",
-                  "command": [
-                    "manage_desktops 'kde-neon' 'install'"
-                  ],
-                  "status": "Stable",
-                  "author": "@igorpecovnik",
-                  "condition": "[ ! -f /usr/share/xsessions/gnome.desktop ]"
-                },
-                {
-                  "id": "KDEN02",
-                  "description": "Uninstall",
-                  "command": [
-                    "manage_desktops 'kde-neon' 'uninstall'"
-                  ],
-                  "status": "Stable",
-                  "author": "@igorpecovnik",
-                  "condition": "[ -f /usr/share/xsessions/gnome.desktop ]"
-                },
-                {
-                  "id": "KDEN03",
-                  "description": "Enable autologin",
-                  "command": [
-                    "manage_desktops 'kde-neon' 'auto'"
-                  ],
-                  "status": "Stable",
-                  "author": "@igorpecovnik",
-                  "condition": "[ -f /usr/share/xsessions/gnome.desktop ] && [ ! -f /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf ]"
-                },
-                {
-                  "id": "KDEN04",
-                  "description": "Disable autologin",
-                  "command": [
-                    "manage_desktops 'kde-neon' 'manual'"
-                  ],
-                  "status": "Stable",
-                  "author": "@igorpecovnik",
-                  "condition": "[ -f /usr/share/xsessions/gnome.desktop ] && [ -f /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf ]"
-                }
-              ]
-            },
-            {
-              "id": "XFCEDE",
-              "description": "XFCE desktop",
-              "sub": [
-                {
-                  "id": "XFCE01",
-                  "about": "Install XFCE:\n\nXfce is a lightweight desktop environment for UNIX-like operating systems. It aims to be fast and low on system resources, while still being visually appealing and user friendly.",
-                  "description": "XFCE desktop Install",
-                  "command": [
-                    "module_desktop install de=xfce"
-                  ],
-                  "status": "Stable",
-                  "author": "@igorpecovnik",
-                  "condition": "! module_desktop status de=xfce"
-                },
-                {
-                  "id": "XFCE02",
-                  "description": "Uninstall",
-                  "command": [
-                    "module_desktop remove de=xfce"
-                  ],
-                  "status": "Stable",
-                  "author": "@igorpecovnik",
-                  "condition": "module_desktop status de=xfce"
-                },
-                {
-                  "id": "XFCE03",
-                  "description": "Enable autologin",
-                  "command": [
-                    "module_desktop auto de=xfce"
-                  ],
-                  "status": "Stable",
-                  "author": "@igorpecovnik",
-                  "condition": "module_desktop status de=xfce && ! module_desktop login"
-                },
-                {
-                  "id": "XFCE04",
-                  "description": "Disable autologin",
-                  "command": [
-                    "module_desktop manual de=xfce"
-                  ],
-                  "status": "Stable",
-                  "author": "@igorpecovnik",
-                  "condition": "module_desktop status de=xfce && module_desktop login"
-                }
-              ]
-            },
-            {
-              "id": "Xapian",
-              "description": "Improve application search speed",
-              "command": [
-                "update-apt-xapian-index -u; sleep 3"
-              ],
-              "status": "Stable",
-              "author": "@igorpecovnik",
-              "condition": "srv_active display-manager"
-            }
-          ]
-        },
-        {
-          "id": "DevTools",
-          "description": "Applications and tools for development",
-          "sub": [
-            {
-              "id": "GIT001",
-              "description": "Install tools for cloning and managing repositories (git)",
-              "short": "Git CLI",
-              "module": "module_generic",
-              "command": [
-                "get_user_continue \"This operation will install git.\n\nDo you wish to continue?\" process_input",
-                "pkg_install git"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "! pkg_installed git"
-            },
-            {
-              "id": "GIT002",
-              "description": "Remove tools for cloning and managing repositories (git)",
-              "command": [
-                "get_user_continue \"This operation will remove git.\n\nDo you wish to continue?\" process_input",
-                "pkg_remove git"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "pkg_installed git"
-            }
-          ]
-        },
-        {
-          "id": "Downloaders",
-          "description": "Download apps for movies, TV shows, music and subtitles",
-          "sub": [
-            {
-              "id": "BAZ001",
-              "description": "Bazarr automatic subtitles downloader for Sonarr and Radarr",
-              "short": "Bazarr",
-              "module": "module_bazarr",
-              "about": "This operation will install Bazarr subtitles manager for Sonarr and Radarr",
-              "command": [
-                "module_bazarr install"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "! module_bazarr status"
-            },
-            {
-              "id": "BAZ002",
-              "description": "Bazarr remove",
-              "about": "This operation will remove Bazarr subtitles manager for Sonarr and Radarr",
-              "command": [
-                "module_bazarr remove"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_bazarr status"
-            },
-            {
-              "id": "BAZ003",
-              "description": "Bazarr purge with data folder",
-              "about": "This operation will purge Bazarr subtitles manager with data folder",
-              "command": [
-                "module_bazarr purge"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_bazarr status"
-            },
-            {
-              "id": "DEL001",
-              "description": "Deluge BitTorrent client",
-              "short": "Deluge",
-              "module": "module_deluge",
-              "about": "This operation will install BitTorrent client",
-              "command": [
-                "module_deluge install"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "! module_deluge status"
-            },
-            {
-              "id": "DEL002",
-              "description": "Deluge remove",
-              "about": "This operation will remove Deluge BitTorrent client",
-              "command": [
-                "module_deluge remove"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_deluge status"
-            },
-            {
-              "id": "DEL003",
-              "description": "Deluge purge with data folder",
-              "about": "This operation will remove Deluge BitTorrent client data folder",
-              "command": [
-                "module_deluge purge"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_deluge status"
-            },
-            {
-              "id": "DOW001",
-              "description": "qBittorrent BitTorrent client ",
-              "short": "qBittorrent",
-              "module": "module_qbittorrent",
-              "about": "This operation will install qBittorrent BitTorrent client",
-              "command": [
-                "module_qbittorrent install"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "! module_qbittorrent status"
-            },
-            {
-              "id": "DOW002",
-              "description": "qBittorrent remove",
-              "about": "This operation will remove qBittorrent BitTorrent client",
-              "command": [
-                "module_qbittorrent remove"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_qbittorrent status"
-            },
-            {
-              "id": "DOW003",
-              "description": "qBittorrent purge with data folder",
-              "about": "This operation will remove qBittorrent BitTorrent data folder",
-              "command": [
-                "module_qbittorrent purge"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_qbittorrent status"
-            },
-            {
-              "id": "DOW025",
-              "description": "Prowlarr index manager and proxy for PVR",
-              "short": "Prowlarr",
-              "module": "module_prowlarr",
-              "about": "This operation will install Prowlarr",
-              "command": [
-                "module_prowlarr install"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "! module_prowlarr status"
-            },
-            {
-              "id": "DOW026",
-              "description": "Prowlarr remove",
-              "about": "This operation will remove Prowlarr",
-              "command": [
-                "module_prowlarr remove"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_prowlarr status"
-            },
-            {
-              "id": "DOW027",
-              "description": "Prowlarr purge with data folder",
-              "about": "This operation will purge Prowlarr with data folder",
-              "command": [
-                "module_prowlarr purge"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_prowlarr status"
-            },
-            {
-              "id": "JEL001",
-              "description": "Jellyseerr Jellyfin/Emby/Plex integration install",
-              "short": "Jellyseerr",
-              "module": "module_jellyseerr",
-              "about": "This operation will install Jellyseerr",
-              "command": [
-                "module_jellyseerr install"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "! module_jellyseerr status"
-            },
-            {
-              "id": "JEL002",
-              "description": "Jellyseerr remove",
-              "about": "This operation will remove Jellyseerr",
-              "command": [
-                "module_jellyseerr remove"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_jellyseerr status"
-            },
-            {
-              "id": "JEL003",
-              "description": "Jellyseerr purge with data folder",
-              "about": "This operation will purge Jellyseerr with data folder",
-              "command": [
-                "module_jellyseerr purge"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_jellyseerr status ]]"
-            },
-            {
-              "id": "LID001",
-              "description": "Lidarr automatic music downloader",
-              "short": "Lidarr",
-              "module": "module_lidarr",
-              "about": "This operation will install Lidarr music collection manager for Usenet and BitTorrent users",
-              "command": [
-                "module_lidarr install"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "! module_lidarr status"
-            },
-            {
-              "id": "LID002",
-              "description": "Lidarr remove",
-              "about": "This operation will remove Lidarr",
-              "command": [
-                "module_lidarr remove"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_lidarr status"
-            },
-            {
-              "id": "LID003",
-              "description": "Lidarr purge with data folder",
-              "about": "This operation will purge Lidarr with data folder",
-              "command": [
-                "module_lidarr purge"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_lidarr status"
-            },
-            {
-              "id": "MDS001",
-              "description": "Medusa automatic downloader for TV shows",
-              "short": "Medusa",
-              "module": "module_medusa",
-              "about": "This operation will install Medusa TV shows downloader",
-              "command": [
-                "module_medusa install"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "! module_medusa status"
-            },
-            {
-              "id": "MDS002",
-              "description": "Medusa TV shows downloader remove",
-              "about": "This operation will remove Medusa TV shows downloader",
-              "command": [
-                "module_medusa remove"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_medusa status"
-            },
-            {
-              "id": "MDS003",
-              "description": "Medusa TV shows downloader purge",
-              "about": "This operation will purge Medusa TV shows data folder",
-              "command": [
-                "module_medusa purge"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_medusa status"
-            },
-            {
-              "id": "RAD001",
-              "description": "Radarr automatic downloader for movies",
-              "short": "Radarr",
-              "module": "module_radarr",
-              "about": "This operation will install Radarr movie collection manager",
-              "command": [
-                "module_radarr install"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "! module_radarr status"
-            },
-            {
-              "id": "RAD002",
-              "description": "Radarr remove",
-              "about": "This operation will remove Radarr movie collection manager",
-              "command": [
-                "module_radarr remove"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_radarr status"
-            },
-            {
-              "id": "RAD003",
-              "description": "Radarr purge with data folder",
-              "about": "This operation will purge Radarr movie collection manager data folder",
-              "command": [
-                "module_radarr purge"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_radarr status"
-            },
-            {
-              "id": "RDR001",
-              "description": "Readarr automatic downloader for Ebooks",
-              "short": "Readarr",
-              "module": "module_readarr",
-              "about": "This operation will install Readarr",
-              "command": [
-                "module_readarr install"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "! module_readarr status"
-            },
-            {
-              "id": "RDR002",
-              "description": "Readarr remove",
-              "about": "This operation will remove Readarr",
-              "command": [
-                "module_readarr remove"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_readarr status"
-            },
-            {
-              "id": "RDR003",
-              "description": "Readarr purge with data folder",
-              "about": "This operation will purge Readarr with data folder",
-              "command": [
-                "module_readarr purge"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_readarr status"
-            },
-            {
-              "id": "SABN01",
-              "description": "SABnzbd newsgroup downloader",
-              "short": "SABnzbd",
-              "module": "module_sabnzbd",
-              "about": "This operation will install SABnzbd newsgroup downloader",
-              "command": [
-                "module_sabnzbd install"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "! module_sabnzbd status"
-            },
-            {
-              "id": "SABN02",
-              "description": "SABnzbd remove",
-              "about": "This operation will remove SABnzbd newsgroup downloader",
-              "command": [
-                "module_sabnzbd remove"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_sabnzbd status"
-            },
-            {
-              "id": "SABN03",
-              "description": "SABnzbd purge with data folder",
-              "about": "This operation will purge SABnzbd newsgroup data folder",
-              "command": [
-                "module_sabnzbd purge"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_sabnzbd status"
-            },
-            {
-              "id": "SON001",
-              "description": "Sonarr automatic downloader for TV shows",
-              "short": "Sonarr",
-              "module": "module_sonarr",
-              "about": "This operation will install Sonarr PVR for Usenet and BitTorrent",
-              "command": [
-                "module_sonarr install"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "! module_sonarr status"
-            },
-            {
-              "id": "SON002",
-              "description": "Sonarr remove",
-              "about": "This operation will remove Sonarr PVR for Usenet and BitTorrent",
-              "command": [
-                "module_sonarr remove"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_sonarr status"
-            },
-            {
-              "id": "SON003",
-              "description": "Sonarr purge with data folder",
-              "about": "This operation will purge Sonarr PVR for Usenet and BitTorrent purge data folder",
-              "command": [
-                "module_sonarr purge"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_sonarr status"
-            },
-            {
-              "id": "TRA001",
-              "description": "Transmission BitTorrent client",
-              "short": "Transmission",
-              "module": "module_transmission",
-              "about": "This operation will install Transmission BitTorrent client",
-              "command": [
-                "module_transmission install"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "! module_transmission status"
-            },
-            {
-              "id": "TRA002",
-              "description": "Transmission remove",
-              "about": "This operation will remove Transmission BitTorrent client",
-              "command": [
-                "module_transmission remove"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_transmission status"
-            },
-            {
-              "id": "TRA003",
-              "description": "Transmission purge with data folder",
-              "about": "This operation will remove Transmission BitTorrent client data folder",
-              "command": [
-                "module_transmission purge"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_transmission status"
-            }
-          ]
-        },
-        {
-          "id": "Finance",
-          "description": "Manage your finances",
-          "sub": [
-            {
-              "id": "ABU001",
-              "description": "Do your finances with Actual Budget",
-              "short": "Actual Budget",
-              "module": "module_actualbudget",
-              "command": [
-                "module_actualbudget install"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "! module_actualbudget status"
-            },
-            {
-              "id": "ABU002",
-              "description": "Actual Budget remove",
-              "command": [
-                "module_actualbudget remove"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_actualbudget status"
-            },
-            {
-              "id": "ABU003",
-              "description": "Actual Budget purge with data folder",
-              "command": [
-                "module_actualbudget purge"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_actualbudget status"
-            }
-          ]
-        },
-        {
-          "id": "HomeAutomation",
-          "description": "Home Automation for control home appliances",
-          "sub": [
-            {
-              "id": "DOM001",
-              "description": "Domoticz open source home automation",
-              "short": "Domoticz",
-              "module": "module_domoticz",
-              "about": "This operation will install Domoticz.",
-              "command": [
-                "module_domoticz install"
-              ],
-              "status": "Preview",
-              "author": "@igorpecovnik",
-              "condition": "! module_domoticz status"
-            },
-            {
-              "id": "DOM002",
-              "description": "Domoticz remove",
-              "about": "This operation will remove Domoticz.",
-              "command": [
-                "module_domoticz remove"
-              ],
-              "status": "Preview",
-              "author": "@igorpecovnik",
-              "condition": "module_domoticz status"
-            },
-            {
-              "id": "DOM003",
-              "description": "Domoticz purge with data folder",
-              "about": "This operation will purge Domoticz.",
-              "command": [
-                "module_domoticz purge"
-              ],
-              "status": "Preview",
-              "author": "@igorpecovnik",
-              "condition": "module_domoticz status"
-            },
-            {
-              "id": "EVCC01",
-              "description": "EVCC - solar charging automation",
-              "short": "EVCC",
-              "module": "module_evcc",
-              "about": "This operation will install solar charging automation.",
-              "command": [
-                "module_evcc install"
-              ],
-              "status": "Preview",
-              "author": "@igorpecovnik",
-              "condition": "! module_evcc status"
-            },
-            {
-              "id": "EVCC02",
-              "description": "EVCC - solar charging automation remove",
-              "about": "This operation will remove solar charging automation.",
-              "command": [
-                "module_evcc remove"
-              ],
-              "status": "Preview",
-              "author": "@igorpecovnik",
-              "condition": "module_evcc status"
-            },
-            {
-              "id": "EVCC03",
-              "description": "EVCC purge with data folder",
-              "about": "This operation will purge solar charging automation with data folder.",
-              "command": [
-                "module_evcc purge"
-              ],
-              "status": "Preview",
-              "author": "@igorpecovnik",
-              "condition": "module_evcc status"
-            },
-            {
-              "id": "HAB001",
-              "description": "openHAB empowering the smart home",
-              "short": "openHAB",
-              "module": "module_openhab",
-              "about": "This operation will install openHAB.",
-              "command": [
-                "module_openhab install"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "! module_openhab status"
-            },
-            {
-              "id": "HAB002",
-              "description": "openHAB remove",
-              "about": "This operation will purge openHAB.",
-              "command": [
-                "module_openhab remove"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_openhab status"
-            },
-            {
-              "id": "HAB003",
-              "description": "openHAB purge with data folder",
-              "about": "This operation will purge openHAB.",
-              "command": [
-                "module_openhab purge"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_openhab status"
-            },
-            {
-              "id": "HAS001",
-              "description": "Home Assistant open source home automation",
-              "short": "Home Assistant",
-              "module": "module_haos",
-              "about": "This operation will install Home Assistant.",
-              "command": [
-                "module_haos install"
-              ],
-              "status": "Preview",
-              "author": "@igorpecovnik",
-              "condition": "! module_haos status && grep -q bookworm /etc/os-release"
-            },
-            {
-              "id": "HAS002",
-              "description": "Home Assistant remove",
-              "about": "This operation will remove Home Assistant.",
-              "command": [
-                "module_haos remove"
-              ],
-              "status": "Preview",
-              "author": "@igorpecovnik",
-              "condition": "module_haos status"
-            },
-            {
-              "id": "HAS003",
-              "description": "Home Assistant purge with data folder",
-              "about": "This operation will purge Home Assistant.",
-              "command": [
-                "module_haos purge"
-              ],
-              "status": "Preview",
-              "author": "@igorpecovnik",
-              "condition": "module_haos status"
-            }
-          ]
-        },
-        {
-          "id": "Management",
-          "description": "Remote File & Management tools",
-          "sub": [
-            {
-              "id": "CPT001",
-              "description": "Cockpit web-based management tool",
-              "short": "Cockpit",
-              "module": "module_generic",
-              "command": [
-                "see_menu module_cockpit"
-              ],
-              "status": "Stable",
-              "author": "@Tearran",
-              "condition": ""
-            },
-            {
-              "id": "HPG001",
-              "description": "Install Homepage startpage / application dashboard",
-              "short": "Homepage",
-              "module": "module_homepage",
-              "command": [
-                "module_homepage install"
-              ],
-              "status": "Stable",
-              "author": "@igorpecovnik",
-              "condition": "! module_homepage status"
-            },
-            {
-              "id": "HPG002",
-              "description": "Remove Homepage",
-              "command": [
-                "module_homepage remove"
-              ],
-              "status": "Stable",
-              "author": "@igorpecovnik",
-              "condition": "module_homepage status"
-            },
-            {
-              "id": "HPG003",
-              "description": "Purge Homepage with data folder",
-              "command": [
-                "module_homepage purge"
-              ],
-              "status": "Stable",
-              "author": "@igorpecovnik",
-              "condition": "module_homepage status"
-            },
-            {
-              "id": "NBOX01",
-              "description": "NetBox infrastructure resource modeling install",
-              "short": "NetBox",
-              "module": "module_netbox",
-              "about": "This operation will install NetBox, an infrastructure resource modeling (IPAM/DCIM) tool",
-              "command": [
-                "module_netbox install"
-              ],
-              "status": "Stable",
-              "author": "@igorpecovnik",
-              "condition": "! module_netbox status"
-            },
-            {
-              "id": "NBOX02",
-              "description": "NetBox remove",
-              "about": "This operation will remove NetBox container",
-              "command": [
-                "module_netbox remove"
-              ],
-              "status": "Stable",
-              "author": "@igorpecovnik",
-              "condition": "module_netbox status"
-            },
-            {
-              "id": "NBOX03",
-              "description": "NetBox purge with data folder",
-              "about": "This operation will purge NetBox data and remove the container",
-              "command": [
-                "module_netbox purge"
-              ],
-              "status": "Stable",
-              "author": "@igorpecovnik",
-              "condition": "module_netbox status"
-            },
-            {
-              "id": "SMB001",
-              "description": "SAMBA Remote File share",
-              "short": "Samba",
-              "module": "module_generic",
-              "command": [
-                "see_menu module_samba"
-              ],
-              "status": "Stable",
-              "author": "@Tearran",
-              "condition": ""
-            },
-            {
-              "id": "WBM001",
-              "description": "Webmin web-based management tool",
-              "short": "Webmin",
-              "module": "module_generic",
-              "command": [
-                "see_menu module_webmin"
-              ],
-              "status": "Stable",
-              "author": "@Tearran",
-              "condition": ""
-            }
-          ]
-        },
-        {
-          "id": "Media",
-          "description": "Media servers, organizers and editors",
-          "sub": [
-            {
-              "id": "EMB001",
-              "description": "Emby organizes video, music, live TV, and photos",
-              "short": "Emby",
-              "module": "module_embyserver",
-              "about": "This operation will install Emby server.",
-              "command": [
-                "module_embyserver install"
-              ],
-              "status": "Stable",
-              "author": "@schwar3kat",
-              "condition": "! module_embyserver status"
-            },
-            {
-              "id": "EMB002",
-              "description": "Emby server remove",
-              "about": "This operation will remove Emby server",
-              "command": [
-                "module_embyserver remove"
-              ],
-              "status": "Stable",
-              "author": "@schwar3kat",
-              "condition": "module_embyserver status"
-            },
-            {
-              "id": "EMB003",
-              "description": "Emby server purge with data folder",
-              "command": [
-                "module_embyserver purge"
-              ],
-              "status": "Stable",
-              "author": "@schwar3kat",
-              "condition": "module_embyserver status"
-            },
-            {
-              "id": "FIL001",
-              "description": "Filebrowser provides a web-based file manager accessible via a browser",
-              "short": "Filebrowser",
-              "module": "module_filebrowser",
-              "about": "This operation will install Filebrowser container.",
-              "command": [
-                "module_filebrowser install"
-              ],
-              "status": "Stable",
-              "author": "@igorpecovnik",
-              "condition": "! module_filebrowser status"
-            },
-            {
-              "id": "FIL002",
-              "description": "Filebrowser container remove",
-              "about": "This operation will remove Filebrowser container.",
-              "command": [
-                "module_filebrowser remove"
-              ],
-              "status": "Stable",
-              "author": "@igorpecovnik",
-              "condition": "module_filebrowser status"
-            },
-            {
-              "id": "FIL003",
-              "description": "Filebrowser container purge with data folder",
-              "command": [
-                "module_filebrowser purge"
-              ],
-              "status": "Stable",
-              "author": "@igorpecovnik",
-              "condition": "module_filebrowser status"
-            },
-            {
-              "id": "HPS001",
-              "description": "Hastebin Paste Server",
-              "short": "Hastebin",
-              "module": "module_hastebin",
-              "command": [
-                "module_hastebin install"
-              ],
-              "status": "Stable",
-              "author": "@efectn",
-              "condition": "! module_hastebin status"
-            },
-            {
-              "id": "HPS002",
-              "description": "Hastebin remove",
-              "command": [
-                "module_hastebin remove"
-              ],
-              "status": "Stable",
-              "author": "@efectn",
-              "condition": "module_hastebin status"
-            },
-            {
-              "id": "HPS003",
-              "description": "Hastebin purge with data folder",
-              "command": [
-                "module_hastebin purge"
-              ],
-              "status": "Stable",
-              "author": "@efectn",
-              "condition": "module_hastebin status"
-            },
-            {
-              "id": "IMM001",
-              "description": "Immich - high-performance self-hosted photo and video backup solution",
-              "short": "Immich",
-              "module": "module_immich",
-              "about": "This operation will install Immich server with dependencies (PostgreSQL and Redis).",
-              "command": [
-                "module_immich install"
-              ],
-              "status": "Preview",
-              "author": "@igorpecovnik",
-              "condition": "! module_immich status"
-            },
-            {
-              "id": "IMM002",
-              "description": "Immich remove",
-              "about": "This operation will remove the Immich container.",
-              "command": [
-                "module_immich remove"
-              ],
-              "status": "Preview",
-              "author": "@igorpecovnik",
-              "condition": "module_immich status"
-            },
-            {
-              "id": "IMM003",
-              "description": "Immich purge with data folder",
-              "about": "This operation will remove Immich container and delete all its data.",
-              "command": [
-                "module_immich purge"
-              ],
-              "status": "Preview",
-              "author": "@igorpecovnik",
-              "condition": "module_immich status"
-            },
-            {
-              "id": "JMS001",
-              "description": "Jellyfin Media System",
-              "short": "Jellyfin",
-              "module": "module_jellyfin",
-              "command": [
-                "module_jellyfin install"
-              ],
-              "status": "Preview",
-              "author": "@igorpecovnik",
-              "condition": "! module_jellyfin status"
-            },
-            {
-              "id": "JMS002",
-              "description": "Jellyfin remove",
-              "command": [
-                "module_jellyfin remove"
-              ],
-              "status": "Preview",
-              "author": "@igorpecovnik",
-              "condition": "module_jellyfin status"
-            },
-            {
-              "id": "JMS003",
-              "description": "Jellyfin purge with data folder",
-              "command": [
-                "module_jellyfin purge"
-              ],
-              "status": "Preview",
-              "author": "@igorpecovnik",
-              "condition": "module_jellyfin status"
-            },
-            {
-              "id": "MED001",
-              "description": "Plex Media server",
-              "about": "This operation will install Plex Media server.",
-              "command": [
-                "module_plexmediaserver install"
-              ],
-              "status": "Disabled",
-              "author": "@schwar3kat",
-              "condition": "! module_plexmediaserver status"
-            },
-            {
-              "id": "MED002",
-              "description": "Plex Media server remove",
-              "about": "This operation will purge Plex Media server.",
-              "command": [
-                "module_plexmediaserver remove"
-              ],
-              "status": "Disabled",
-              "author": "@schwar3kat",
-              "condition": "module_plexmediaserver status"
-            },
-            {
-              "id": "NAV001",
-              "description": "Navidrome music server and streamer compatible with Subsonic/Airsonic",
-              "short": "Navidrome",
-              "module": "module_navidrome",
-              "command": [
-                "module_navidrome install"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "! module_navidrome status"
-            },
-            {
-              "id": "NAV002",
-              "description": "Navidrome remove",
-              "command": [
-                "module_navidrome remove"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_navidrome status"
-            },
-            {
-              "id": "NAV003",
-              "description": "Navidrome purge with data folder",
-              "command": [
-                "module_navidrome purge"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_navidrome status"
-            },
-            {
-              "id": "NCT001",
-              "description": "Nextcloud content collaboration platform",
-              "short": "Nextcloud",
-              "module": "module_nextcloud",
-              "command": [
-                "module_nextcloud install"
-              ],
-              "status": "Stable",
-              "author": "@igorpecovnik",
-              "condition": "! module_nextcloud status"
-            },
-            {
-              "id": "NCT002",
-              "description": "Nextcloud remove",
-              "command": [
-                "module_nextcloud remove"
-              ],
-              "status": "Stable",
-              "author": "@igorpecovnik",
-              "condition": "module_nextcloud status"
-            },
-            {
-              "id": "NCT003",
-              "description": "Nextcloud purge with data folder",
-              "command": [
-                "module_nextcloud purge"
-              ],
-              "status": "Stable",
-              "author": "@igorpecovnik",
-              "condition": "module_nextcloud status"
-            },
-            {
-              "id": "OMV001",
-              "description": "Deploy NAS using OpenMediaVault",
-              "short": "OMV",
-              "module": "module_omv",
-              "about": "This operation will install OpenMediaVault on your system.",
-              "command": [
-                "module_omv install"
-              ],
-              "status": "Stable",
-              "author": "@igorpecovnik",
-              "condition": "! module_omv status"
-            },
-            {
-              "id": "OMV002",
-              "description": "OpenMediaVault remove",
-              "about": "This operation will completely remove OpenMediaVault from your system.",
-              "command": [
-                "module_omv remove"
-              ],
-              "status": "Stable",
-              "author": "@igorpecovnik",
-              "condition": "module_omv status"
-            },
-            {
-              "id": "OWC001",
-              "description": "Owncloud share files and folders, easy and secure",
-              "short": "Owncloud",
-              "module": "module_owncloud",
-              "command": [
-                "module_owncloud install"
-              ],
-              "status": "Stable",
-              "author": "@igorpecovnik",
-              "condition": "! module_owncloud status"
-            },
-            {
-              "id": "OWC002",
-              "description": "Owncloud remove",
-              "command": [
-                "module_owncloud remove"
-              ],
-              "status": "Stable",
-              "author": "@igorpecovnik",
-              "condition": "module_owncloud status"
-            },
-            {
-              "id": "OWC003",
-              "description": "Owncloud purge with data folder",
-              "command": [
-                "module_owncloud purge"
-              ],
-              "status": "Stable",
-              "author": "@igorpecovnik",
-              "condition": "module_owncloud status"
-            },
-            {
-              "id": "STC001",
-              "description": "Syncthing continuous file synchronization",
-              "short": "Syncthing",
-              "module": "module_syncthing",
-              "command": [
-                "module_syncthing install"
-              ],
-              "status": "Stable",
-              "author": "@igorpecovnik",
-              "condition": "! module_syncthing status"
-            },
-            {
-              "id": "STC002",
-              "description": "Syncthing remove",
-              "command": [
-                "module_syncthing remove"
-              ],
-              "status": "Stable",
-              "author": "@igorpecovnik",
-              "condition": "module_syncthing status"
-            },
-            {
-              "id": "STC003",
-              "description": "Syncthing purge with data folder",
-              "command": [
-                "module_syncthing purge"
-              ],
-              "status": "Stable",
-              "author": "@igorpecovnik",
-              "condition": "module_syncthing status"
-            },
-            {
-              "id": "STR001",
-              "description": "Stirling PDF tools for viewing and editing PDF files",
-              "short": "Stirling",
-              "module": "module_stirling",
-              "about": "This operation will install Stirling-PDF tools.",
-              "command": [
-                "module_stirling install"
-              ],
-              "status": "Stable",
-              "author": "@igorpecovnik",
-              "condition": "! module_stirling status"
-            },
-            {
-              "id": "STR002",
-              "description": "Stirling PDF remove",
-              "about": "This operation will remove Stirling-PDF tools.",
-              "command": [
-                "module_stirling remove"
-              ],
-              "status": "Stable",
-              "author": "@igorpecovnik",
-              "condition": "module_stirling status"
-            },
-            {
-              "id": "STR003",
-              "description": "Stirling PDF purge with data folder",
-              "about": "This operation will purge Stirling-PDF tools with data folder.",
-              "command": [
-                "module_stirling purge"
-              ],
-              "status": "Stable",
-              "author": "@igorpecovnik",
-              "condition": "module_stirling status"
-            }
-          ]
-        },
-        {
-          "id": "Monitoring",
-          "description": "Real-time monitoring, collecting metrics, up-time status",
-          "sub": [
-            {
-              "id": "GRA001",
-              "description": "Grafana data analytics",
-              "short": "Grafana",
-              "module": "module_grafana",
-              "prompt": "This operation will install Grafana.",
-              "command": [
-                "module_grafana install"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "! module_grafana status"
-            },
-            {
-              "id": "GRA002",
-              "description": "Grafana remove",
-              "prompt": "This operation will remove Grafana.",
-              "command": [
-                "module_grafana remove"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_grafana status"
-            },
-            {
-              "id": "GRA003",
-              "description": "Grafana purge with data folder",
-              "about": "This operation will purge Grafana with data folder",
-              "command": [
-                "module_grafana purge"
-              ],
-              "status": "Stable",
-              "author": "@igorpecovnik",
-              "condition": "module_grafana status"
-            },
-            {
-              "id": "NAX001",
-              "description": "NetAlertX network scanner & notification framework",
-              "short": "NetAlertX",
-              "module": "module_netalertx",
-              "prompt": "This operation will install NetAlertX.",
-              "command": [
-                "module_netalertx install"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "! module_netalertx status"
-            },
-            {
-              "id": "NAX002",
-              "description": "NetAlertX network scanner remove",
-              "prompt": "This operation will remove NetAlertX.",
-              "command": [
-                "module_netalertx remove"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_netalertx status"
-            },
-            {
-              "id": "NAX003",
-              "description": "NetAlertX network scanner purge with data folder",
-              "about": "This operation will purge NetAlertX with data folder",
-              "command": [
-                "module_netalertx purge"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_netalertx status"
-            },
-            {
-              "id": "NTD001",
-              "description": "Netdata - monitoring real-time metrics",
-              "short": "Netdata",
-              "module": "module_netdata",
-              "about": "This operation will install Netdata",
-              "command": [
-                "module_netdata install"
-              ],
-              "status": "Stable",
-              "author": "@igorpecovnik",
-              "condition": "! module_netdata status"
-            },
-            {
-              "id": "NTD002",
-              "description": "Netdata remove",
-              "about": "This operation will remove Netdata",
-              "command": [
-                "module_netdata remove"
-              ],
-              "status": "Stable",
-              "author": "@igorpecovnik",
-              "condition": "module_netdata status"
-            },
-            {
-              "id": "NTD003",
-              "description": "Netdata purge with data folder",
-              "about": "This operation will purge Netdata with data folder",
-              "command": [
-                "module_netdata purge"
-              ],
-              "status": "Stable",
-              "author": "@igorpecovnik",
-              "condition": "module_netdata status"
-            },
-            {
-              "id": "PRO001",
-              "description": "Prometheus docker image",
-              "short": "Prometheus",
-              "module": "module_prometheus",
-              "prompt": "This operation will install Prometheus.",
-              "command": [
-                "module_prometheus install"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "! module_prometheus status"
-            },
-            {
-              "id": "PRO002",
-              "description": "Prometheus remove",
-              "prompt": "This operation will remove Prometheus.",
-              "command": [
-                "module_prometheus remove"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_prometheus status"
-            },
-            {
-              "id": "PRO003",
-              "description": "Prometheus purge with data folder",
-              "about": "This operation will purge Prometheus with data folder",
-              "command": [
-                "module_prometheus purge"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_prometheus status"
-            },
-            {
-              "id": "UPK001",
-              "description": "Uptime Kuma self-hosted monitoring tool",
-              "short": "Uptime Kuma",
-              "module": "module_uptimekuma",
-              "about": "This operation will install Uptime Kuma",
-              "command": [
-                "module_uptimekuma install"
-              ],
-              "status": "Stable",
-              "author": "@igorpecovnik",
-              "condition": "! module_uptimekuma status"
-            },
-            {
-              "id": "UPK002",
-              "description": "Uptime Kuma remove",
-              "about": "This operation will remove Uptime Kuma",
-              "command": [
-                "module_uptimekuma remove"
-              ],
-              "status": "Stable",
-              "author": "@igorpecovnik",
-              "condition": "module_uptimekuma status"
-            },
-            {
-              "id": "UPK003",
-              "description": "Uptime Kuma purge with data folder",
-              "about": "This operation will remove Uptime Kuma with data folder",
-              "command": [
-                "module_uptimekuma purge"
-              ],
-              "status": "Stable",
-              "author": "@igorpecovnik",
-              "condition": "module_uptimekuma status"
-            }
-          ]
-        },
-        {
-          "id": "Netconfig",
-          "description": "Console network tools for measuring load and bandwidth",
-          "sub": [
-            {
-              "id": "AVH001",
-              "description": "avahi-daemon hostname broadcast via mDNS",
-              "short": "avahi-daemon",
-              "module": "module_netbox",
-              "prompt": "This operation will install avahi-daemon.",
-              "command": [
-                "pkg_install avahi-daemon libnss-mdns",
-                "cp /usr/share/doc/avahi-daemon/examples/sftp-ssh.service /etc/avahi/services/",
-                "cp /usr/share/doc/avahi-daemon/examples/ssh.service /etc/avahi/services/",
-                "srv_restart avahi-daemon.service"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "! pkg_installed avahi-daemon"
-            },
-            {
-              "id": "AVH002",
-              "description": "avahi-daemon remove",
-              "prompt": "This operation will remove avahi-daemon.",
-              "command": [
-                "srv_stop avahi-daemon avahi-daemon.socket",
-                "pkg_remove avahi-daemon"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "pkg_installed avahi-daemon"
-            },
-            {
-              "id": "IPR001",
-              "description": "iperf3 bandwidth measuring tool",
-              "short": "iperf3",
-              "module": "module_netbox",
-              "prompt": "This operation will install iperf3.",
-              "command": [
-                "pkg_install iperf3"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "! pkg_installed iperf3"
-            },
-            {
-              "id": "IPR002",
-              "description": "iperf3 remove",
-              "prompt": "This operation will remove iperf3.",
-              "command": [
-                "pkg_remove iperf3"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "pkg_installed iperf3"
-            },
-            {
-              "id": "IPT001",
-              "description": "iptraf-ng IP LAN monitor",
-              "short": "iptraf-ng",
-              "module": "module_netbox",
-              "prompt": "This operation will install iptraf-ng.",
-              "command": [
-                "pkg_install iptraf-ng"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "! pkg_installed iptraf-ng"
-            },
-            {
-              "id": "IPT002",
-              "description": "iptraf-ng remove",
-              "prompt": "This operation will remove iptraf-ng.",
-              "command": [
-                "pkg_remove iptraf-ng"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "pkg_installed iptraf-ng"
-            },
-            {
-              "id": "NLD001",
-              "description": "nload - realtime console network usage monitor",
-              "short": "nload",
-              "module": "module_netbox",
-              "prompt": "This operation will install nload.",
-              "command": [
-                "pkg_install nload"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "! pkg_installed nload"
-            },
-            {
-              "id": "NLD002",
-              "description": "nload - remove",
-              "prompt": "This operation will remove nload.",
-              "command": [
-                "pkg_remove nload"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "pkg_installed nload"
-            }
-          ]
-        },
-        {
-          "id": "Printing",
-          "description": "Tools for printing and 3D printing",
-          "sub": [
-            {
-              "id": "OCT001",
-              "description": "OctoPrint web-based 3D printers management tool",
-              "short": "OctoPrint",
-              "module": "module_octoprint",
-              "about": "This operation will install OctoPrint",
-              "command": [
-                "module_octoprint install"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "! module_octoprint status"
-            },
-            {
-              "id": "OCT002",
-              "description": "OctoPrint remove",
-              "about": "This operation will remove OctoPrint",
-              "command": [
-                "module_octoprint remove"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_octoprint status"
-            },
-            {
-              "id": "OCT003",
-              "description": "OctoPrint purge with data folder",
-              "about": "This operation will purge OctoPrint with data folder",
-              "command": [
-                "module_octoprint purge"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_octoprint status"
-            }
-          ]
-        },
-        {
-          "id": "VPN",
-          "description": "Virtual Private Network tools",
-          "sub": [
-            {
-              "id": "WRG001",
-              "description": "WireGuard VPN client / server",
-              "short": "WireGuard",
-              "module": "module_wireguard",
-              "command": [
-                "module_wireguard install"
-              ],
-              "status": "Enabled",
-              "author": "@armbian",
-              "condition": "! module_wireguard status"
-            },
-            {
-              "id": "WRG002",
-              "description": "WireGuard remove",
-              "about": "This operation will remove WireGuard",
-              "command": [
-                "module_wireguard remove"
-              ],
-              "status": "Enabled",
-              "author": "@armbian",
-              "condition": "module_wireguard status"
-            },
-            {
-              "id": "WRG003",
-              "description": "WireGuard clients QR codes",
-              "command": [
-                "module_wireguard qrcode"
-              ],
-              "status": "Enabled",
-              "author": "@armbian",
-              "condition": "module_wireguard status"
-            },
-            {
-              "id": "WRG004",
-              "description": "WireGuard purge with data folder",
-              "about": "This operation will purge WireGuard with data folder",
-              "command": [
-                "module_wireguard purge"
-              ],
-              "status": "Enabled",
-              "author": "@armbian",
-              "condition": "module_wireguard status"
-            },
-            {
-              "id": "ZTR001",
-              "description": "ZeroTier connect devices over your own private network in the world.",
-              "short": "ZeroTier",
-              "command": [
-                "see_menu module_zerotier"
-              ],
-              "status": "Stable",
-              "author": "@jnovos",
-              "condition": ""
-            }
-          ]
-        },
-        {
-          "id": "WebHosting",
-          "description": "Web server, LEMP, reverse proxy, Let's Encrypt SSL",
-          "sub": [
-            {
-              "id": "SWAG01",
-              "description": "SWAG reverse proxy",
-              "short": "SWAG",
-              "module": "module_swag",
-              "command": [
-                "module_swag install"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "! module_swag status"
-            },
-            {
-              "id": "SWAG02",
-              "description": "SWAG reverse proxy .htpasswd set",
-              "command": [
-                "module_swag password"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_swag status"
-            },
-            {
-              "id": "SWAG03",
-              "description": "SWAG remove",
-              "command": [
-                "module_swag remove"
-              ],
-              "status": "Stable",
-              "author": "@armbian",
-              "condition": "module_swag status"
-            },
-            {
-              "id": "SWAG04",
-              "description": "SWAG purge with data folder",
-              "command": [
-                "module_swag purge"
-              ],
-              "status": "Stable",
-              "author": "@igorpecovnik",
-              "condition": "module_swag status"
-            }
-          ]
+            ]
         }
-      ]
-    }
-  ]
+    ]
 }

--- a/tools/modules/software/module_wireguard.sh
+++ b/tools/modules/software/module_wireguard.sh
@@ -2,7 +2,7 @@ module_options+=(
 	["module_wireguard,author"]="@armbian"
 	["module_wireguard,maintainer"]="@igorpecovnik"
 	["module_wireguard,feature"]="module_wireguard"
-	["module_wireguard,example"]="install remove purge qrcode status help"
+	["module_wireguard,example"]="pull client server remove purge qrcode image container servermode help"
 	["module_wireguard,desc"]="Install wireguard container"
 	["module_wireguard,status"]="Active"
 	["module_wireguard,doc_link"]="https://docs.linuxserver.io/images/docker-wireguard/#server-mode"
@@ -29,34 +29,70 @@ function module_wireguard () {
 
 	case "$1" in
 		"${commands[0]}")
+			# Check if the module is already installed
 			pkg_installed docker-ce || module_docker install
+
+			# Create the base and config directory if it doesn't exist
 			[[ -d "$WIREGUARD_BASE" ]] || mkdir -p "$WIREGUARD_BASE" || { echo "Couldn't create storage directory: $WIREGUARD_BASE"; exit 1; }
-			if [[ -z $2 ]]; then
-				NUMBER_OF_PEERS=$($DIALOG --title "Enter comma delimited peer keywords" --inputbox " \n" 7 50 "pc,laptop,phone" 3>&1 1>&2 2>&3)
+			[[ -d "$WIREGUARD_BASE/config/wg_confs/" ]] || mkdir -p "$WIREGUARD_BASE/config/wg_confs/" || { echo "Couldn't create config directory: $WIREGUARD_BASE/config/wg_confs/"; exit 1; }
+
+			# Check if the image is already pulled
+			${module_options["module_wireguard,feature"]} ${commands[6]}
+			if [[ $? -ne 0 ]]; then
+				docker pull lscr.io/linuxserver/wireguard:latest || { echo "Couldn't pull image: lscr.io/linuxserver/wireguard:latest"; exit 1; }
 			fi
+		;;
+		"${commands[1]}")
+
+			# Pull the image if not already done
+			${module_options["module_wireguard,feature"]} ${commands[0]}
+
+			# Create temp file
+			TMP_FILE=$(mktemp)
+
+			# Optional initial content
+			if [[ -f "${WIREGUARD_BASE}/config/wg_confs/client.conf" ]]; then
+				cp "${WIREGUARD_BASE}/config/wg_confs/client.conf" "$TMP_FILE"
+			else
+				echo "# WireGuard client configuration file" > "$TMP_FILE"
+			fi
+
+			# Ask user to edit content
+			${EDITOR:-nano} "$TMP_FILE"
+
+			# Use `install` to move the file with correct owner and permissions
+			rm -f "${WIREGUARD_BASE}/config/wg_confs/wg0.conf"
+			install -m 600 -o 1000 -g 1000 "$TMP_FILE" "${WIREGUARD_BASE}/config/wg_confs/client.conf"
+			rm -f "$TMP_FILE"
+
+			# Check if the container is running, if so, remove it
+			${module_options["module_wireguard,feature"]} ${commands[7]}
+			if [[ $? -eq 0 ]]; then
+				docker rm -f wireguard >/dev/null 2>&1
+			fi
+
+			# Get local subnets from user input or use default
+			if [[ -z $2 ]]; then
+				LOCAL_SUBNETS=$($DIALOG --title "Enter comma delimited subnets for routing" --inputbox "\n* delete if this is not your local subnet \n" 9 70 "10.0.10.0/24" 3>&1 1>&2 2>&3)
+			else
+				LOCAL_SUBNETS="$2"
+			fi
+
 			docker run -d \
 			--name=wireguard \
 			--net=lsio \
 			--cap-add=NET_ADMIN \
-			--cap-add=SYS_MODULE `#optional` \
+			--cap-add=SYS_MODULE \
+			--privileged \
 			-e PUID=1000 \
 			-e PGID=1000 \
 			-e TZ="$(cat /etc/timezone)" \
-			-e SERVERURL=auto \
-			-e SERVERPORT=51820 \
-			-e PEERS="${NUMBER_OF_PEERS}" \
-			-e PEERDNS=auto \
-			-e INTERNAL_SUBNET=10.13.13.0 \
-			-e ALLOWEDIPS=0.0.0.0/0 \
-			-e PERSISTENTKEEPALIVE_PEERS= \
-			-e LOG_CONFS=true \
-			-p 51820:51820/udp \
 			-v "${WIREGUARD_BASE}/config:/config" \
-			--sysctl="net.ipv4.conf.all.src_valid_mark=1" \
 			--restart unless-stopped \
+			--sysctl net.ipv4.ip_forward=1 \
 			lscr.io/linuxserver/wireguard:latest
 			for i in $(seq 1 20); do
-				if docker inspect -f '{{ index .Config.Labels "build_version" }}' wireguard >/dev/null 2>&1 ; then
+				if docker inspect -f '{{ index .Config.Labels "build_version" }}' wireguard >/dev/null 2>&1 && [[ -f "${WIREGUARD_BASE}/config/wg_confs/client.conf" ]]; then
 					break
 				else
 					sleep 3
@@ -66,16 +102,148 @@ function module_wireguard () {
 					exit 1
 				fi
 			done
+			if [[ -n "${LOCAL_SUBNETS}" ]]; then
+				# Create host-side route helper script for LAN routing via WireGuard container
+				cat > "/usr/local/bin/add-vpn-lan-routes.sh" <<- EOT
+				#!/bin/bash
+
+				docker exec wireguard iptables -t nat -A POSTROUTING -o client -j MASQUERADE
+
+				# Get the IP address of the WireGuard container dynamically
+				CONTAINER_IP=\$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' wireguard)
+
+				if [[ -z "\$CONTAINER_IP" ]]; then
+					echo "WireGuard container not found or not running"
+					exit 1
+				fi
+
+				echo "Adding LAN routes via container IP: \$CONTAINER_IP"
+
+				# Add route for specific LAN subnets (customize as needed)
+				EOT
+				# Loop through each subnet and append a route command
+				IFS=',' read -ra SUBNETS <<< "$LOCAL_SUBNETS"
+				for subnet in "${SUBNETS[@]}"; do
+					echo "ip route add $subnet via \"\$CONTAINER_IP\"" >> /usr/local/bin/add-vpn-lan-routes.sh
+				done
+
+				cat > "/usr/local/bin/remove-vpn-lan-routes.sh" <<- EOT
+				#!/bin/bash
+				docker exec wireguard iptables -t nat -C POSTROUTING -o client -j MASQUERADE 2>/dev/null && \
+				docker exec wireguard iptables -t nat -D POSTROUTING -o client -j MASQUERADE || true
+				EOT
+				# Loop through each subnet and append a route command
+				IFS=',' read -ra SUBNETS <<< "$LOCAL_SUBNETS"
+				for subnet in "${SUBNETS[@]}"; do
+					echo "ip route show \"$subnet\" | grep -q \"$subnet\" && ip route del \"$subnet\" || true" >> /usr/local/bin/remove-vpn-lan-routes.sh
+				done
+
+				chmod +x /usr/local/bin/add-vpn-lan-routes.sh
+				chmod +x /usr/local/bin/remove-vpn-lan-routes.sh
+
+				echo -e "\n✅ Created: /usr/local/bin/add-vpn-lan-routes.sh"
+				echo -e "Run this script to restore LAN routes via the WireGuard container."
+
+				echo -e "\n✅ Created: /usr/local/bin/remove-vpn-lan-routes.sh"
+				echo -e "Run this script to remove LAN routes via the WireGuard container."
+
+				cat > "/etc/systemd/system/add-vpn-lan-routes.service" <<- EOT
+				[Unit]
+				Description=Add routes for LAN via WireGuard Docker container
+				After=network-online.target docker.service
+				Wants=network-online.target
+
+				[Service]
+				Type=oneshot
+				ExecStart=/usr/local/bin/add-vpn-lan-routes.sh
+				RemainAfterExit=yes
+
+				[Install]
+				WantedBy=multi-user.target
+				EOT
+
+				# Remove routes just in case they were added before
+				bash /usr/local/bin/remove-vpn-lan-routes.sh || true
+
+				systemctl daemon-reexec
+				systemctl daemon-reload
+				systemctl enable add-vpn-lan-routes.service
+				systemctl restart add-vpn-lan-routes.service
+			fi
 		;;
-		"${commands[1]}")
+		"${commands[2]}")
+
+			# Pull the image if not already done
+			${module_options["module_wireguard,feature"]} ${commands[0]}
+
+			if [[ -z $2 ]]; then
+				NUMBER_OF_PEERS=$($DIALOG --title "Enter comma delimited peer keywords" --inputbox " \n" 7 50 "laptop" 3>&1 1>&2 2>&3)
+			fi
+			if [[ $? -eq 0 ]]; then
+				${module_options["module_wireguard,feature"]} ${commands[7]}
+				if [[ $? -eq 0 ]]; then
+					docker rm -f wireguard >/dev/null 2>&1
+				fi
+
+				# Remove client config if any
+				rm -f "${WIREGUARD_BASE}/config/wg_confs/client.conf"
+
+				docker run -d \
+				--name=wireguard \
+				--net=lsio \
+				--cap-add=NET_ADMIN \
+				--cap-add=SYS_MODULE `#optional` \
+				-e PUID=1000 \
+				-e PGID=1000 \
+				-e TZ="$(cat /etc/timezone)" \
+				-e SERVERURL=auto \
+				-e SERVERPORT=51820 \
+				-e PEERS="${NUMBER_OF_PEERS}" \
+				-e PEERDNS=auto \
+				-e INTERNAL_SUBNET=10.13.13.0 \
+				-e ALLOWEDIPS=0.0.0.0/0 \
+				-e PERSISTENTKEEPALIVE_PEERS= \
+				-e LOG_CONFS=true \
+				-p 51820:51820/udp \
+				-v "${WIREGUARD_BASE}/config:/config" \
+				--sysctl="net.ipv4.conf.all.src_valid_mark=1" \
+				--restart unless-stopped \
+				lscr.io/linuxserver/wireguard:latest
+				for i in $(seq 1 20); do
+					if docker inspect -f '{{ index .Config.Labels "build_version" }}' wireguard >/dev/null 2>&1 && [[ -f "${WIREGUARD_BASE}/config/wg_confs/wg0.conf" ]]; then
+							break
+					else
+						sleep 3
+					fi
+					if [ $i -eq 20 ] ; then
+						echo -e "\nTimed out waiting for ${title} to start, consult your container logs for more info (\`docker logs wireguard\`)"
+						exit 1
+					fi
+				done
+				${module_options["module_wireguard,feature"]} ${commands[5]}
+			fi
+		;;
+		"${commands[3]}")
+			if srv_active add-vpn-lan-routes; then
+				srv_stop add-vpn-lan-routes.service
+				srv_disable add-vpn-lan-routes.service
+			fi
+			# Run route removal script only if it exists, ignore errors
+			if [[ -f "/usr/local/bin/remove-vpn-lan-routes.sh" ]]; then
+				bash /usr/local/bin/remove-vpn-lan-routes.sh || true
+			fi
+			# Remove files
+			rm -f /usr/local/bin/add-vpn-lan-routes.sh
+			rm -f /usr/local/bin/remove-vpn-lan-routes.sh
+			rm -f /etc/systemd/system/add-vpn-lan-routes.service
 			[[ "${container}" ]] && docker container rm -f "$container" >/dev/null
 			[[ "${image}" ]] && docker image rm "$image" >/dev/null
 		;;
-		"${commands[2]}")
-			${module_options["module_wireguard,feature"]} ${commands[1]}
+		"${commands[4]}")
+			${module_options["module_wireguard,feature"]} ${commands[3]}
 			[[ -n "${WIREGUARD_BASE}" && "${WIREGUARD_BASE}" != "/" ]] && rm -rf "${WIREGUARD_BASE}"
 		;;
-		"${commands[3]}")
+		"${commands[5]}")
 			if [[ -z $2 ]]; then
 				LIST=($(ls -1 ${WIREGUARD_BASE}/config/ | grep peer | cut -d"_" -f2))
 				LIST_LENGTH=$((${#LIST[@]} / 2))
@@ -88,24 +256,47 @@ function module_wireguard () {
 				read
 			fi
 		;;
-		"${commands[4]}")
-			if [[ "${container}" && "${image}" ]]; then
+		"${commands[6]}")
+			local image=$(docker image ls -a | mawk '/wireguard?( |$)/{print $3}')
+			if [[ "${image}" ]]; then
 				return 0
 			else
 				return 1
 			fi
 		;;
-		"${commands[5]}")
+		"${commands[7]}")
+			local container=$(docker container ls -a | mawk '/wireguard?( |$)/{print $1}')
+			if [[ "${container}" ]]; then
+				return 0
+			else
+				return 1
+			fi
+		;;
+		"${commands[8]}")
+			local container=$(docker container ls -a | mawk '/wireguard?( |$)/{print $1}')
+			local image=$(docker image ls -a | mawk '/wireguard?( |$)/{print $3}')
+			if [[ "${container}" && "${image}" && -f "${WIREGUARD_BASE}/config/wg_confs/wg0.conf" ]]; then
+				return 0
+			else
+				return 1
+			fi
+		;;
+		"${commands[9]}")
 			echo -e "\nUsage: ${module_options["module_wireguard,feature"]} <command>"
 			echo -e "Commands:  ${module_options["module_wireguard,example"]}"
 			echo "Available commands:"
-			echo -e "\tinstall\t- Install $title."
-			echo -e "\tstatus\t- Installation status $title."
-			echo -e "\tremove\t- Remove $title."
+			echo -e "\tpull\t\t- Pull $title image."
+			echo -e "\tclient\t\t- Add client config $title."
+			echo -e "\tserver\t\t- Add server config $title."
+			echo -e "\tremove\t\t- Remove $title."
+			echo -e "\tpurge\t\t- Purge $title with data."
+			echo -e "\tqrcode\t\t- Show qrcodes for clients $title."
+			echo -e "\timage\t\t- Image download status $title."
+			echo -e "\tcontainer\t- Container run status $title."
 			echo
 		;;
 		*)
-			${module_options["module_wireguard,feature"]} ${commands[5]}
+			${module_options["module_wireguard,feature"]} ${commands[9]}
 		;;
 	esac
 }


### PR DESCRIPTION
# Description

This PR significantly improves the WireGuard module integration within armbian-config by:

- Introducing client mode support
- Automating local subnet routing via VPN container
- Ensuring routes are persisted across reboots using systemd
- Expanding the documentation for both server and client setup
- Users can paste or edit a WireGuard config directly inside the tool.
- Supports custom LAN subnets to route through the container.
- Systemd unit add-vpn-lan-routes.service ensures these are restored on boot.

# Testing Procedure

- [x] Testing menu and API
- [x] Tested client (Nanopi M6) connected to VPN server. Routing works, connects automatically on reboot.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
