### PR TITLE
audit: fix git-dir, output ref, and bump max-turns to 30

### DIFF
--- a/.github/workflows/maintenance-desktop-audit.yml
+++ b/.github/workflows/maintenance-desktop-audit.yml
@@ -163,7 +163,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.prompt.outputs.prompt }}
           # Limit turns to prevent runaway conversations
-          claude_args: "--max-turns 15"
+          claude_args: "--max-turns 30"
 
       - name: "Open / update pull request"
         if: |


### PR DESCRIPTION
## Summary

Three fixes from the last CI runs of the claude-code-action integration.

### 1. Checkout configng to workspace root

The action was checking out configng into a \`configng/\` subdirectory, but \`claude-code-action\` runs \`git config\` in the workspace root. Fixed by removing \`path: configng\` from the checkout step; the build repo moves to \`armbian-build/\`.

### 2. \`structured_output\` not \`conclusion\`

The PR body referenced \`steps.claude.outputs.conclusion\` which doesn't exist. The correct output name is \`structured_output\`.

### 3. Bump max-turns from 15 to 30

Claude Code ran successfully but hit the 15-turn limit before finishing edits to all 8 DE YAMLs + common.yaml for 5 missing releases. 30 gives enough headroom.

## CI trace from last run

Claude Code authenticated, installed, started editing files — then:
\`\`\`
error: Claude Code returned an error result: Reached maximum number of turns (15)
\`\`\`

With 30 turns it should complete the full matrix.

## Test plan

- [ ] Merge this PR
- [ ] Trigger the workflow manually
- [ ] Confirm Claude Code completes and the bot PR is opened with all 5 missing releases covered