### PR TITLE
Home Assistant: Expand requirement to whole Debian

### DIFF
--- a/tools/json/config.software.json
+++ b/tools/json/config.software.json
@@ -1363,7 +1363,7 @@
                             ],
                             "status": "Preview",
                             "author": "@igorpecovnik",
-                            "condition": "! module_haos status && grep -q bookworm /etc/os-release"
+                            "condition": "! module_haos status && grep -q Debian /etc/os-release"
                         },
                         {
                             "id": "HAS002",


### PR DESCRIPTION
# Description

Both Trixie and Bookworm are working while other variants (sid / bullseye) are anyway not supported, while they still might work.

# Testing Procedure

- [x] Test install on Debian Trixie

# Checklist

- [x] Changes have been tested and verified
