### PR TITLE
bianbu: bump noble snapshot from v2.2 to v2.3

### DIFF
--- a/tools/modules/desktops/yaml/bianbu.yaml
+++ b/tools/modules/desktops/yaml/bianbu.yaml
@@ -4,7 +4,7 @@ display_manager: none
 status: unsupported
 repo:
   # SpacemiT's K1 RISC-V archive is a frozen per-release snapshot — the
-  # suite path encodes the snapshot version (v2.2 on noble, v3.0 on
+  # suite path encodes the snapshot version (v2.3 on noble, v3.0 on
   # resolute), so the per-release `repo_suite` override below carries
   # that piece. Components are wider than the default `[main]` because
   # SpacemiT mirrors all four Ubuntu components.
@@ -56,12 +56,12 @@ releases:
   noble:
     architectures: [riscv64]
     repo_suite:
-      - "noble/snapshots/v2.2"
-      - "noble-security/snapshots/v2.2"
-      - "noble-updates/snapshots/v2.2"
-      - "noble-porting/snapshots/v2.2"
-      - "noble-customization/snapshots/v2.2"
-      - "bianbu-v2.2-updates"
+      - "noble/snapshots/v2.3"
+      - "noble-security/snapshots/v2.3"
+      - "noble-updates/snapshots/v2.3"
+      - "noble-porting/snapshots/v2.3"
+      - "noble-customization/snapshots/v2.3"
+      - "bianbu-v2.3-updates"
 
   resolute:
     architectures: [riscv64]


### PR DESCRIPTION
## Summary

SpacemiT published a v2.3 snapshot of their noble archive. Bump `bianbu.yaml`'s six noble `repo_suite` entries (base + -security, -updates, -porting, -customization, and the floating `bianbu-v<ver>-updates` channel) from v2.2 to v2.3, and update the inline comment.

`resolute` stays on v3.0 — that's a different snapshot track.

## Test plan

- [ ] Rendered source lines for bianbu noble should read `.../bianbu/ noble[*]/snapshots/v2.3 main universe restricted multiverse` and `.../bianbu/ bianbu-v2.3-updates main universe restricted multiverse`
- [ ] `resolute` continues to render v3.0 suites unchanged