### PR TITLE
Fix, improve and enable distribution upgrade routines

### DIFF
--- a/tools/include/markdown/LTSREL-header.md
+++ b/tools/include/markdown/LTSREL-header.md
@@ -1,0 +1,5 @@
+Long-Term Support (LTS) upgrades provide a **well-tested and stable release** of the underlying Linux distribution (Debian or Ubuntu). These versions receive **security patches and critical bug fixes** for an extended period, making them the recommended choice for production systems and users who prioritize stability over new features.
+
+!!! Note
+
+    While LTS upgrades are considered safe, always back up your data before proceeding with a distribution upgrade.

--- a/tools/include/markdown/ROLREL-header.md
+++ b/tools/include/markdown/ROLREL-header.md
@@ -1,0 +1,7 @@
+Testing upgrades track the **latest distribution releases** that are not yet fully stabilized. They include **new features, packages, and improvements**, but may also introduce regressions or breaking changes. This option is best suited for **developers, testers, and enthusiasts** who want early access and are willing to troubleshoot issues. 
+
+!! Warning
+
+    Testing upgrades may cause system instability. Avoid using this option on production devices. Always back up important data before upgrading.  
+
+

--- a/tools/json/config.system.json
+++ b/tools/json/config.system.json
@@ -535,24 +535,26 @@
                             "condition": "module_armbian_firmware repository rolling status"
                         },
                         {
-                            "id": "UPD005",
+                            "id": "LTSREL",
                             "description": "Distribution upgrade to latest stable / LTS",
+                            "short": "Stable LTS Distribution Upgrade",
                             "about": "Release upgrade is irriversible operation which upgrades all packages. \n\nResoulted upgrade might break your build beyond repair!",
                             "command": [
                                 "release_upgrade stable"
                             ],
-                            "status": "Disabled",
+                            "status": "Stable",
                             "author": "@igorpecovnik",
                             "condition": "[ -f /etc/armbian-distribution-status ] && release_upgrade stable verify"
                         },
                         {
-                            "id": "UPD006",
+                            "id": "ROLREL",
                             "description": "Distribution upgrade to rolling unstable",
+                            "short": "Unstable Testing Distribution Upgrade",
                             "about": "Release upgrade is irriversible operation which upgrades all packages. \n\nResoulted upgrade might break your build beyond repair!",
                             "command": [
                                 "release_upgrade rolling"
                             ],
-                            "status": "Disabled",
+                            "status": "Stable",
                             "author": "@igorpecovnik",
                             "condition": "[ -f /etc/armbian-distribution-status ] && release_upgrade rolling verify"
                         },

--- a/tools/modules/functions/package.sh
+++ b/tools/modules/functions/package.sh
@@ -95,3 +95,16 @@ pkg_upgrade()
 {
 	_pkg_have_stdin && debconf-apt-progress -- apt-get -y upgrade "$@" || apt-get -y upgrade "$@"
 }
+
+module_options+=(
+	["pkg_fix,author"]="@igorpecovnik"
+	["pkg_fix,desc"]="Fix dependency issues"
+	["pkg_fix,example"]="pkg_fix"
+	["pkg_fix,feature"]="pkg_fix"
+	["pkg_fix,status"]="Interface"
+)
+
+pkg_fix()
+{
+	_pkg_have_stdin && debconf-apt-progress -- apt-get -y --fix-broken install "$@" || apt-get -y --fix-broken install "$@"
+}

--- a/tools/modules/system/release_upgrade.sh
+++ b/tools/modules/system/release_upgrade.sh
@@ -43,11 +43,12 @@ release_upgrade(){
 		[[ -f /etc/apt/sources.list.d/armbian.sources ]] && sed -i "s/$distroid/$upgrade/g" /etc/apt/sources.list.d/armbian.sources
 		[[ -f /etc/apt/sources.list.d/armbian.list ]] && sed -i "s/$distroid/$upgrade/g" /etc/apt/sources.list.d/armbian.list
 		pkg_update
-		pkg_upgrade -o Dpkg::Options::="--force-confold" --without-new-pkgs || return 1
-		pkg_fix || return 1
-		pkg_full_upgrade -o Dpkg::Options::="--force-confold" || return 1
-		pkg_fix || return 1
-		pkg_full_upgrade -o Dpkg::Options::="--force-confold" || return 1
+		pkg_upgrade -o Dpkg::Options::="--force-confold" --without-new-pkgs
+		pkg_fix || return 1 # Hacks for Ubuntu
+		pkg_full_upgrade -o Dpkg::Options::="--force-confold"
+		pkg_fix || return 1 # Hacks for Ubuntu
+		pkg_full_upgrade -o Dpkg::Options::="--force-confold"
+		pkg_fix || return 1 # Hacks for Ubuntu
 		pkg_remove # remove all auto-installed packages
 	fi
 }

--- a/tools/modules/system/release_upgrade.sh
+++ b/tools/modules/system/release_upgrade.sh
@@ -43,11 +43,11 @@ release_upgrade(){
 		[[ -f /etc/apt/sources.list.d/armbian.sources ]] && sed -i "s/$distroid/$upgrade/g" /etc/apt/sources.list.d/armbian.sources
 		[[ -f /etc/apt/sources.list.d/armbian.list ]] && sed -i "s/$distroid/$upgrade/g" /etc/apt/sources.list.d/armbian.list
 		pkg_update
-		pkg_upgrade -o Dpkg::Options::="--force-confold" --without-new-pkgs
-		pkg_fix
-		pkg_full_upgrade -o Dpkg::Options::="--force-confold"
-		pkg_fix
-		pkg_full_upgrade -o Dpkg::Options::="--force-confold"
+		pkg_upgrade -o Dpkg::Options::="--force-confold" --without-new-pkgs || return 1
+		pkg_fix || return 1
+		pkg_full_upgrade -o Dpkg::Options::="--force-confold" || return 1
+		pkg_fix || return 1
+		pkg_full_upgrade -o Dpkg::Options::="--force-confold" || return 1
 		pkg_remove # remove all auto-installed packages
 	fi
 }


### PR DESCRIPTION
# Description

Enable release upgrades from armbian-config

Issue reference:  https://github.com/armbian/build/pull/8569

# Testing Procedure

- [x] Upgrade from Debian Bookworm to Trixie
- [x] Upgrade from Jammy, Noble, Plucky 
- [x] Upgrade from Debian Bullseye to Trixie (problem is missing key)

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
