### PR TITLE
Create init_args.sh for environment variable setup

### DIFF
--- a/tools/modules/initialize/init_args.sh
+++ b/tools/modules/initialize/init_args.sh
@@ -42,9 +42,6 @@ _init_vars_main() {
 	# shellcheck disable=SC1091
 	[[ -r "$OS_RELEASE" ]] && source "$OS_RELEASE" || true
 
-	# Read version from file if available (overrides hardcoded version)
-	[[ -f "${PROJECT_ROOT}/VERSION" ]] && PROJECT_VERSION="$(cat "${PROJECT_ROOT}/VERSION")"
-
 	# ==== TUI VARIABLES ====
 	BACKTITLE="${BACKTITLE:-"Contribute: https://github.com/${PROJECT_NAME}"}"
 	TITLE="${TITLE:-"${VENDOR:-${PROJECT_NAME}} configuration utility"}"


### PR DESCRIPTION
Add init_args.sh for initializing environment variables and system info.

# Description

Issue reference:   https://github.com/armbian/configng/pull/665#issuecomment-3225862673

@coderabbitai
