### PR TITLE
desktops: route apt.armbian.com browsers + add code, armbian-imager, restore thunderbird

### DIFF
--- a/tools/modules/desktops/scripts/parse_desktop_yaml.py
+++ b/tools/modules/desktops/scripts/parse_desktop_yaml.py
@@ -177,23 +177,29 @@ def _apply_tier_overrides(packages, source, tier, release, arch):
         <tier>:
           architectures:
             <arch>:
+              packages: [...]          # add on this arch in any release
               packages_remove: [...]   # remove on this arch in any release
           releases:
             <release>:
               architectures:
                 <arch>:
+                  packages: [...]          # add on this release+arch combo
                   packages_remove: [...]   # remove on this release+arch combo
 
     Both layers are applied. Use the per-arch layer for permanent
-    arch-wide holes (e.g. blender always missing on armhf), and the
-    per-release-per-arch layer for transient holes (e.g. loupe missing
-    on bookworm because GNOME 43 didn't have it).
+    arch-wide additions/holes (e.g. google-chrome-stable always on
+    amd64, blender always missing on armhf), and the per-release-per-
+    arch layer for transient differences (e.g. loupe missing on
+    bookworm because GNOME 43 didn't have it).
     """
     tier_block = _as_dict(_as_dict(source.get("tier_overrides")).get(tier))
 
     # Per-arch (any release) layer.
     archs = _as_dict(tier_block.get("architectures"))
     arch_block = _as_dict(archs.get(arch))
+    for pkg in _as_list(arch_block.get("packages")):
+        if pkg not in packages:
+            packages.append(pkg)
     for pkg in _as_list(arch_block.get("packages_remove")):
         if pkg in packages:
             packages.remove(pkg)
@@ -203,6 +209,9 @@ def _apply_tier_overrides(packages, source, tier, release, arch):
     release_block = _as_dict(releases.get(release))
     release_archs = _as_dict(release_block.get("architectures"))
     release_arch_block = _as_dict(release_archs.get(arch))
+    for pkg in _as_list(release_arch_block.get("packages")):
+        if pkg not in packages:
+            packages.append(pkg)
     for pkg in _as_list(release_arch_block.get("packages_remove")):
         if pkg in packages:
             packages.remove(pkg)

--- a/tools/modules/desktops/yaml/common.yaml
+++ b/tools/modules/desktops/yaml/common.yaml
@@ -55,6 +55,7 @@ tiers:
       - inkscape
       - thunderbird
       - audacity
+      - code                  # vscode (from apt.armbian.com)
 
 # Browser substitution table for the literal `browser` token in any
 # tier. The parser replaces `browser` with the right package per
@@ -74,68 +75,64 @@ tiers:
 #   - Debian has 'firefox-esr' but NO 'firefox' package.
 #   - Ubuntu's 'chromium' .deb is a snap-shim wrapper that pulls in
 #     snapd. Armbian doesn't ship snapd, so the shim is broken at
-#     runtime — substitute a real GTK browser instead.
-#     epiphany-browser (GNOME Web) is small, native deb, and
-#     available on every Ubuntu arch.
+#     runtime — apt.armbian.com hosts real .debs (chromium, firefox,
+#     google-chrome-stable) used in this map instead.
+#   - amd64 always gets google-chrome-stable (Google publishes no
+#     arm/riscv builds, so this is amd64-only).
 #   - 'chromium' isn't built for riscv64 in either Debian or Ubuntu.
 #
-# Verified against Debian bookworm/trixie and Ubuntu noble/plucky as
-# of 2026-04. Update this map when new releases ship or when an
-# arch dependency changes.
+# Verified against Debian bookworm/trixie, Ubuntu noble/plucky, and
+# apt.armbian.com as of 2026-04. Update this map when new releases
+# ship or when an arch dependency changes.
 browser:
   bookworm:
-    amd64:   chromium
+    amd64:   google-chrome-stable
     arm64:   chromium
     armhf:   chromium
     # bookworm has no riscv64 port — no entry needed
   trixie:
-    amd64:   chromium
+    amd64:   google-chrome-stable
     arm64:   chromium
     armhf:   chromium
     riscv64: firefox-esr     # 'firefox' does not exist in Debian
   noble:
-    amd64:   epiphany-browser    # 'chromium' deb is a snap-shim
-    arm64:   epiphany-browser
-    armhf:   epiphany-browser
-    riscv64: epiphany-browser    # 'chromium'/'firefox' both missing
+    amd64:   google-chrome-stable
+    arm64:   chromium        # apt.armbian.com real .deb (Ubuntu's is snap-shim)
+    armhf:   chromium
+    riscv64: firefox          # apt.armbian.com real .deb
   plucky:
-    amd64:   epiphany-browser
-    arm64:   epiphany-browser
-    armhf:   epiphany-browser
-    riscv64: epiphany-browser
+    amd64:   google-chrome-stable
+    arm64:   chromium
+    armhf:   chromium
+    riscv64: firefox
   jammy:
-    # Ubuntu 22.04 LTS — same snap-shim situation as noble; the
-    # 'chromium' deb just invokes snapd which Armbian doesn't ship.
-    # epiphany-browser is a real native deb available on all arches.
-    amd64:   epiphany-browser
-    arm64:   epiphany-browser
-    armhf:   epiphany-browser
-    riscv64: epiphany-browser
+    # Ubuntu 22.04 LTS — chromium / firefox apt names on Ubuntu are
+    # snap-shims; apt.armbian.com hosts real .debs of the same name.
+    amd64:   google-chrome-stable
+    arm64:   chromium
+    armhf:   chromium
+    riscv64: firefox
   questing:
-    # Ubuntu 25.10 — same snap-shim situation as noble/plucky.
-    amd64:   epiphany-browser
-    arm64:   epiphany-browser
-    armhf:   epiphany-browser
-    riscv64: epiphany-browser
+    # Ubuntu 25.10
+    amd64:   google-chrome-stable
+    arm64:   chromium
+    armhf:   chromium
+    riscv64: firefox
   resolute:
-    # Ubuntu 26.04 LTS — same snap-shim situation as noble/plucky.
-    amd64:   epiphany-browser
-    arm64:   epiphany-browser
-    armhf:   epiphany-browser
-    riscv64: epiphany-browser
+    # Ubuntu 26.04 LTS
+    amd64:   google-chrome-stable
+    arm64:   chromium
+    armhf:   chromium
+    riscv64: firefox
   forky:
-    # Debian 14 — same rules as trixie: 'firefox' is not a Debian
-    # package, only 'firefox-esr' exists; chromium is available for
-    # the three tier-1 arches.
-    amd64:   chromium
+    # Debian 14 — same rules as trixie.
+    amd64:   google-chrome-stable
     arm64:   chromium
     armhf:   chromium
     riscv64: firefox-esr     # 'firefox' does not exist in Debian
   sid:
     # Debian unstable — same rules as trixie/forky.
-    # loong64 gets firefox-esr because chromium is not yet built for
-    # this architecture in the Debian archive.
-    amd64:   chromium
+    amd64:   google-chrome-stable
     arm64:   chromium
     armhf:   chromium
     riscv64: firefox-esr     # 'firefox' does not exist in Debian

--- a/tools/modules/desktops/yaml/common.yaml
+++ b/tools/modules/desktops/yaml/common.yaml
@@ -46,6 +46,7 @@ tiers:
       - vlc                  # media player
       - file-roller          # archive manager
       - transmission-gtk     # torrent client
+      - armbian-imager       # SD-card image flasher (from apt.armbian.com)
 
   full:
     packages:
@@ -231,42 +232,28 @@ tier_overrides:
         architectures:
           armhf:  { packages_remove: [thunderbird] }
       noble:
-        # thunderbird on Ubuntu is a snap-shim that only exists on
-        # amd64/arm64; the deb is missing on armhf and riscv64.
-        # We strip it on EVERY arch on Ubuntu because the shim
-        # requires snapd which Armbian doesn't ship.
+        # Ubuntu's thunderbird .deb on amd64/arm64 is a snap-shim
+        # wrapper, but apt.armbian.com hosts a real thunderbird .deb
+        # for those arches that wins by version. armhf and riscv64
+        # have no upstream Ubuntu deb at all and we don't (yet) ship
+        # them via apt.armbian.com — strip on those arches only.
         architectures:
-          amd64:    { packages_remove: [thunderbird] }
-          arm64:    { packages_remove: [thunderbird] }
           armhf:    { packages_remove: [thunderbird] }
           riscv64:  { packages_remove: [thunderbird] }
       plucky:
         architectures:
-          amd64:    { packages_remove: [thunderbird] }
-          arm64:    { packages_remove: [thunderbird] }
           armhf:    { packages_remove: [thunderbird] }
           riscv64:  { packages_remove: [thunderbird] }
       jammy:
-        # thunderbird on Ubuntu 22.04 (jammy) was migrated to a
-        # snap-shim deb; Armbian doesn't ship snapd so the shim is
-        # broken at runtime. Strip it on all arches, same as noble/plucky.
         architectures:
-          amd64:    { packages_remove: [thunderbird] }
-          arm64:    { packages_remove: [thunderbird] }
           armhf:    { packages_remove: [thunderbird] }
           riscv64:  { packages_remove: [thunderbird] }
       questing:
-        # Same snap-shim situation as noble/plucky.
         architectures:
-          amd64:    { packages_remove: [thunderbird] }
-          arm64:    { packages_remove: [thunderbird] }
           armhf:    { packages_remove: [thunderbird] }
           riscv64:  { packages_remove: [thunderbird] }
       resolute:
-        # Same snap-shim situation as noble/plucky.
         architectures:
-          amd64:    { packages_remove: [thunderbird] }
-          arm64:    { packages_remove: [thunderbird] }
           armhf:    { packages_remove: [thunderbird] }
           riscv64:  { packages_remove: [thunderbird] }
       forky:


### PR DESCRIPTION
## Summary

apt.armbian.com is always present on Armbian systems, so packages it hosts can sit in the regular YAML lists without any conditional-source juggling. This PR uses that to clean up the desktop matrix:

- **Browser virtual token** routes through apt.armbian.com .debs across the board:
  - `amd64` every release → `google-chrome-stable` (Google publishes no arm/riscv builds)
  - Ubuntu (jammy/noble/plucky/questing/resolute) `arm64`/`armhf` → real `chromium` (was `epiphany-browser` fallback because Ubuntu's deb is a snap-shim)
  - Ubuntu `riscv64` → real `firefox` (was `epiphany-browser`)
  - Debian unchanged: `chromium` for amd64/arm64/armhf, `firefox-esr` for riscv64
- **`mid` tier** gains `armbian-imager` (SD-card flasher; universal across arches)
- **`full` tier** gains `code` (vscode; universal)
- **Restore `thunderbird`** on Ubuntu amd64/arm64 — apt.armbian.com's real .deb wins over the snap-shim. armhf/riscv64 still strip it (deb missing upstream and not yet shipped via apt.armbian.com); the audit will catch any false positive on the next run.

### Schema extension

`_apply_tier_overrides()` now honours per-arch / per-release-per-arch `packages:` ADDS in addition to the existing `packages_remove`. Symmetric with how the top-level tier block already supports both. Not used after the browser-map refactor (the browser slot covers the only current need), but kept for future arch-only additions that don't fit the browser slot.

### Net effect

| release | arch | tier | browser | thunderbird | armbian-imager | code |
|---|---|---|---|---|---|---|
| noble | amd64 | mid | google-chrome-stable | — | ✓ | — |
| noble | amd64 | full | google-chrome-stable | ✓ | ✓ | ✓ |
| noble | arm64 | full | chromium | ✓ | ✓ | ✓ |
| noble | armhf | full | chromium | — | ✓ | ✓ |
| noble | riscv64 | full | firefox | — | ✓ | ✓ |
| trixie | amd64 | full | google-chrome-stable | ✓ | ✓ | ✓ |
| trixie | armhf | full | chromium | — | ✓ | ✓ |
| sid | loong64 | mid | firefox-esr | — | ✓ | — |

## Test plan

Smoke-tested locally across the matrix in the table above plus edge cases:

- [x] `bookworm/riscv64` mid drops the browser silently (no riscv64 entry in the bookworm browser map; intentional)
- [x] `sid/loong64` mid renders `firefox-esr` (chromium not yet built for loong64)
- [x] `code` lands at `full` on every arch
- [x] `armbian-imager` lands at `mid` on every arch
- [x] amd64 always renders `google-chrome-stable` regardless of release

Real-board tests still wanted:

- [ ] On a fresh Armbian noble/amd64 image, `armbian-config --api module_desktops install de=xfce tier=full` installs google-chrome-stable + code + armbian-imager + thunderbird + the rest, all from apt.armbian.com or the distro
- [ ] On Ubuntu noble/arm64, `chromium` resolves to the apt.armbian.com .deb (not the snap-transitional)
- [ ] On Debian trixie/amd64, no behaviour regression — `chromium` (Debian deb) replaced by `google-chrome-stable` (apt.armbian.com)