### PR TITLE
Fix dialog typo

### DIFF
--- a/tools/modules/system/change_system_hostname.sh
+++ b/tools/modules/system/change_system_hostname.sh
@@ -10,7 +10,7 @@ module_options+=(
 # @description Change system hostname
 #
 function change_system_hostname() {
-	local new_hostname=$($DIALOG --title "Enter new hostnane" --inputbox "" 7 50 3>&1 1>&2 2>&3)
+	local new_hostname=$($DIALOG --title "Enter new hostname" --inputbox "" 7 50 3>&1 1>&2 2>&3)
 	[ $? -eq 0 ] && [ -n "${new_hostname}" ] && hostnamectl set-hostname "${new_hostname}"
 }
 


### PR DESCRIPTION
# Description

Just a small change to fix a typo in the "Change System Hostname" dialog ("hostnane" to "hostname").

Issue reference: None
Related documentation: Not needed 

# Implementation Details

Typo fix from "hostnane" to "hostname".

# Documentation Summary

N/A

# Testing Procedure

Not needed

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
- [x] I have included necessary metadata in the code, including associative arrays
