### PR TITLE
Use systemd function and not wrapped on

### DIFF
--- a/tools/modules/software/module_haos.sh
+++ b/tools/modules/software/module_haos.sh
@@ -59,7 +59,7 @@ function module_haos() {
 			while true; do
 			if ha supervisor info 2>&1 | grep -q "healthy: false"; then
 				echo "Unhealthy detected, restarting" | systemd-cat -t $(basename "$0") -p debug
-				srv_restart hassio-supervisor
+				systemctl restart hassio-supervisor
 				sleep 600
 			else
 				sleep 5


### PR DESCRIPTION
# Description

On the host machine we need to use systemd service commands, not wrapped from armbian-config as they are not present.

# Testing Procedure

- [x] Manual test

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
