### PR TITLE
desktops: ship YAML/parser/branding assets in the .deb

### DIFF
--- a/bin/armbian-config
+++ b/bin/armbian-config
@@ -40,6 +40,16 @@ lib_dir="$script_dir/../lib/armbian-config"
 doc_dir="$script_dir/../share/doc/armbian-config"
 json_file="$lib_dir/config.jobs.json"
 
+# Desktop module resources (yaml definitions, parser, branding, greeters, skel, postinst).
+# In a source checkout these live under tools/; the .deb installs them under
+# /usr/share/armbian-config/desktops/ (see debian.conf).
+if [[ -d "$script_dir/../tools/modules/desktops" ]]; then
+	desktops_dir="$script_dir/../tools/modules/desktops"
+else
+	desktops_dir="/usr/share/armbian-config/desktops"
+fi
+export desktops_dir
+
 #
 # Load The Bash procedure Objects
 json_data=$(<"$json_file")

--- a/debian.conf
+++ b/debian.conf
@@ -1,4 +1,5 @@
 lib:/usr/
 bin:/usr/
 share:/usr/
+tools/modules/desktops:/usr/share/armbian-config/
 tools/repository/armbian-config.sources:/etc/apt/sources.list.d/

--- a/tools/modules/desktops/module_desktop_branding.sh
+++ b/tools/modules/desktops/module_desktop_branding.sh
@@ -13,7 +13,7 @@ module_options+=(
 #
 function module_desktop_branding() {
 	local de="$1"
-	local desktop_dir="${script_dir}/../tools/modules/desktops"
+	local desktop_dir="${desktops_dir}"
 
 	case "$de" in
 		help|"")

--- a/tools/modules/desktops/module_desktop_yamlparse.sh
+++ b/tools/modules/desktops/module_desktop_yamlparse.sh
@@ -16,8 +16,8 @@ module_options+=(
 #
 function module_desktop_yamlparse() {
 	local de="$1"
-	local yaml_dir="${script_dir}/../tools/modules/desktops/yaml"
-	local parser="${script_dir}/../tools/modules/desktops/scripts/parse_desktop_yaml.py"
+	local yaml_dir="${desktops_dir}/yaml"
+	local parser="${desktops_dir}/scripts/parse_desktop_yaml.py"
 	local arch="${2:-$(dpkg --print-architecture)}"
 	local release="${3:-$DISTROID}"
 
@@ -68,8 +68,8 @@ function module_desktop_yamlparse() {
 # Usage: module_desktop_yamlparse_list [arch] [release]
 #
 function module_desktop_yamlparse_list() {
-	local yaml_dir="${script_dir}/../tools/modules/desktops/yaml"
-	local parser="${script_dir}/../tools/modules/desktops/scripts/parse_desktop_yaml.py"
+	local yaml_dir="${desktops_dir}/yaml"
+	local parser="${desktops_dir}/scripts/parse_desktop_yaml.py"
 	local arch="${1:-$(dpkg --print-architecture)}"
 	local release="${2:-$DISTROID}"
 

--- a/tools/modules/desktops/module_desktops.sh
+++ b/tools/modules/desktops/module_desktops.sh
@@ -259,8 +259,8 @@ function module_desktops() {
 			local use_release="${query_release:-$DISTROID}"
 
 			if [[ -z "$de" ]]; then
-				local yaml_dir="${script_dir}/../tools/modules/desktops/yaml"
-				local parser="${script_dir}/../tools/modules/desktops/scripts/parse_desktop_yaml.py"
+				local yaml_dir="${desktops_dir}/yaml"
+				local parser="${desktops_dir}/scripts/parse_desktop_yaml.py"
 				local result
 				result=$(python3 "$parser" "$yaml_dir" "--list-json" "$use_release" "$use_arch")
 				echo "$result"
@@ -282,8 +282,8 @@ function module_desktops() {
 				[[ "$_DESKTOPS_INSTALLED_CACHE" == "yes" ]]
 				return $?
 			fi
-			local yaml_dir="${script_dir}/../tools/modules/desktops/yaml"
-			local parser="${script_dir}/../tools/modules/desktops/scripts/parse_desktop_yaml.py"
+			local yaml_dir="${desktops_dir}/yaml"
+			local parser="${desktops_dir}/scripts/parse_desktop_yaml.py"
 			local primaries pkgs
 			primaries=$(python3 "$parser" "$yaml_dir" --primaries "$DISTROID" "$(dpkg --print-architecture)" 2>/dev/null) || {
 				_DESKTOPS_INSTALLED_CACHE=no


### PR DESCRIPTION
## Summary
Fixes a fresh-install regression introduced by the YAML-driven desktop refactor (c0b5f9ca). Opening *Software → Desktop* on a freshly installed `armbian-config` produces:

\`\`\`
Error: YAML parser not found at /usr/bin/../tools/modules/desktops/scripts/parse_desktop_yaml.py
\`\`\`

## Root cause
The refactor placed \`parse_desktop_yaml.py\`, the desktop YAML definitions, and the branding/greeters/skel/postinst assets under \`tools/modules/desktops/\`. \`debian.conf\` only ships \`lib/\`, \`bin/\`, and \`share/\`, so \`tools/\` does not exist on installed systems. The modules built paths as \`\${script_dir}/../tools/modules/desktops/...\` which resolves to \`/usr/tools/...\` after install — nothing there.

The same code path silently breaks desktop branding, greeter configs, skel, and postinst hooks on installed systems too; this PR fixes all of them, not just the parser.

## Changes
- \`debian.conf\`: install \`tools/modules/desktops\` to \`/usr/share/armbian-config/desktops/\`.
- \`bin/armbian-config\`: introduce a \`desktops_dir\` global that prefers the in-repo \`tools/modules/desktops\` for development checkouts and falls back to \`/usr/share/armbian-config/desktops\` when installed.
- \`tools/modules/desktops/module_desktop_yamlparse.sh\`, \`module_desktops.sh\`, \`module_desktop_branding.sh\`: switch all path references to \`\${desktops_dir}\`.

## Test plan
- [ ] On a fresh install of the rebuilt .deb, open Software → Desktop and confirm the desktop list loads.
- [ ] Run \`armbian-config --api module_desktop_yamlparse_list\` and confirm it prints the desktop matrix.
- [ ] Install one desktop (e.g. \`xfce\`) and confirm branding assets land in \`/usr/share/backgrounds/armbian/\` etc.
- [ ] In a source checkout, run \`bash bin/armbian-config\` and confirm the same flows still work (dev path).