### PR TITLE
desktops: disable cinnamon on armhf

### DIFF
--- a/tools/modules/desktops/yaml/cinnamon.yaml
+++ b/tools/modules/desktops/yaml/cinnamon.yaml
@@ -38,7 +38,7 @@ packages:
 
 releases:
   bookworm:
-    architectures: [arm64, amd64, armhf]
+    architectures: [arm64, amd64]
     packages:
       - accountsservice
       - gnome-calculator
@@ -49,7 +49,7 @@ releases:
       - update-manager-core
 
   trixie:
-    architectures: [arm64, amd64, armhf, riscv64]
+    architectures: [arm64, amd64, riscv64]
     packages:
       - accountsservice
       - libu2f-udev
@@ -61,7 +61,7 @@ releases:
       - pulseaudio-module-bluetooth
 
   noble:
-    architectures: [arm64, amd64, armhf, riscv64]
+    architectures: [arm64, amd64, riscv64]
     packages:
       - polkitd
       - pkexec
@@ -78,7 +78,7 @@ releases:
       - language-selector-gnome
 
   plucky:
-    architectures: [arm64, amd64, armhf, riscv64]
+    architectures: [arm64, amd64, riscv64]
     packages:
       - polkitd
       - pkexec


### PR DESCRIPTION
## Summary
Cinnamon installs cleanly on armhf but the resulting session is broken: wallpaper and cursor render, but the bottom panel is absent. Reproduced on a fresh install of the Ubuntu variant.

## Root cause
Cinnamon's main process is a single binary that implements both the Muffin window manager/compositor and the panel/applets. When Muffin fails to obtain a working GL context, the entire process fails partway through startup — the X server is up (you see cursor + wallpaper from slick-greeter / the root window) but the Clutter/Cogl stage that paints the panel never comes up.

On most armhf SBCs there is no working 32-bit GL driver in Mesa for the hardware, so Muffin has no real GL backend. Cinnamon does ship a "Cinnamon (Software Rendering)" fallback session (\`cinnamon2d.desktop\`) backed by llvmpipe, but it is **not** selected automatically and there is no way to make it the default without per-board configuration that doesn't belong in a desktop YAML.

Other lightweight DEs we enabled on armhf (xfce, mate, i3-wm, xmonad, enlightenment) do not depend on a GL-accelerated compositor to draw their panel, so they work fine on the same hardware. Cinnamon on x86 also works fine, so this is purely a "no GL on armhf SBCs" limitation, not a packaging or armhf-port problem.

## What changed
Dropped \`armhf\` from \`tools/modules/desktops/yaml/cinnamon.yaml\` across all four releases:

| release  | before                                  | after                          |
|----------|-----------------------------------------|--------------------------------|
| bookworm | \`[arm64, amd64, armhf]\`                 | \`[arm64, amd64]\`               |
| trixie   | \`[arm64, amd64, armhf, riscv64]\`        | \`[arm64, amd64, riscv64]\`      |
| noble    | \`[arm64, amd64, armhf, riscv64]\`        | \`[arm64, amd64, riscv64]\`      |
| plucky   | \`[arm64, amd64, armhf, riscv64]\`        | \`[arm64, amd64, riscv64]\`      |

No other DE entries are touched.

## Verification
\`\`\`
$ for r in bookworm trixie noble plucky; do
    echo "--- $r/armhf ---"
    python3 .../parse_desktop_yaml.py .../yaml --list "$r" armhf | grep -E '^cinnamon'
  done
\`\`\`
returns nothing for any release. Cinnamon is still listed for arm64/amd64 on every release and for riscv64 on trixie/noble/plucky.

## Test plan
- [ ] On a fresh Ubuntu armhf install, confirm cinnamon no longer appears in \`armbian-config\` Software → Desktop.
- [ ] On arm64/amd64/riscv64, confirm cinnamon is still offered and still installs.

## Follow-up
If we ever want cinnamon back on armhf, the fix is to (a) make sure \`libgl1-mesa-dri\` is installed so \`swrast_dri.so\` is present, and (b) force the default session to \`cinnamon2d.desktop\` per-user via AccountsService or equivalent. That's substantial enough to be its own PR.