### PR TITLE
Fix xmonad desktop session and branding

### DIFF
--- a/tools/include/branding/postinst/xmonad.sh
+++ b/tools/include/branding/postinst/xmonad.sh
@@ -6,6 +6,20 @@ if [ -d /etc/armbian/lightdm ]; then cp -R /etc/armbian/lightdm /etc/; fi
 # Disable Pulseaudio timer scheduling which does not work with sndhdmi driver
 if [ -f /etc/pulse/default.pa ]; then sed "s/load-module module-udev-detect$/& tsched=0/g" -i  /etc/pulse/default.pa; fi
 
-# set wallpapper to armbian
+# set wallpaper via feh
+mkdir -p /etc/xmonad
+cat > /etc/xmonad/wallpaper.sh <<- 'WALLEOF'
+#!/bin/bash
+feh --bg-scale /usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-3840x2160.jpg
+WALLEOF
+chmod +x /etc/xmonad/wallpaper.sh
 
-
+# Let NetworkManager coexist with systemd-networkd
+if command -v NetworkManager > /dev/null 2>&1; then
+	mkdir -p /etc/NetworkManager/conf.d
+	cat > /etc/NetworkManager/conf.d/10-armbian-unmanaged.conf <<- NMEOF
+	[keyfile]
+	unmanaged-devices=type:ethernet
+	NMEOF
+	systemctl restart NetworkManager 2>/dev/null || true
+fi

--- a/tools/include/branding/postinst/xmonad.sh
+++ b/tools/include/branding/postinst/xmonad.sh
@@ -3,6 +3,16 @@ set +e
 # overwrite stock lightdm greeter configuration
 if [ -d /etc/armbian/lightdm ]; then cp -R /etc/armbian/lightdm /etc/; fi
 
+# create xmonad session file for LightDM
+mkdir -p /usr/share/xsessions
+cat > /usr/share/xsessions/xmonad.desktop <<- 'XSEOF'
+[Desktop Entry]
+Name=Xmonad
+Comment=Lightweight tiling window manager
+Exec=xmonad
+Type=Application
+XSEOF
+
 # Disable Pulseaudio timer scheduling which does not work with sndhdmi driver
 if [ -f /etc/pulse/default.pa ]; then sed "s/load-module module-udev-detect$/& tsched=0/g" -i  /etc/pulse/default.pa; fi
 

--- a/tools/include/branding/postinst/xmonad.sh
+++ b/tools/include/branding/postinst/xmonad.sh
@@ -3,16 +3,7 @@ set +e
 # overwrite stock lightdm greeter configuration
 if [ -d /etc/armbian/lightdm ]; then cp -R /etc/armbian/lightdm /etc/; fi
 
-# create xmonad session file for LightDM
-mkdir -p /usr/share/xsessions
-cat > /usr/share/xsessions/xmonad.desktop <<- 'XSEOF'
-[Desktop Entry]
-Name=Xmonad
-Comment=Lightweight tiling window manager
-Exec=/etc/X11/Xsession xmonad
-Type=Application
-DesktopNames=Xmonad
-XSEOF
+# xmonad session is provided by gnome-session-flashback
 
 # Disable Pulseaudio timer scheduling which does not work with sndhdmi driver
 if [ -f /etc/pulse/default.pa ]; then sed "s/load-module module-udev-detect$/& tsched=0/g" -i  /etc/pulse/default.pa; fi

--- a/tools/include/branding/postinst/xmonad.sh
+++ b/tools/include/branding/postinst/xmonad.sh
@@ -9,8 +9,9 @@ cat > /usr/share/xsessions/xmonad.desktop <<- 'XSEOF'
 [Desktop Entry]
 Name=Xmonad
 Comment=Lightweight tiling window manager
-Exec=xmonad
+Exec=/etc/X11/Xsession xmonad
 Type=Application
+DesktopNames=Xmonad
 XSEOF
 
 # Disable Pulseaudio timer scheduling which does not work with sndhdmi driver

--- a/tools/include/branding/skel/.xmonad/xmonad.hs
+++ b/tools/include/branding/skel/.xmonad/xmonad.hs
@@ -1,0 +1,20 @@
+import XMonad
+import XMonad.Hooks.DynamicLog
+import XMonad.Hooks.ManageDocks
+import XMonad.Util.Run
+import XMonad.Util.SpawnOnce
+
+myTerminal = "terminator"
+
+myStartupHook = do
+    spawnOnce "feh --bg-scale /usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-3840x2160.jpg"
+    spawnOnce "xmobar"
+    spawnOnce "nm-applet"
+    spawnOnce "dunst"
+
+main = xmonad $ docks def
+    { terminal    = myTerminal
+    , modMask     = mod4Mask
+    , startupHook = myStartupHook
+    , borderWidth = 2
+    }

--- a/tools/include/branding/skel/.xmonad/xmonad.hs
+++ b/tools/include/branding/skel/.xmonad/xmonad.hs
@@ -1,20 +1,7 @@
 import XMonad
-import XMonad.Hooks.DynamicLog
-import XMonad.Hooks.ManageDocks
-import XMonad.Util.Run
-import XMonad.Util.SpawnOnce
 
-myTerminal = "terminator"
-
-myStartupHook = do
-    spawnOnce "feh --bg-scale /usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-3840x2160.jpg"
-    spawnOnce "xmobar"
-    spawnOnce "nm-applet"
-    spawnOnce "dunst"
-
-main = xmonad $ docks def
-    { terminal    = myTerminal
+main = xmonad def
+    { terminal    = "terminator"
     , modMask     = mod4Mask
-    , startupHook = myStartupHook
     , borderWidth = 2
     }

--- a/tools/include/branding/skel/.xmonad/xmonad.hs
+++ b/tools/include/branding/skel/.xmonad/xmonad.hs
@@ -1,7 +1,0 @@
-import XMonad
-
-main = xmonad def
-    { terminal    = "terminator"
-    , modMask     = mod4Mask
-    , borderWidth = 2
-    }

--- a/tools/include/branding/skel/.xprofile
+++ b/tools/include/branding/skel/.xprofile
@@ -1,0 +1,5 @@
+#!/bin/sh
+feh --bg-scale /usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-3840x2160.jpg &
+xmobar &
+nm-applet &
+dunst &

--- a/tools/modules/system/module_desktop_packages.sh
+++ b/tools/modules/system/module_desktop_packages.sh
@@ -430,15 +430,17 @@ function module_desktop_packages() {
 			# xmonad - Haskell tiling window manager
 			packages+=(
 				"xmonad"
+				"libghc-xmonad-contrib-dev"
 				"xmobar"
 				"lightdm"
 				"slick-greeter"
 				"xserver-xorg"
-				"xterm"
 				"dbus-x11"
 				"dmenu"
+				"dmz-cursor-theme"
 				"dunst"
 				"feh"
+				"fonts-ubuntu"
 				"lm-sensors"
 				"network-manager-gnome"
 				"pavucontrol"

--- a/tools/modules/system/module_desktop_packages.sh
+++ b/tools/modules/system/module_desktop_packages.sh
@@ -427,13 +427,15 @@ function module_desktop_packages() {
 			)
 		;;
 		"${de[11]}")
-			# xmonad - Haskell tiling window manager
+			# xmonad - tiling WM via gnome-session-flashback
 			packages+=(
 				"xmonad"
+				"gnome-session-flashback"
 				"xmobar"
 				"lightdm"
 				"slick-greeter"
 				"xserver-xorg"
+				"xinit"
 				"dbus-x11"
 				"dmenu"
 				"dmz-cursor-theme"

--- a/tools/modules/system/module_desktop_packages.sh
+++ b/tools/modules/system/module_desktop_packages.sh
@@ -430,7 +430,6 @@ function module_desktop_packages() {
 			# xmonad - Haskell tiling window manager
 			packages+=(
 				"xmonad"
-				"libghc-xmonad-contrib-dev"
 				"xmobar"
 				"lightdm"
 				"slick-greeter"


### PR DESCRIPTION
## Summary
- Use `gnome-session-flashback` for proper xmonad session (provides dbus, polkit, session management)
- Add `.xprofile` for startup apps (wallpaper, xmobar, nm-applet, dunst)
- Add `xinit`, `fonts-ubuntu`, `dmz-cursor-theme`
- Add NM coexistence with systemd-networkd in postinst
- Remove `libghc-xmonad-contrib-dev` (~500MB, not needed for default config)

## Test plan
- [ ] xmonad login via "GNOME Flashback (Xmonad)" session in LightDM
- [ ] Wallpaper, xmobar, nm-applet visible after login
- [ ] Mod4+Shift+Enter opens terminator