### PR TITLE
Ghost: use latest version v6

### DIFF
--- a/tools/modules/software/module_ghost.sh
+++ b/tools/modules/software/module_ghost.sh
@@ -58,7 +58,7 @@ function module_ghost () {
 			-p ${module_options["module_ghost,port"]}:2368 \
 			-e url=http://$LOCALIPADD:${module_options["module_ghost,port"]} \
 			-v "$GHOST_BASE:/var/lib/ghost/content" \
-			ghost:5-alpine
+			ghost:6
 		;;
 	"${commands[1]}")
 			if pkg_installed docker-ce; then


### PR DESCRIPTION
# Description

There are some troubles with v5 - let's use v6 instead.

# Implementation Details

Docker version change, dependencies are ok.

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have ensured that my changes do not introduce new warnings or errors
- [ ] No new external dependencies are included
- [ ] Changes have been tested and verified
- [ ] I have included necessary metadata in the code, including associative arrays
