### PR TITLE
audit: fix git-dir error and path references for claude-code-action

### DIFF
--- a/.github/workflows/maintenance-desktop-audit.yml
+++ b/.github/workflows/maintenance-desktop-audit.yml
@@ -50,16 +50,16 @@ jobs:
     name: "Desktop matrix audit"
     runs-on: ubuntu-latest
     steps:
+      # Checkout configng to the workspace root (no 'path:') so
+      # claude-code-action can find .git and run git config.
       - name: "Checkout configng"
         uses: actions/checkout@v4
-        with:
-          path: configng
 
       - name: "Checkout armbian/build"
         uses: actions/checkout@v4
         with:
           repository: armbian/build
-          path: build
+          path: armbian-build
           fetch-depth: 1
 
       - name: "Set up Python"
@@ -72,12 +72,11 @@ jobs:
 
       - name: "Run deterministic audit"
         id: audit
-        working-directory: configng
         run: |
           set -euo pipefail
           args=(
-            --build-repo "${{ github.workspace }}/build"
-            --configng-repo "${{ github.workspace }}/configng"
+            --build-repo "${{ github.workspace }}/armbian-build"
+            --configng-repo "${{ github.workspace }}"
             --output "${{ github.workspace }}/audit-report.json"
           )
           if [[ -n "${{ github.event.inputs.tier }}" ]]; then
@@ -134,7 +133,6 @@ jobs:
       - name: "Prepare Claude prompt"
         id: prompt
         if: steps.audit.outputs.actionable == 'true' && github.event.inputs.dry_run != 'true'
-        working-directory: configng
         run: |
           set -euo pipefail
           python3 tools/modules/desktops/github/audit_prompt.py \
@@ -162,7 +160,6 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.prompt.outputs.prompt }}
-          # Limit turns to prevent runaway conversations
           claude_args: "--max-turns 15"
 
       - name: "Open / update pull request"
@@ -171,7 +168,6 @@ jobs:
           github.event.inputs.dry_run != 'true'
         uses: peter-evans/create-pull-request@v6
         with:
-          path: configng
           branch: bot/desktop-matrix-audit
           delete-branch: true
           base: main


### PR DESCRIPTION
## Summary

Fixes the 'fatal: not in a git directory' error and the non-existent output reference that broke the last CI run.

### Changes

1. **Checkout configng to workspace root** — the action was checking out configng into a \`configng/\` subdirectory, but \`claude-code-action\` runs \`git config\` in the workspace root and fails when \`.git\` is in a subdirectory. Now configng is at the root; the build repo moves to \`armbian-build/\`.

2. **Remove \`path: configng\` from peter-evans** — repo is at root, no path override needed.

3. **\`structured_output\` not \`conclusion\`** — the action doesn't expose a \`conclusion\` output. \`structured_output\` is the correct name.

### Test plan

- [ ] Merge, revert PR #829 (to restore the 5 missing releases as findings), then trigger the workflow manually