### PR TITLE
Pi-hole: link with Unbound by default, change default port, bugfixes

### DIFF
--- a/tools/include/markdown/PIH001-footer.md
+++ b/tools/include/markdown/PIH001-footer.md
@@ -3,7 +3,7 @@
     The web interface of Pi-hole can be accessed via:
 
     - URL = `http://<your.IP>/admin`
-    - Password is set and adjust from `armbian-config`
+    - Password is set on install and can be adjusted from `armbian-config`
 
 === "Documentation"
 

--- a/tools/include/markdown/PIH001-header.md
+++ b/tools/include/markdown/PIH001-header.md
@@ -1,13 +1,26 @@
-Pi-hole is a network-wide ad blocker that acts as a DNS (Domain Name System) sinkhole. It works by blocking requests to known ad servers, trackers, and malicious websites across all devices connected to your home network. Here's how it works:
+**Pi-hole** is a network-wide ad blocker that acts as a DNS (Domain Name System) sinkhole. It blocks connections to known ad servers, trackers, and malicious domains across all devices in your network, without requiring any browser extensions or client-side software.
 
-- DNS-Based Filtering: Pi-hole intercepts DNS requests from devices on your network. When a device tries to connect to a website, Pi-hole checks if the website's domain is on a blocklist. If it is, Pi-hole prevents the connection from being made, effectively blocking ads, trackers, and potentially harmful sites.
+## How Pi-hole Works
 
-- Customizable Blocklists: Pi-hole allows you to choose from a variety of community-maintained blocklists or even add your own. These blocklists contain domains known to serve ads, trackers, and other unwanted content.
+- **DNS-Based Filtering**
+Pi-hole intercepts DNS queries made by devices on your network. When a domain is requested, Pi-hole checks it against a set of blocklists. If the domain is known to serve ads or track user activity, Pi-hole blocks the request, preventing unwanted content from loading.
 
-- Device and Network-Level Protection: Once set up, Pi-hole works across your entire network. This means all devices (smartphones, tablets, computers, smart TVs, etc.) that use your Pi-hole as their DNS server automatically benefit from ad-blocking without needing individual apps or browser extensions.
+- **Customizable Blocklists**
+You can choose from various community-maintained blocklists or add your own. These lists contain domains associated with ads, trackers, malware, or other undesirable content.
 
-- Web Interface: Pi-hole offers an intuitive web interface where you can monitor statistics, review blocked domains, and tweak settings like adding custom blocklists or whitelisting certain sites.
+- **Whole-Network Protection**
+Once Pi-hole is configured as your network’s DNS server, all devices - smartphones, laptops, smart TVs, and IoT devices - are automatically protected. No additional configuration or software is required on the individual devices.
 
-- Privacy and Speed: By blocking unwanted content at the DNS level, Pi-hole not only improves browsing speed (since ads are not loaded), but also enhances privacy by preventing tracking scripts from running in the background.
+- **Built-in Recursive DNS with Unbound**
+For added privacy and full DNS resolution control, **Unbound** is installed and enabled by default during Pi-hole installation. Unbound functions as a local recursive DNS resolver, fetching responses directly from authoritative DNS servers rather than relying on upstream providers. This minimizes third-party exposure and can improve query performance.
 
-Pi-hole is typically installed on a Armbian minimal, but it can also run on other systems. It's a great way to have ad-blocking and privacy protection across your entire network without needing to install anything on individual devices.
+- **Web Interface**
+Pi-hole includes a web-based dashboard that provides real-time visibility into DNS activity. The interface allows you to view statistics, manage blocklists, whitelist domains, and configure settings with ease.
+
+- **Privacy and Performance Benefits**
+By blocking unwanted domains at the DNS level, Pi-hole reduces page load times, lowers bandwidth usage, and enhances user privacy by preventing tracking scripts and ads from reaching client devices.
+
+- **Platform Compatibility**
+Pi-hole can be installed on a variety of platforms. It runs well on lightweight systems such as **Armbian Minimal**, but is also available as a Docker container and supports deployment on most Linux-based environments.
+
+Pi-hole offers an effective and centralized way to enhance privacy and reduce unwanted content across your entire network.

--- a/tools/include/markdown/UNB001-footer.md
+++ b/tools/include/markdown/UNB001-footer.md
@@ -1,6 +1,6 @@
 === "Default DNS port"
 
-    - Default DNS port: 53
+    - Default DNS port: 8053
 
 === "Directories"
 

--- a/tools/json/config.software.json
+++ b/tools/json/config.software.json
@@ -252,7 +252,7 @@
                         },
                         {
                             "id": "PIH001",
-                            "description": "Pi-hole DNS ad blocker",
+                            "description": "Pi-hole DNS ad blocker with Unbound support",
                             "short": "Pi-hole",
                             "module": "module_pi_hole",
                             "command": [
@@ -286,7 +286,7 @@
                             "id": "PIH004",
                             "description": "Pi-hole purge with data folder",
                             "command": [
-                                "module_pi_hole remove"
+                                "module_pi_hole purge"
                             ],
                             "status": "Stable",
                             "author": "@armbian",
@@ -318,7 +318,7 @@
                             "id": "UNB003",
                             "description": "Unbound purge with data folder",
                             "command": [
-                                "module_unbound remove"
+                                "module_unbound purge"
                             ],
                             "status": "Stable",
                             "author": "@armbian",

--- a/tools/modules/runtime/config.runtime.sh
+++ b/tools/modules/runtime/config.runtime.sh
@@ -140,7 +140,7 @@ update_sub_submenu_data "Software" "HomeAutomation" "DOM002" "http://$LOCALIPADD
 update_sub_submenu_data "Software" "HomeAutomation" "EVCC02" "http://$LOCALIPADD:${module_options["module_evcc,port"]}"
 
 # DNS
-update_sub_submenu_data "Software" "DNS" "PIH003" "http://$LOCALIPADD:${module_options["module_pi_hole,port"]%% *}" # removing second port from url
+update_sub_submenu_data "Software" "DNS" "PIH003" "http://$LOCALIPADD:${module_options["module_pi_hole,port"]%% *}/admin" # removing second port from url
 update_sub_submenu_data "Software" "DNS" "ADG002" "http://$LOCALIPADD:${module_options["module_adguardhome,port"]%% *}" # removing second port from url
 
 # Monitoring

--- a/tools/modules/software/module_unbound.sh
+++ b/tools/modules/software/module_unbound.sh
@@ -7,7 +7,7 @@ module_options+=(
 	["module_unbound,status"]="Active"
 	["module_unbound,doc_link"]="https://unbound.docs.nlnetlabs.nl/en/latest/"
 	["module_unbound,group"]="DNS"
-	["module_unbound,port"]=""
+	["module_unbound,port"]="8053"
 	["module_unbound,arch"]="x86-64"
 )
 #
@@ -33,8 +33,10 @@ function module_unbound () {
 			[[ -d "$UNBOUND_BASE" ]] || mkdir -p "$UNBOUND_BASE" || { echo "Couldn't create storage directory: $UNBOUND_BASE"; exit 1; }
 			docker run -d \
 			--net=lsio \
-			-p 53:53 \
-			-v "${UNBOUND_BASE}:/opt/unbound/etc/unbound/" \
+			-e PUID=1000 \
+			-e PGID=1000 \
+			-p ${module_options["module_unbound,port"]}:53/tcp \
+			-p ${module_options["module_unbound,port"]}:53/udp \
 			--name unbound \
 			--restart=unless-stopped \
 			mvance/unbound:latest


### PR DESCRIPTION
# Description

- change Unbound external port to 8053
- fix password set on Pi-hole
- ask for password after installation
- install and use Unbound with Pi-hole by default
- improve Pi-hole documentation
- purge of Unbound and Pi-hole were not removing folders
- set link to webadmin from armbian-config
- move default web port of Pi-hole from 80 to 8811

# Testing Procedure

- [x] Installed and tested on Armbian Ubuntu

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
