### PR TITLE
initialize: add script-wide debug_log and --debug flag

### DIFF
--- a/bin/armbian-config
+++ b/bin/armbian-config
@@ -6,7 +6,44 @@ unset UXMODE
 # allows CTRL c to exit
 trap "exit" INT TERM
 
-[[ $EUID != 0 ]] && exec sudo "$0" "$@"
+# --debug[=level|=path|=level:path]: turn on script-wide debug logging
+# Examples:
+#   armbian-config --debug              # DEBUG=1, default log file
+#   armbian-config --debug=2             # DEBUG=2 (also captures set -x)
+#   armbian-config --debug=/tmp/my.log   # DEBUG=1, custom log file
+#   armbian-config --debug=2:/tmp/my.log # both
+# Strips the flag out of "$@" before the rest of the script sees it.
+_parse_debug_flag() {
+	local arg new_args=()
+	for arg in "$@"; do
+		case "$arg" in
+			--debug)
+				DEBUG=1
+				;;
+			--debug=*)
+				local v="${arg#--debug=}"
+				if [[ "$v" == *:* ]]; then
+					DEBUG="${v%%:*}"
+					DEBUG_LOG="${v#*:}"
+				elif [[ "$v" =~ ^[0-9]+$ ]]; then
+					DEBUG="$v"
+				else
+					DEBUG=1
+					DEBUG_LOG="$v"
+				fi
+				;;
+			*)
+				new_args+=("$arg")
+				;;
+		esac
+	done
+	export DEBUG DEBUG_LOG
+	_debug_argv=("${new_args[@]}")
+}
+_parse_debug_flag "$@"
+set -- "${_debug_argv[@]}"
+
+[[ $EUID != 0 ]] && exec sudo --preserve-env=DEBUG,DEBUG_LOG "$0" "$@"
 #
 # Get the script directory
 script_dir="$(dirname "$0")"
@@ -15,6 +52,11 @@ declare -A module_options
 
 # Load the initialize modules
 source "$script_dir/../lib/armbian-config/config.initialize.sh"
+
+# Open the debug log file up-front so the session header lands before any
+# checkpoint/debug_log output. No-op when DEBUG is unset.
+_debug_log_init
+debug_log "armbian-config invoked: $0 $*"
 
 # Start loading messages
 checkpoint reset
@@ -98,11 +140,18 @@ case "$1" in
      --cmd  [option]     Run a command from the menu (simple)
      --api  [option]     Run a helper command        (advanced)
      --doc               Generate the README.md file
+     --debug[=spec]      Enable debug logging to a file.
+                         spec is one of: <level> (1 or 2),
+                         <path>, or <level>:<path>.
+                         Default file: /var/log/armbian-config.log
+                         Level 2 also captures set -x via BASH_XTRACEFD.
 
      Examples:
      armbian-config --help [cmd||System||Software||Network||Localisation]
      armbian-config --cmd help
      armbian-config --api help
+     armbian-config --debug --cmd help
+     armbian-config --debug=2:/tmp/ac.log
 "
         fi
     ;;

--- a/tools/modules/functions/module_dialog_ui.sh
+++ b/tools/modules/functions/module_dialog_ui.sh
@@ -653,8 +653,8 @@ dialog_menu() {
 			done
 
 			# Debug: show options array
-			[[ -n "$debug" ]] && echo "DEBUG: options array has ${#options[@]} elements" >&2
-			[[ -n "$debug" ]] && echo "DEBUG: use_item_help=$use_item_help" >&2
+			debug_log "dialog_menu(read): options array has ${#options[@]} elements"
+			debug_log "dialog_menu(read): use_item_help=$use_item_help"
 
 			if $use_no_items; then
 				# Simple list without descriptions

--- a/tools/modules/functions/module_package.sh
+++ b/tools/modules/functions/module_package.sh
@@ -162,13 +162,13 @@ pkg_install()
 	# Dry-run to capture the list of new packages apt will install
 	local dry_run_output
 	dry_run_output=$(apt-get -s -y install "${pkg_names[@]}" 2>&1)
-	echo "DEBUG pkg_install: dry-run for ${#pkg_names[@]} packages" >&2
+	debug_log "pkg_install: dry-run for ${#pkg_names[@]} packages"
 	local new_packages=()
 	local capture=false
 	while IFS= read -r line; do
 		if [[ "$line" == "The following NEW packages will be installed:" ]]; then
 			capture=true
-			echo "DEBUG pkg_install: found: $line" >&2
+			debug_log "pkg_install: found: $line"
 			continue
 		fi
 		# Stop capturing when we hit any other section header
@@ -186,7 +186,7 @@ pkg_install()
 			fi
 		fi
 	done <<< "$dry_run_output"
-	echo "DEBUG pkg_install: apt dry-run reports ${#new_packages[@]} new packages" >&2
+	debug_log "pkg_install: apt dry-run reports ${#new_packages[@]} new packages"
 
 	local exit_code
 	apt_operation_progress install "$@"
@@ -201,7 +201,7 @@ pkg_install()
 	# Track newly installed packages
 	if [[ $exit_code -eq 0 ]]; then
 		ACTUALLY_INSTALLED+=("${new_packages[@]}")
-		echo "DEBUG pkg_install: ACTUALLY_INSTALLED now has ${#ACTUALLY_INSTALLED[@]} entries" >&2
+		debug_log "pkg_install: ACTUALLY_INSTALLED now has ${#ACTUALLY_INSTALLED[@]} entries"
 	fi
 
 	return $exit_code

--- a/tools/modules/initialize/checkpoint.sh
+++ b/tools/modules/initialize/checkpoint.sh
@@ -15,8 +15,16 @@ _checkpoint_add()
 
 	if [[ -n "$DEBUG" ]]; then
 		local time=$(date +%s)
-		printf "%-30s %4d sec\n" "$msg" $((time - _checkpoint_time))
+		local line
+		printf -v line "%-30s %4d sec" "$msg" $((time - _checkpoint_time))
 		_checkpoint_time=$time
+		# Prefer the debug_log sink (file when DEBUG_LOG is set) so checkpoint
+		# timings live alongside every other debug line.
+		if declare -f debug_log >/dev/null 2>&1; then
+			debug_log "checkpoint: $line"
+		else
+			echo "$line"
+		fi
 
 	elif [[ -n "$UXMODE" && "$type" == mark ]]; then
 		_checkpoint_time=$(date +%s)

--- a/tools/modules/initialize/debug_log.sh
+++ b/tools/modules/initialize/debug_log.sh
@@ -1,0 +1,78 @@
+# debug_log.sh - script-wide debug logging
+
+module_options+=(
+	["debug_log,author"]="@igorpecovnik"
+	["debug_log,feature"]="debug_log"
+	["debug_log,example"]="debug_log \"pkg_install: \${#pkg_names[@]} packages\""
+	["debug_log,desc"]="Write a debug message to the debug log sink"
+	["debug_log,status"]="Active"
+	["debug_log,group"]="Development"
+)
+
+#
+# Debug logging
+# -------------
+# Activation:
+#   DEBUG=1   -> debug_log lines are captured
+#   DEBUG=2   -> same + xtrace (set -x) captured via BASH_XTRACEFD
+#
+# Destination:
+#   DEBUG_LOG=<path>  ->  append to this file (created if missing)
+#   If DEBUG is set but DEBUG_LOG is unset, default to
+#     /var/log/armbian-config.log when running as root, else
+#     /tmp/armbian-config.log
+#   If the log file cannot be opened, fall back to stderr.
+#
+# Callers should use `debug_log "message"`. It is always safe to call
+# (it is a no-op when DEBUG is empty), so modules can instrument freely.
+#
+
+_debug_log_fd=""
+
+_debug_log_init() {
+	[[ -n "$_debug_log_fd" ]] && return 0      # already initialised
+	[[ -z "$DEBUG" ]] && return 0              # not enabled
+
+	if [[ -z "$DEBUG_LOG" ]]; then
+		if [[ $EUID -eq 0 ]]; then
+			DEBUG_LOG="/var/log/armbian-config.log"
+		else
+			DEBUG_LOG="/tmp/armbian-config.log"
+		fi
+	fi
+
+	# Try to open the log file on fd 9; fall back to stderr (fd 2) on failure.
+	if { exec 9>>"$DEBUG_LOG"; } 2>/dev/null; then
+		_debug_log_fd=9
+		export DEBUG_LOG
+	else
+		_debug_log_fd=2
+		unset DEBUG_LOG
+	fi
+
+	# Write a session header so concatenated runs stay readable.
+	printf '\n===== armbian-config debug session: %s pid=%d user=%s =====\n' \
+		"$(date '+%Y-%m-%d %H:%M:%S')" "$$" "${USER:-$(id -un 2>/dev/null)}" >&${_debug_log_fd}
+
+	# DEBUG=2 -> capture shell xtrace to the same sink.
+	if [[ "$DEBUG" == 2 ]]; then
+		export BASH_XTRACEFD=${_debug_log_fd}
+		export PS4='+ ${BASH_SOURCE##*/}:${LINENO}:${FUNCNAME[0]:-main}: '
+		set -x
+	fi
+}
+
+debug_log() {
+	[[ -z "$DEBUG" ]] && return 0
+	_debug_log_init
+	local src="${BASH_SOURCE[1]##*/}"
+	local line="${BASH_LINENO[0]}"
+	local fn="${FUNCNAME[1]:-main}"
+	printf '%s [%s:%s %s] %s\n' \
+		"$(date '+%H:%M:%S')" "$src" "$line" "$fn" "$*" >&${_debug_log_fd}
+}
+
+_debug_log_path() {
+	# Used by `armbian-config --debug-log-path` and checkpoint to know where to tee.
+	echo "${DEBUG_LOG:-}"
+}


### PR DESCRIPTION
## Summary
Adds a small script-wide debug logging facility so module authors can instrument code paths without paying a runtime cost when debugging is off, and so end users can collect a usable trace with a single flag.

## What's new

**\`tools/modules/initialize/debug_log.sh\`** — provides \`debug_log \"msg\"\` which:
- is a zero-cost no-op when \`DEBUG\` is unset
- appends a timestamp + \`source:line function\` + message to a log file when \`DEBUG=1\`
- additionally captures \`set -x\` into the same file via \`BASH_XTRACEFD\` when \`DEBUG=2\`
- defaults \`DEBUG_LOG\` to \`/var/log/armbian-config.log\` (or \`/tmp/armbian-config.log\` for non-root)
- falls back to stderr if the log file cannot be opened
- writes a session header (date / pid / user) so concatenated runs stay readable

**\`bin/armbian-config\`** — new \`--debug[=spec]\` flag:
\`\`\`
armbian-config --debug                        # level 1, default log file
armbian-config --debug=2                      # also captures set -x
armbian-config --debug=/tmp/ac.log            # custom path
armbian-config --debug=2:/tmp/ac.log          # both
armbian-config --debug --cmd help             # composes with existing flags
\`\`\`
The flag is stripped from argv before the existing dispatch runs, and \`DEBUG\` / \`DEBUG_LOG\` are forwarded across the \`sudo\` re-exec (\`--preserve-env\`). Setting those variables in the environment works as an alternative to the flag.

## Touch-ups that fall out of this
- **\`checkpoint.sh\`** — \`_checkpoint_add\` now routes timing lines through \`debug_log\` when it's available, so existing checkpoint instrumentation lands in the same log sink as everything else.
- **\`module_package.sh\`** — four ad-hoc \`echo \"DEBUG pkg_install: ...\" >&2\` lines that were always printed on stderr have been converted to \`debug_log\`. They were noisy on production installs and silently lost on error.
- **\`module_dialog_ui.sh\`** — same treatment for two debug echoes in the \`read\` fallback path.

## Test plan
- [x] \`DEBUG\` unset → \`debug_log\` is a complete no-op (smoke-tested).
- [x] \`DEBUG=1\` + custom \`DEBUG_LOG\` → log file created, session header present, structured lines appended.
- [x] \`DEBUG=2\` → shell xtrace captured into the same log file.
- [x] \`--debug\` flag parser handles \`--debug\`, \`--debug=<int>\`, \`--debug=<path>\`, \`--debug=<int>:<path>\`, and strips itself out of \`\$@\`.
- [x] Run \`armbian-config --debug --cmd help\` on a real install and confirm the log file appears at \`/var/log/armbian-config.log\`.
- [x] Confirm \`sudo\` re-exec preserves \`DEBUG\` / \`DEBUG_LOG\`.

## Notes for reviewers
- The helper is deliberately tiny. It does not implement severity levels beyond on/xtrace because I did not want to invent API we do not have use sites for yet.
- It is safe to sprinkle \`debug_log\` calls anywhere — modules do not need to guard them with \`if [[ -n \"\$DEBUG\" ]]\`.
- Module load order: \`debug_log.sh\` is merged into \`config.initialize.sh\` before \`checkpoint.sh\` (alphabetical), so checkpoint's forward reference resolves at source time.