### PR TITLE
docs: rewrite Desktops-header.md for the tier model

### DIFF
--- a/tools/include/markdown/CINM01-header.md
+++ b/tools/include/markdown/CINM01-header.md
@@ -1,5 +1,1 @@
 Cinnamon is a Linux desktop environment that provides advanced innovative features and a traditional user experience. The desktop layout is similar to GNOME 2 with underlying technology forked from GNOME Shell. Cinnamon makes users feel at home with an easy-to-use and comfortable desktop experience.
-
-!!! warning "Desktop installation is resource-intensive"
-
-    Installing a desktop environment will download and install a large number of packages. This process may take a significant amount of time depending on your internet connection and device performance. A reboot is required after installation.

--- a/tools/include/markdown/Desktops-header.md
+++ b/tools/include/markdown/Desktops-header.md
@@ -1,29 +1,57 @@
 Armbian desktop installation uses upstream meta-packages from Debian and Ubuntu repositories, making it distro-agnostic and independent of pre-built Armbian desktop packages.
 
-**How it works:**
+**Tiered installs**
 
-- Installs the desktop environment meta-package (e.g., `xfce4`, `gnome-session`) along with essential extras
-- Tracks all newly installed packages so uninstall cleanly removes everything added on top of CLI, including dependencies
-- Applies Armbian branding: wallpapers, icons, login screen theme, and default user settings
-- Configures the display manager (LightDM, GDM3, or SDDM) with auto-login (this can be disabled in menu)
-- Installs [Armbian Imager](https://imager.armbian.com/) as an AppImage for writing OS images
-- Sets up Profile Sync Daemon (psd) to keep browser profiles in RAM, reducing flash media wear
-- Removes unnecessary bloat pulled in by meta-packages
+Every desktop ships at one of three sizes. You can install at any tier and switch between tiers later without uninstalling.
 
-**Networking:**
-
-Desktop environments that require NetworkManager (e.g., GNOME) install it alongside the existing `systemd-networkd`. Wired Ethernet interfaces remain managed by `systemd-networkd`, while NetworkManager handles WiFi and VPN connections. This avoids disrupting existing network configuration.
-
-**Supported desktops:**
-
-| Desktop | Best for | Resources |
+| Tier | Contents | Approximate size |
 |---|---|---|
-| XFCE | Single board computers, low-end hardware | ~300 MB RAM |
-| GNOME | Modern desktops, touchscreen devices | ~800 MB RAM |
-| Cinnamon | Users familiar with Windows layout | ~500 MB RAM |
-| MATE | Classic GNOME 2 fans, low-resource systems | ~350 MB RAM |
-| KDE Plasma | Power users, heavy customization | ~600 MB RAM |
-| i3-wm | Developers, keyboard-driven workflows | ~150 MB RAM |
+| **Minimal** | Desktop environment + display manager + base utilities. No browser, no office suite. | ~500 MB |
+| **Mid** | Minimal plus a browser, text editor, calculator, image and PDF viewer, media player, archive manager and torrent client. | ~1 GB |
+| **Full** | Mid plus LibreOffice, GIMP, Inkscape, Thunderbird and Audacity. | ~2.5 GB |
+
+The browser shipped at mid and full tiers is chosen automatically: `chromium` on Debian, `firefox-esr` on Debian riscv64, and `epiphany-browser` on Ubuntu (Ubuntu's `chromium` and `firefox` packages are snap-shim wrappers that don't work without `snapd`, which Armbian doesn't ship).
+
+**How it works**
+
+- Installs the desktop meta-package (e.g. `xfce4`, `gnome-session`) plus the per-tier extras and any release-specific packages your distribution needs.
+- Tracks every package the install pulls in. The list is saved to `/etc/armbian/desktop/<de>.packages`, the chosen tier to `/etc/armbian/desktop/<de>.tier`. Uninstall and downgrade use these files so they only ever remove packages the desktop install added — packages you installed manually after the fact are never touched.
+- Applies Armbian branding: wallpapers, icons, login screen theme, and default user settings.
+- Configures the display manager (LightDM, GDM3 or SDDM) with auto-login enabled by default. You can disable auto-login from the desktop menu without removing the desktop.
+- Sets up Profile Sync Daemon (psd) to keep browser profiles in RAM, reducing flash media wear.
+- Removes a small set of unwanted extras pulled in by some meta-packages (e.g. Ubuntu's `apport` crash reporter, snap-related stubs).
+
+**Switching tiers after install**
+
+You don't need to reinstall to add or remove tier extras. The desktop menu offers "Change *desktop* to *tier*" entries for any tier other than the one currently installed. Behind the scenes:
+
+- Going up (minimal → mid → full) installs only the new packages introduced by the higher tier.
+- Going down (full → mid → minimal) removes only the packages the install added that aren't in the lower tier. Your manually-installed packages are not touched.
+
+**Networking**
+
+Some desktops (notably GNOME) require NetworkManager. When installed, NetworkManager is configured to coexist with Armbian's existing `systemd-networkd`: wired Ethernet stays managed by `systemd-networkd`, while NetworkManager handles WiFi and VPN connections. This avoids disrupting your existing network configuration.
+
+**Supported desktops**
+
+| Desktop | Best for | Approximate RAM (minimal tier) |
+|---|---|---|
+| XFCE | Single board computers, low-end hardware | ~300 MB |
+| GNOME | Modern desktops, touchscreen devices | ~800 MB |
+| Cinnamon | Users familiar with Windows layout | ~500 MB |
+| MATE | Classic GNOME 2 fans, low-resource systems | ~350 MB |
+| KDE Plasma | Power users, heavy customization | ~600 MB |
+| i3-wm | Developers, keyboard-driven workflows | ~150 MB |
+| Xmonad | Haskell tiling window manager | ~120 MB |
+| Enlightenment | EFL-based, lightweight and stylish | ~250 MB |
+
+Mid and full tiers add roughly 500 MB and 2 GB on top of these minimum figures, depending on which tier extras your release/architecture combination ships.
+
+!!! warning "Desktop installation is resource-intensive"
+
+    Installing a desktop environment will download and install a large number of packages. The full tier on a fresh Ubuntu image pulls in roughly 2.5 GB and may take a significant amount of time depending on your internet connection and device performance. A reboot is required after installation.
+
+    Running `module_desktops remove` reclaims the disk space; `apt-get clean` is run automatically as part of the remove path.
 
 !!! note "Switching desktops"
 

--- a/tools/include/markdown/GNME01-header.md
+++ b/tools/include/markdown/GNME01-header.md
@@ -1,5 +1,1 @@
 GNOME is a modern, user-friendly desktop environment for Linux, offering a clean interface, essential apps, and customization through extensions. It prioritizes simplicity, accessibility, and efficiency.
-
-!!! warning "Desktop installation is resource-intensive"
-
-    Installing a desktop environment will download and install a large number of packages. This process may take a significant amount of time depending on your internet connection and device performance. A reboot is required after installation.

--- a/tools/include/markdown/I3WM01-header.md
+++ b/tools/include/markdown/I3WM01-header.md
@@ -3,7 +3,3 @@ i3 is a tiling window manager designed for power users and developers. It is key
 !!! info "Keyboard shortcuts"
 
     i3 is controlled primarily via keyboard. The default modifier key is **$mod** (Super/Windows key). Press **$mod+Enter** to open a terminal, **$mod+d** to launch applications via rofi, and **$mod+Shift+e** to exit.
-
-!!! warning "Desktop installation is resource-intensive"
-
-    Installing a desktop environment will download and install a large number of packages. This process may take a significant amount of time depending on your internet connection and device performance. A reboot is required after installation.

--- a/tools/include/markdown/KDEN01-header.md
+++ b/tools/include/markdown/KDEN01-header.md
@@ -1,9 +1,5 @@
 KDE Neon provides the latest KDE Plasma desktop built on top of Ubuntu. It uses the KDE Neon repository to deliver cutting-edge Plasma releases, offering the newest features and improvements ahead of distribution packages. Ubuntu Noble/Plucky only.
 
-!!! warning "Desktop installation is resource-intensive"
-
-    Installing a desktop environment will download and install a large number of packages. This process may take a significant amount of time depending on your internet connection and device performance. A reboot is required after installation.
-
 !!! note "KDE Neon vs KDE Plasma"
 
     **KDE Neon** uses the KDE Neon repository for the latest Plasma releases (Ubuntu only). **KDE Plasma** uses distribution packages and works on both Debian and Ubuntu.

--- a/tools/include/markdown/KDEP01-header.md
+++ b/tools/include/markdown/KDEP01-header.md
@@ -1,5 +1,1 @@
 KDE Plasma is a feature-rich desktop environment with extensive customization options. It provides a familiar taskbar and start menu layout with modern effects, widgets, and a powerful system settings application.
-
-!!! warning "Desktop installation is resource-intensive"
-
-    Installing a desktop environment will download and install a large number of packages. This process may take a significant amount of time depending on your internet connection and device performance. A reboot is required after installation.

--- a/tools/include/markdown/MATE01-header.md
+++ b/tools/include/markdown/MATE01-header.md
@@ -1,5 +1,1 @@
 MATE is a continuation of GNOME 2, providing a traditional desktop experience with a classic two-panel layout. It is lightweight, stable, and fully customizable — a good choice for users who prefer a familiar desktop without the overhead of modern compositing effects.
-
-!!! warning "Desktop installation is resource-intensive"
-
-    Installing a desktop environment will download and install a large number of packages. This process may take a significant amount of time depending on your internet connection and device performance. A reboot is required after installation.

--- a/tools/include/markdown/XFCE01-header.md
+++ b/tools/include/markdown/XFCE01-header.md
@@ -1,5 +1,1 @@
 Xfce is a lightweight, fast, and user-friendly desktop environment for Linux, offering a classic interface, essential apps, and customization. It prioritizes performance, simplicity, and efficiency, making it an excellent choice for devices with limited resources.
-
-!!! warning "Desktop installation is resource-intensive"
-
-    Installing a desktop environment will download and install a large number of packages. This process may take a significant amount of time depending on your internet connection and device performance. A reboot is required after installation.


### PR DESCRIPTION
## Summary

Update the user-facing intro for the Desktop menu (`tools/include/markdown/Desktops-header.md`) to match the state of the desktop submodule after the tier system landed in #824, and consolidate the duplicated 'resource-intensive' warning that lived in seven per-DE headers into a single place.

## Desktops-header.md

- New **Tiered installs** section with a table of minimal/mid/full and rough sizes (~500 MB / ~1 GB / ~2.5 GB).
- Documents the **browser substitution rule** (`chromium` on Debian, `firefox-esr` on Debian riscv64, `epiphany-browser` on Ubuntu) and explains why we don't ship Ubuntu's chromium/firefox snap-shim.
- Rewritten **How it works** bullets:
  - mention the install manifest at `/etc/armbian/desktop/<de>.{packages,tier}` and the clean-uninstall guarantee (downgrade/remove only ever touches packages the desktop install added)
  - drop the Armbian Imager line — it's no longer auto-installed (opt-in via `module_appimage install app=armbian-imager`)
  - mention the `packages_uninstall` extras (apport, snap stubs)
- New **Switching tiers** section explaining upgrade/downgrade from the menu without reinstalling.
- Tightened **Networking** section ('notably GNOME' instead of 'desktop environments that require NetworkManager').
- **Supported desktops** table extended with xmonad and enlightenment, both already `status: supported` in the YAML.
- Single consolidated **'resource-intensive' warning admonition** that replaces the seven copies that used to live in per-DE headers. The new warning also mentions the automatic `apt-get clean` on remove.

## Per-DE *01-header.md

Stripped the same `Desktop installation is resource-intensive` warning from all seven per-DE install headers (XFCE01, CINM01, GNME01, KDEP01, KDEN01, MATE01, I3WM01). The wording was identical across files, so consolidating it into the parent header means future edits happen in one place.

Other admonitions in those files are **kept**:
- I3WM01: keyboard shortcuts info block
- KDEN01: KDE Neon vs KDE Plasma note

Both are DE-specific and belong on the per-DE page.

## Test plan

- [ ] Run `tools/config-assemble.sh -p` and check the rendered docs page for the desktop section
- [ ] Confirm the per-DE install pages no longer carry the duplicated warning
- [ ] Confirm the parent Desktop menu page now has the consolidated warning