### PR TITLE
Add gpg as armbian-config package dependency

### DIFF
--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -22,7 +22,7 @@ jobs:
       section: "default"
       priority: "optional"
       compile: "tools/config-assemble.sh -p"
-      depends: "bash, jq, whiptail, sudo, procps, systemd, lsb-release, iproute2, debconf, libtext-iconv-perl"
+      depends: "bash, jq, whiptail, sudo, procps, systemd, lsb-release, iproute2, debconf, libtext-iconv-perl, gpg"
       description: "Armbian config: The Next Generation"
 
     secrets:


### PR DESCRIPTION
# Description

We need this at once when installing Docker, while minimal image could come without.

@leggewie 

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
