### PR TITLE
desktops: enable armhf for XFCE, MATE, i3-wm, Xmonad, Enlightenment, Cinnamon

### DIFF
--- a/tools/modules/desktops/yaml/cinnamon.yaml
+++ b/tools/modules/desktops/yaml/cinnamon.yaml
@@ -38,7 +38,7 @@ packages:
 
 releases:
   bookworm:
-    architectures: [arm64, amd64]
+    architectures: [arm64, amd64, armhf]
     packages:
       - accountsservice
       - gnome-calculator
@@ -49,7 +49,7 @@ releases:
       - update-manager-core
 
   trixie:
-    architectures: [arm64, amd64]
+    architectures: [arm64, amd64, armhf]
     packages:
       - accountsservice
       - libu2f-udev
@@ -61,7 +61,7 @@ releases:
       - pulseaudio-module-bluetooth
 
   noble:
-    architectures: [arm64, amd64]
+    architectures: [arm64, amd64, armhf]
     packages:
       - polkitd
       - pkexec
@@ -78,7 +78,7 @@ releases:
       - language-selector-gnome
 
   plucky:
-    architectures: [arm64, amd64]
+    architectures: [arm64, amd64, armhf]
     packages:
       - polkitd
       - pkexec

--- a/tools/modules/desktops/yaml/enlightenment.yaml
+++ b/tools/modules/desktops/yaml/enlightenment.yaml
@@ -21,13 +21,13 @@ packages:
 
 releases:
   bookworm:
-    architectures: [arm64, amd64]
+    architectures: [arm64, amd64, armhf]
     packages:
       - accountsservice
       - libu2f-udev
 
   trixie:
-    architectures: [arm64, amd64]
+    architectures: [arm64, amd64, armhf]
     packages:
       - accountsservice
       - libu2f-udev
@@ -39,14 +39,14 @@ releases:
       - pulseaudio-module-bluetooth
 
   noble:
-    architectures: [arm64, amd64]
+    architectures: [arm64, amd64, armhf]
     packages:
       - polkitd
       - pkexec
       - libu2f-udev
 
   plucky:
-    architectures: [arm64, amd64]
+    architectures: [arm64, amd64, armhf]
     packages:
       - polkitd
       - pkexec

--- a/tools/modules/desktops/yaml/i3-wm.yaml
+++ b/tools/modules/desktops/yaml/i3-wm.yaml
@@ -33,7 +33,7 @@ packages:
 
 releases:
   bookworm:
-    architectures: [arm64, amd64]
+    architectures: [arm64, amd64, armhf]
     packages:
       - accountsservice
       - libu2f-udev
@@ -62,7 +62,7 @@ releases:
       - libfontembed1
 
   plucky:
-    architectures: [arm64, amd64]
+    architectures: [arm64, amd64, armhf]
     packages:
       - polkitd
       - pkexec

--- a/tools/modules/desktops/yaml/mate.yaml
+++ b/tools/modules/desktops/yaml/mate.yaml
@@ -46,7 +46,7 @@ packages_uninstall:
 
 releases:
   bookworm:
-    architectures: [arm64, amd64]
+    architectures: [arm64, amd64, armhf]
     packages:
       - accountsservice
       - gnome-calculator
@@ -69,7 +69,7 @@ releases:
       - pulseaudio-module-bluetooth
 
   noble:
-    architectures: [arm64, amd64]
+    architectures: [arm64, amd64, armhf]
     packages:
       - polkitd
       - pkexec
@@ -86,7 +86,7 @@ releases:
       - language-selector-gnome
 
   plucky:
-    architectures: [arm64, amd64]
+    architectures: [arm64, amd64, armhf]
     packages:
       - polkitd
       - pkexec

--- a/tools/modules/desktops/yaml/xfce.yaml
+++ b/tools/modules/desktops/yaml/xfce.yaml
@@ -54,7 +54,7 @@ packages_uninstall:
 
 releases:
   bookworm:
-    architectures: [arm64, amd64]
+    architectures: [arm64, amd64, armhf]
     packages:
       - accountsservice
       - gnome-calculator
@@ -77,7 +77,7 @@ releases:
       - pulseaudio-module-bluetooth
 
   noble:
-    architectures: [arm64, amd64]
+    architectures: [arm64, amd64, armhf]
     packages:
       - polkitd
       - pkexec
@@ -94,7 +94,7 @@ releases:
       - language-selector-gnome
 
   plucky:
-    architectures: [arm64, amd64]
+    architectures: [arm64, amd64, armhf]
     packages:
       - polkitd
       - pkexec

--- a/tools/modules/desktops/yaml/xmonad.yaml
+++ b/tools/modules/desktops/yaml/xmonad.yaml
@@ -24,13 +24,13 @@ packages:
 
 releases:
   bookworm:
-    architectures: [arm64, amd64]
+    architectures: [arm64, amd64, armhf]
     packages:
       - accountsservice
       - libu2f-udev
 
   trixie:
-    architectures: [arm64, amd64]
+    architectures: [arm64, amd64, armhf]
     packages:
       - accountsservice
       - libu2f-udev
@@ -42,14 +42,14 @@ releases:
       - pulseaudio-module-bluetooth
 
   noble:
-    architectures: [arm64, amd64]
+    architectures: [arm64, amd64, armhf]
     packages:
       - polkitd
       - pkexec
       - libu2f-udev
 
   plucky:
-    architectures: [arm64, amd64]
+    architectures: [arm64, amd64, armhf]
     packages:
       - polkitd
       - pkexec


### PR DESCRIPTION
## Summary
armhf coverage in the desktop YAML matrix was inconsistent. Some lightweight DEs had armhf enabled on only one release; others had none at all despite being marked \`status: supported\` and shipping armhf packages in every target archive.

## What changed
Enabled \`armhf\` in the \`architectures:\` list for the following DE/release combinations that were previously missing it:

| DE             | bookworm | trixie | noble | plucky |
|----------------|:-:|:-:|:-:|:-:|
| XFCE           | + |   | + | + |
| MATE           | + |   | + | + |
| i3-wm          | + |   |   | + |
| Xmonad         | + | + | + | + |
| Enlightenment  | + | + | + | + |
| Cinnamon       | + | + | + | + |

(Cells marked \`+\` are the newly-added ones. \`riscv64\` listings were not touched.)

## Verification
Checked each DE metapackage against the archive before enabling:
- \`packages.debian.org/<release>/armhf/<pkg>\` for bookworm and trixie
- \`packages.ubuntu.com/<release>/armhf/<pkg>\` (cross-checked with Launchpad) for noble and plucky

All of these metapackages are published for armhf in all four releases:
\`xfce4\`, \`xfce4-goodies\`, \`i3\`, \`mate-desktop-environment\`, \`xmonad\`, \`xmobar\`, \`enlightenment\`, \`cinnamon\`, \`cinnamon-desktop-environment\`.

Smoke-tested the parser:
\`\`\`
$ python3 tools/modules/desktops/scripts/parse_desktop_yaml.py \\
    tools/modules/desktops/yaml --list <release> armhf
\`\`\`
lists all six DEs across bookworm/trixie/noble/plucky. arm64/amd64 counts per release are unchanged (10 on Debian, 11 on Ubuntu).

## Intentionally NOT enabled
- **gnome**, **kde-plasma** — metapackages exist on armhf, but the runtime footprint is not practical on typical armhf SBCs (<2 GB RAM). If we want to offer them on armhf anyway, that's a separate decision and can be a one-line follow-up PR.
- **budgie**, **deepin**, **kde-neon**, **bianbu** — all \`status: unsupported\` or arch-specific (bianbu is riscv64 only). Not touched.

## Test plan
- [ ] \`armbian-config --api module_desktops supported arch=armhf release=noble\` returns \`true\` for xfce, mate, i3-wm, xmonad, enlightenment, cinnamon.
- [ ] Install e.g. xfce on an armhf board running Debian trixie and confirm the resulting session boots.
- [ ] Confirm the arm64/amd64 desktop lists are unchanged.

Question for reviewers: should I enable gnome/kde-plasma on armhf in a follow-up PR, or leave them arm64+amd64 only?