### PR TITLE
desktops: enable riscv64 for XFCE, MATE, i3-wm, Xmonad, Enlightenment, Cinnamon

### DIFF
--- a/tools/modules/desktops/yaml/cinnamon.yaml
+++ b/tools/modules/desktops/yaml/cinnamon.yaml
@@ -49,7 +49,7 @@ releases:
       - update-manager-core
 
   trixie:
-    architectures: [arm64, amd64, armhf]
+    architectures: [arm64, amd64, armhf, riscv64]
     packages:
       - accountsservice
       - libu2f-udev
@@ -61,7 +61,7 @@ releases:
       - pulseaudio-module-bluetooth
 
   noble:
-    architectures: [arm64, amd64, armhf]
+    architectures: [arm64, amd64, armhf, riscv64]
     packages:
       - polkitd
       - pkexec
@@ -78,7 +78,7 @@ releases:
       - language-selector-gnome
 
   plucky:
-    architectures: [arm64, amd64, armhf]
+    architectures: [arm64, amd64, armhf, riscv64]
     packages:
       - polkitd
       - pkexec

--- a/tools/modules/desktops/yaml/enlightenment.yaml
+++ b/tools/modules/desktops/yaml/enlightenment.yaml
@@ -27,7 +27,7 @@ releases:
       - libu2f-udev
 
   trixie:
-    architectures: [arm64, amd64, armhf]
+    architectures: [arm64, amd64, armhf, riscv64]
     packages:
       - accountsservice
       - libu2f-udev
@@ -39,14 +39,14 @@ releases:
       - pulseaudio-module-bluetooth
 
   noble:
-    architectures: [arm64, amd64, armhf]
+    architectures: [arm64, amd64, armhf, riscv64]
     packages:
       - polkitd
       - pkexec
       - libu2f-udev
 
   plucky:
-    architectures: [arm64, amd64, armhf]
+    architectures: [arm64, amd64, armhf, riscv64]
     packages:
       - polkitd
       - pkexec

--- a/tools/modules/desktops/yaml/i3-wm.yaml
+++ b/tools/modules/desktops/yaml/i3-wm.yaml
@@ -62,7 +62,7 @@ releases:
       - libfontembed1
 
   plucky:
-    architectures: [arm64, amd64, armhf]
+    architectures: [arm64, amd64, armhf, riscv64]
     packages:
       - polkitd
       - pkexec

--- a/tools/modules/desktops/yaml/mate.yaml
+++ b/tools/modules/desktops/yaml/mate.yaml
@@ -69,7 +69,7 @@ releases:
       - pulseaudio-module-bluetooth
 
   noble:
-    architectures: [arm64, amd64, armhf]
+    architectures: [arm64, amd64, armhf, riscv64]
     packages:
       - polkitd
       - pkexec
@@ -86,7 +86,7 @@ releases:
       - language-selector-gnome
 
   plucky:
-    architectures: [arm64, amd64, armhf]
+    architectures: [arm64, amd64, armhf, riscv64]
     packages:
       - polkitd
       - pkexec

--- a/tools/modules/desktops/yaml/xfce.yaml
+++ b/tools/modules/desktops/yaml/xfce.yaml
@@ -77,7 +77,7 @@ releases:
       - pulseaudio-module-bluetooth
 
   noble:
-    architectures: [arm64, amd64, armhf]
+    architectures: [arm64, amd64, armhf, riscv64]
     packages:
       - polkitd
       - pkexec
@@ -94,7 +94,7 @@ releases:
       - language-selector-gnome
 
   plucky:
-    architectures: [arm64, amd64, armhf]
+    architectures: [arm64, amd64, armhf, riscv64]
     packages:
       - polkitd
       - pkexec

--- a/tools/modules/desktops/yaml/xmonad.yaml
+++ b/tools/modules/desktops/yaml/xmonad.yaml
@@ -30,7 +30,7 @@ releases:
       - libu2f-udev
 
   trixie:
-    architectures: [arm64, amd64, armhf]
+    architectures: [arm64, amd64, armhf, riscv64]
     packages:
       - accountsservice
       - libu2f-udev
@@ -42,14 +42,14 @@ releases:
       - pulseaudio-module-bluetooth
 
   noble:
-    architectures: [arm64, amd64, armhf]
+    architectures: [arm64, amd64, armhf, riscv64]
     packages:
       - polkitd
       - pkexec
       - libu2f-udev
 
   plucky:
-    architectures: [arm64, amd64, armhf]
+    architectures: [arm64, amd64, armhf, riscv64]
     packages:
       - polkitd
       - pkexec


### PR DESCRIPTION
## Summary
Mirrors the recent armhf cleanup for riscv64. Same six lightweight, \`status: supported\` DEs, same set of releases (with bookworm intentionally excluded — it has no riscv64 port).

## What changed
Added \`riscv64\` to the \`architectures:\` list for the following DE/release combinations that were previously missing it:

| DE             | trixie | noble | plucky |
|----------------|:-:|:-:|:-:|
| XFCE           |   | + | + |
| MATE           |   | + | + |
| i3-wm          |   |   | + |
| Xmonad         | + | + | + |
| Enlightenment  | + | + | + |
| Cinnamon       | + | + | + |

(Cells marked \`+\` are the newly-added ones. \`bookworm\` is unchanged across all six files: Debian only started shipping riscv64 in trixie.)

## Verification
Cross-checked each metapackage against the actual binary-riscv64 archive indices, not the HTML pages (which can intermittently 5xx and lie):
- \`deb.debian.org/debian/dists/trixie/main/binary-riscv64/Packages.gz\`
- \`ports.ubuntu.com/ubuntu-ports/dists/{noble,plucky}/{main,universe}/binary-riscv64/Packages.gz\`

Every relevant metapackage has a literal \`Package:\` entry on riscv64 in all three releases:
\`xfce4\`, \`xfce4-goodies\`, \`i3\`, \`mate-desktop-environment\`, \`xmonad\`, \`xmobar\`, \`enlightenment\`, \`cinnamon\`, \`cinnamon-desktop-environment\`.

Smoke-tested the parser against \`tools/modules/desktops/yaml\`:
\`\`\`
$ for r in bookworm trixie noble plucky; do
    python3 .../parse_desktop_yaml.py .../yaml --list "\$r" riscv64
  done
\`\`\`
- \`bookworm/riscv64\`: empty (correct — no riscv64 in bookworm).
- \`trixie/riscv64\`, \`noble/riscv64\`, \`plucky/riscv64\`: all six lightweight DEs listed (plus the existing \`bianbu\` entry on noble/plucky).
- arm64/amd64/armhf counts per release are unchanged (10/10/6 on Debian, 11/11/6 on Ubuntu).

## Intentionally NOT enabled
- **gnome**, **kde-plasma** — metapackages are present in the riscv64 indices but their dep closures are huge and historically the last to stabilize on a new Debian port. Same reasoning as the armhf PR. Easy follow-up if there's interest.
- **budgie**, **deepin**, **kde-neon** — \`status: unsupported\` or arch-specific.
- **bianbu** — already riscv64-only by design (SpacemiT-specific).

## Test plan
- [ ] \`armbian-config --api module_desktops supported arch=riscv64 release=trixie\` returns \`true\` for xfce, mate, i3-wm, xmonad, enlightenment, cinnamon.
- [ ] Install xfce on a riscv64 board running Debian trixie and confirm the resulting session boots.
- [ ] Confirm bookworm desktop lists are unchanged (parser still returns empty for bookworm/riscv64, and the old arm64/amd64/armhf counts are preserved).