### PR TITLE
audit: allow Claude to write edits + stash execution log

### DIFF
--- a/.github/workflows/maintenance-desktop-audit.yml
+++ b/.github/workflows/maintenance-desktop-audit.yml
@@ -160,8 +160,31 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.prompt.outputs.prompt }}
-          # Limit turns to prevent runaway conversations
-          claude_args: "--max-turns 30"
+          # acceptEdits: let Claude apply Edit/Write without prompting.
+          # allowed-tools: without an explicit list the action denies
+          # most tool calls — a prior run produced 3 permission denials
+          # and 0 edits. Include Bash(git:*) for read-only git inspection.
+          claude_args: >-
+            --max-turns 30
+            --permission-mode acceptEdits
+            --allowed-tools Edit,Write,Read,Glob,Grep,Bash(git:*)
+
+      - name: "Stash Claude execution log for diagnostics"
+        if: always() && steps.audit.outputs.actionable == 'true' && github.event.inputs.dry_run != 'true'
+        run: |
+          src="${RUNNER_TEMP}/claude-execution-output.json"
+          if [[ -f "$src" ]]; then
+            cp "$src" "${{ github.workspace }}/claude-execution-output.json"
+          fi
+
+      - name: "Upload Claude execution log"
+        if: always() && steps.audit.outputs.actionable == 'true' && github.event.inputs.dry_run != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-execution-output
+          path: ${{ github.workspace }}/claude-execution-output.json
+          if-no-files-found: ignore
+          retention-days: 30
 
       - name: "Clean up temp files before PR creation"
         if: |
@@ -170,7 +193,7 @@ jobs:
         run: |
           # Remove build artifacts and temp files so peter-evans
           # only commits the YAML changes Claude made.
-          rm -rf armbian-build audit-report.json claude-prompt.txt
+          rm -rf armbian-build audit-report.json claude-prompt.txt claude-execution-output.json
 
       - name: "Open / update pull request"
         if: |


### PR DESCRIPTION
## Summary
- Run [24311122990](https://github.com/armbian/configng/actions/runs/24311122990/job/70980831505) surfaced a silent failure: the audit found 1 actionable item (missing release `resolute`), Claude ran 17 turns at a cost of \$0.41, but `permission_denials_count: 3` meant no edits landed — so `bot/desktop-matrix-audit` stayed at main and `peter-evans/create-pull-request` skipped PR creation.
- Fix: pass `--permission-mode acceptEdits` and an explicit `--allowed-tools Edit,Write,Read,Glob,Grep,Bash(git:*)` list to `claude-code-action@v1` so Claude's edits actually get written.
- Diagnostics: upload `claude-execution-output.json` from `${RUNNER_TEMP}` as an `always()` artifact so the next failure is debuggable from the transcript alone. Cleanup step extended so the log doesn't leak into the bot PR.

## Test plan
- [ ] Manual `workflow_dispatch` run after merge
- [ ] Confirm a PR opens when the audit reports actionable items (currently: 1 missing release `resolute`)
- [ ] Confirm `claude-execution-output` artifact is attached to the run
- [ ] Confirm the bot PR diff is scoped to `tools/modules/desktops/yaml/*` only