### PR TITLE
fix(hwacc): use correct flag for RKMPP detection

### DIFF
--- a/tools/modules/software/module_jellyfin.sh
+++ b/tools/modules/software/module_jellyfin.sh
@@ -24,7 +24,7 @@ function module_jellyfin () {
 
 	# Hardware acceleration
 	unset hwacc
-	if [[ "${LINUXFAMILY}" == "rockchip64" && "${BOOT_SOC}" == "rk3588" ]]; then
+	if [[ "${LINUXFAMILY}" == "rk35xx" && "${BOOT_SOC}" == "rk3588" ]]; then
 		for dev in dri dma_heap mali0 rga mpp_service \
 			iep mpp-service vpu_service vpu-service \
 			hevc_service hevc-service rkvdec rkvenc vepu h265e ; do \


### PR DESCRIPTION
The prior flag `"${LINUXFAMILY}" == "rockchip64"` was returning `false` as the actual value was set to `rk35xx` (tested on ROCK 5T, Noble 25.8.1 Minimal), resulting in no access to hardware acceleration from within the container.

Wasn't affecting direct playback, but using any kind of transcoding were resulting in playback error in the Jellyfin clients, and `ffmpeg` error 187 in the container logs.

This change makes sure the hardware are exposed to the container.

N.B: the script still has [permission issues](https://jellyfin.org/docs/general/post-install/transcoding/hardware-acceleration/rockchip#configure-on-linux-host) (because of `udev` rules not being set). That means, without fixing that, the hardware access is still limited. Will send a separate PR to address the permissions... as these two issues are not entangled, and can be addressed separately.