### PR TITLE
Change database name from 'armbian' to 'netbox'

### DIFF
--- a/tools/modules/software/module_netbox.sh
+++ b/tools/modules/software/module_netbox.sh
@@ -63,7 +63,7 @@ function module_netbox () {
 				cat > "$NETBOX_BASE/config/configuration.py" <<- EOT
 				ALLOWED_HOSTS = ['*']
 				DATABASE = {
-					'NAME': 'armbian',
+					'NAME': 'netbox',
 					'USER': 'armbian',
 					'PASSWORD': 'armbian',
 					'HOST': 'postgres',


### PR DESCRIPTION
# Description

When generating database for `netbox`, name it `netbox` not `armbian`.

# Checklist

- [x] My code follows the style guidelines of this project