### PR TITLE
Introduce armbian-config config file to store app wide variables

### DIFF
--- a/tools/modules/functions/set_runtime_variables.sh
+++ b/tools/modules/functions/set_runtime_variables.sh
@@ -40,6 +40,11 @@ function set_runtime_variables() {
 	DIALOG_CANCEL=1
 	DIALOG_ESC=255
 
+	# use armbian-config configuration file
+	CONFIG_FILE="/etc/armbian-config"
+	touch "$CONFIG_FILE"
+	[[ -f /etc/armbian-config ]] && source "$CONFIG_FILE"
+
 	# we have our own lsb_release which does not use Python. Others shell install it here
 	if [[ ! -f /usr/bin/lsb_release ]]; then
 		if is_package_manager_running; then
@@ -112,4 +117,25 @@ function update_kernel_env() {
 		fi
 	fi
 	BRANCH=$new_branch
+}
+
+# Function to set or update a variable
+#
+# Example of usage:
+#
+# set_config_var "DOMAIN" "www.test.org" "$CONFIG_FILE"
+# set_config_var "STORAGE" "/armbian" "$CONFIG_FILE"
+#
+set_config_var() {
+    local key="$1"
+    local value="$2"
+    local file="$3"
+
+    if grep -qE "^${key}=" "$file"; then
+        # Update existing key
+        sed -i "s|^${key}=.*|${key}=${value}|" "$file"
+    else
+        # Append new key
+        echo "${key}=${value}" >> "$file"
+    fi
 }

--- a/tools/modules/software/module_swag.sh
+++ b/tools/modules/software/module_swag.sh
@@ -27,13 +27,15 @@ function module_swag() {
 
 	case "$1" in
 		"${commands[0]}")
-			SWAG_URL=$(dialog --title \
+			SWAG_URL=$($DIALOG --title \
 			"Secure Web Application Gateway URL?" \
 			--inputbox "\nExamples: myhome.domain.org (port 80 and 443 must be exposed to internet)" \
-			8 80 "" 3>&1 1>&2 2>&3);
+			8 80 "${DOMAIN}" 3>&1 1>&2 2>&3);
 
 			if [[ ${SWAG_URL} && $? -eq 0 ]]; then
 
+				# save to configuration file
+				set_config_var "DOMAIN" "${SWAG_URL}" "$CONFIG_FILE"
 				# adjust hostname
 				hostnamectl set-hostname $(echo ${SWAG_URL} | sed -E 's/^\s*.*:\/\///g')
 				# install docker


### PR DESCRIPTION
# Description

Purpose of this configuration file is to have a storage for common app wide variables such as DOMAIN name used in SWAG reverse proxy. If domain is enabled, URL to apps is changed from IP to domain name with https enabled.

# Implementation Details

Storing variables in `/etc/armbian-config`

# Testing Procedure

- [x] Store and read while installing SWAG

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified