### PR TITLE
Docker installations will fail when /etc/timezone is absent

### DIFF
--- a/tools/modules/functions/set_runtime_variables.sh
+++ b/tools/modules/functions/set_runtime_variables.sh
@@ -51,6 +51,11 @@ function set_runtime_variables() {
 	[[ -f /etc/armbian-release ]] && source /etc/armbian-release && ARMBIAN="Armbian $VERSION $IMAGE_TYPE"
 	[[ -f /etc/armbian-distribution-status ]] && DISTRO_STATUS="/etc/armbian-distribution-status"
 
+	# Docker installatons read timezone and they will fail if this doesn't exist. This is often the case with some minimal Debian/Ubuntu installations.
+	if [[ ! -f /etc/timezone ]]; then
+		echo "America/New_York" | sudo tee /etc/timezone
+	fi
+
 	DISTRO=$(lsb_release -is)
 	DISTROID=$(lsb_release -sc 2> /dev/null || grep "VERSION=" /etc/os-release | grep -oP '(?<=\().*(?=\))')
 	KERNELID=$(uname -r)


### PR DESCRIPTION
# Description

Docker installations read timezone and they will fail if this doesn't …exist. This is often the case with some minimal Debian/Ubuntu installations.

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have ensured that my changes do not introduce new warnings or errors
- [ ] No new external dependencies are included
- [ ] Changes have been tested and verified
- [ ] I have included necessary metadata in the code, including associative arrays
