### PR TITLE
I observed the wave function collapsing into a string to break the event horizon, and wished it away before it could

### DIFF
--- a/tools/modules/software/module_jellyfin.sh
+++ b/tools/modules/software/module_jellyfin.sh
@@ -47,7 +47,8 @@ function module_jellyfin () {
 			[[ -d "$JELLYFIN_BASE" ]] || mkdir -p "$JELLYFIN_BASE" || { echo "Couldn't create storage directory: $JELLYFIN_BASE"; exit 1; }
 			docker run -d \
 			--name=jellyfin \
-			--net=lsio "${hwacc}" \
+			--net=lsio \
+   			${hwacc} \
 			-e PUID=1000 \
 			-e PGID=1000 \
 			-e TZ="$(cat /etc/timezone)" \


### PR DESCRIPTION
It started - innocently - as an effort to run Jellyfin with armbian-config on a ROCK 5C Lite.

I thought, "Oh, I know... I'll use Portainer to check what went wrong. Look, it's just there... waiting to be installed, and that's it!"

A reasonable pursuit.... and deceptively convenient-looking one as well!

But Portainer, you see, has rules. Rules like “[thou shalt NOT have a password shorter than the palm of your hand](https://github.com/portainer/portainer/issues/6904)”, even when you just want to test something on a single-board computer in the corner of your desk, surrounded by grunts, coffee and passive-cooled heat sinks.

So I invented a password. It was… expressive. It spoke of the way I felt about the portainer developers, and the world where holding your users hostage, and making them bend their knees is allowed and encouraged. But later, forgot exactly what it said (cause my expression about this particular condition gets richer over time).

But Portainer has no sense of heuristics... it wanted to be insulted _just the exact same way_ as before.

"Fine. I’ll start over", I said to myself.

I deleted the container. The image. The volume. I purge it the way armbian gods intended, and also the way I saw it fit... But Portainer clings to the past, remembering, that I had once insulted it, and it liked it very much.

"Is there no way to get the initial setup screen back, ChatGPT?" I ask into the void. The void responds - as an agent of free will - with many options; and as an agent of free will myself, I chose to ignore them all to look for the source code. I [found it](https://github.com/armbian/config), and it said the princess is in [another castle](https://github.com/armbian/configng).

I'll spare you the details of how I found out what's the script that's being run and how is it all working, cause I'd like to be succinct and on point, and wouldn't want to waste your time listening to me meander around a rant as an artform. But in short, I discovered that the `/armbian/portainer/data` is silently guarding `portainer.db` like a horcrux which I hadn't been dealing with in my past ventures.

I delete it. Redemption. The setup screen returns. I win.

But this isn’t about Portainer.

You see, it all began because Jellyfin wouldn’t start.

```
docker: invalid reference format.
```

Cryptic. Cold. A Dockerism, dropped without empathy.

So I dove into armbian-config, even deeper this time, expecting scripts, but found an ecosystem. I wandered its directory structure like a monk through cybernetic catacombs. I went after the sniff of `$SOFTWARE_FOLDER`, and found it was `/armbian`. I found modules speaking in associative arrays and case statements. Interrogated `lscr.io` image reference, instead of the official image, as the usual suspect. I whispered to them, "let me in".

And then I found it.

```
--net=lsio "${hwacc}"
```

Like a noose of quotes around a once-beautiful, many-parted string.

The `--device` flags, meant to be many, were collapsed into one.

Docker wept. It tried to interpret the whole thing as a single image name - and failed.

So I unwrapped the string. Gently. With the respect due to a multi-line Bash incantation passed through too many interpreters. I split it, honored its multiplicity, and passed each flag as its own again. It's the least I could do, after what we've all been through.

This isn't just a fix. It's a story of a string that lost itself, and a user who followed it down into the underworld of container orchestration and came back... changed. Enlightened. Slightly deranged, but mostly content to have found the bug and still have enough sanity left to send a fix back up to the pleroma.

The logs are quiet now. Jellyfin runs. Portainer obeys.

And for a brief moment in the ever-looping churn of tech entropy... a twig unbroke.