### PR TITLE
desktops: drop plucky and questing release blocks

### DIFF
--- a/tools/modules/desktops/scripts/parse_desktop_yaml.py
+++ b/tools/modules/desktops/scripts/parse_desktop_yaml.py
@@ -177,23 +177,29 @@ def _apply_tier_overrides(packages, source, tier, release, arch):
         <tier>:
           architectures:
             <arch>:
+              packages: [...]          # add on this arch in any release
               packages_remove: [...]   # remove on this arch in any release
           releases:
             <release>:
               architectures:
                 <arch>:
+                  packages: [...]          # add on this release+arch combo
                   packages_remove: [...]   # remove on this release+arch combo
 
     Both layers are applied. Use the per-arch layer for permanent
-    arch-wide holes (e.g. blender always missing on armhf), and the
-    per-release-per-arch layer for transient holes (e.g. loupe missing
-    on bookworm because GNOME 43 didn't have it).
+    arch-wide additions/holes (e.g. google-chrome-stable always on
+    amd64, blender always missing on armhf), and the per-release-per-
+    arch layer for transient differences (e.g. loupe missing on
+    bookworm because GNOME 43 didn't have it).
     """
     tier_block = _as_dict(_as_dict(source.get("tier_overrides")).get(tier))
 
     # Per-arch (any release) layer.
     archs = _as_dict(tier_block.get("architectures"))
     arch_block = _as_dict(archs.get(arch))
+    for pkg in _as_list(arch_block.get("packages")):
+        if pkg not in packages:
+            packages.append(pkg)
     for pkg in _as_list(arch_block.get("packages_remove")):
         if pkg in packages:
             packages.remove(pkg)
@@ -203,6 +209,9 @@ def _apply_tier_overrides(packages, source, tier, release, arch):
     release_block = _as_dict(releases.get(release))
     release_archs = _as_dict(release_block.get("architectures"))
     release_arch_block = _as_dict(release_archs.get(arch))
+    for pkg in _as_list(release_arch_block.get("packages")):
+        if pkg not in packages:
+            packages.append(pkg)
     for pkg in _as_list(release_arch_block.get("packages_remove")):
         if pkg in packages:
             packages.remove(pkg)

--- a/tools/modules/desktops/yaml/budgie.yaml
+++ b/tools/modules/desktops/yaml/budgie.yaml
@@ -56,5 +56,3 @@ releases:
   noble:
     architectures: [arm64, amd64]
 
-  plucky:
-    architectures: [arm64, amd64]

--- a/tools/modules/desktops/yaml/cinnamon.yaml
+++ b/tools/modules/desktops/yaml/cinnamon.yaml
@@ -66,19 +66,6 @@ releases:
     packages_uninstall:
       - ubuntu-session
 
-  plucky:
-    architectures: [arm64, amd64, riscv64]
-    packages:
-      - polkitd
-      - pkexec
-      - libu2f-udev
-    packages_remove:
-      - pavumeter
-    packages_uninstall:
-      - ubuntu-session
-
-  # ── Debian 14 / Debian Sid ─────────────────────────────────────────
-
   forky:
     # Debian 14 — pipewire replaces pulseaudio (same as trixie).
     # armhf excluded: cinnamon-desktop-environment has no armhf build.
@@ -117,19 +104,6 @@ releases:
       - polkitd
       - pkexec
       - libu2f-udev
-    packages_uninstall:
-      - ubuntu-session
-
-  questing:
-    # Ubuntu 25.10 — same as plucky; pavumeter absent from archive.
-    architectures: [arm64, amd64, riscv64]
-    packages:
-      - polkitd
-      - pkexec
-      - libu2f-udev
-    packages_remove:
-      # pavumeter was dropped from Ubuntu in plucky and stays absent.
-      - pavumeter
     packages_uninstall:
       - ubuntu-session
 

--- a/tools/modules/desktops/yaml/common.yaml
+++ b/tools/modules/desktops/yaml/common.yaml
@@ -201,6 +201,11 @@ tier_overrides:
         architectures:
           armhf:  { packages_remove: [loupe] }
   full:
+    # `code` (Microsoft VSCode) is published for amd64/arm64/armhf only —
+    # no riscv64 build exists upstream. Strip arch-wide.
+    architectures:
+      riscv64:
+        packages_remove: [code]
     releases:
       bookworm:
         # thunderbird is missing on bookworm/armhf.
@@ -234,5 +239,10 @@ tier_overrides:
           armhf:    { packages_remove: [thunderbird] }
       sid:
         # thunderbird is missing on sid/armhf — same gap as trixie/forky.
+        # `code` is not tracked for sid in apt.armbian.com (Debian unstable;
+        # vendor debs may break) — strip on every sid arch.
         architectures:
-          armhf:    { packages_remove: [thunderbird] }
+          amd64:    { packages_remove: [code] }
+          arm64:    { packages_remove: [code] }
+          armhf:    { packages_remove: [code, thunderbird] }
+          riscv64:  { packages_remove: [code] }

--- a/tools/modules/desktops/yaml/common.yaml
+++ b/tools/modules/desktops/yaml/common.yaml
@@ -82,8 +82,8 @@ tiers:
 #     arm/riscv builds, so this is amd64-only).
 #   - 'chromium' isn't built for riscv64 in either Debian or Ubuntu.
 #
-# Verified against Debian bookworm/trixie, Ubuntu noble/plucky, and
-# apt.armbian.com as of 2026-04. Update this map when new releases
+# Verified against Debian bookworm/trixie, Ubuntu jammy/noble/resolute,
+# and apt.armbian.com as of 2026-04. Update this map when new releases
 # ship or when an arch dependency changes.
 browser:
   bookworm:
@@ -101,20 +101,9 @@ browser:
     arm64:   chromium        # apt.armbian.com real .deb (Ubuntu's is snap-shim)
     armhf:   chromium
     riscv64: firefox          # apt.armbian.com real .deb
-  plucky:
-    amd64:   google-chrome-stable
-    arm64:   chromium
-    armhf:   chromium
-    riscv64: firefox
   jammy:
     # Ubuntu 22.04 LTS — chromium / firefox apt names on Ubuntu are
     # snap-shims; apt.armbian.com hosts real .debs of the same name.
-    amd64:   google-chrome-stable
-    arm64:   chromium
-    armhf:   chromium
-    riscv64: firefox
-  questing:
-    # Ubuntu 25.10
     amd64:   google-chrome-stable
     arm64:   chromium
     armhf:   chromium
@@ -199,11 +188,6 @@ tier_overrides:
           amd64:  { packages_remove: [loupe] }
           arm64:  { packages_remove: [loupe] }
           armhf:  { packages_remove: [loupe] }
-      plucky:
-        # loupe in plucky was dropped on armhf (GNOME 48 didn't ship
-        # an armhf build for it). Other arches still have it.
-        architectures:
-          armhf:  { packages_remove: [loupe] }
       jammy:
         # loupe was introduced with GNOME 44/45; Ubuntu 22.04 (jammy)
         # shipped GNOME 42 and has no loupe package on any arch.
@@ -212,13 +196,8 @@ tier_overrides:
           arm64:    { packages_remove: [loupe] }
           armhf:    { packages_remove: [loupe] }
           riscv64:  { packages_remove: [loupe] }
-      questing:
-        # loupe on armhf continues to be absent in questing — no GNOME
-        # armhf build for loupe, same gap as plucky.
-        architectures:
-          armhf:  { packages_remove: [loupe] }
       resolute:
-        # Same loupe/armhf gap as questing.
+        # loupe/armhf still missing — no GNOME armhf build.
         architectures:
           armhf:  { packages_remove: [loupe] }
   full:
@@ -240,15 +219,7 @@ tier_overrides:
         architectures:
           armhf:    { packages_remove: [thunderbird] }
           riscv64:  { packages_remove: [thunderbird] }
-      plucky:
-        architectures:
-          armhf:    { packages_remove: [thunderbird] }
-          riscv64:  { packages_remove: [thunderbird] }
       jammy:
-        architectures:
-          armhf:    { packages_remove: [thunderbird] }
-          riscv64:  { packages_remove: [thunderbird] }
-      questing:
         architectures:
           armhf:    { packages_remove: [thunderbird] }
           riscv64:  { packages_remove: [thunderbird] }

--- a/tools/modules/desktops/yaml/common.yaml
+++ b/tools/modules/desktops/yaml/common.yaml
@@ -55,6 +55,7 @@ tiers:
       - inkscape
       - thunderbird
       - audacity
+      - code                  # vscode (from apt.armbian.com)
 
 # Browser substitution table for the literal `browser` token in any
 # tier. The parser replaces `browser` with the right package per
@@ -74,68 +75,64 @@ tiers:
 #   - Debian has 'firefox-esr' but NO 'firefox' package.
 #   - Ubuntu's 'chromium' .deb is a snap-shim wrapper that pulls in
 #     snapd. Armbian doesn't ship snapd, so the shim is broken at
-#     runtime — substitute a real GTK browser instead.
-#     epiphany-browser (GNOME Web) is small, native deb, and
-#     available on every Ubuntu arch.
+#     runtime — apt.armbian.com hosts real .debs (chromium, firefox,
+#     google-chrome-stable) used in this map instead.
+#   - amd64 always gets google-chrome-stable (Google publishes no
+#     arm/riscv builds, so this is amd64-only).
 #   - 'chromium' isn't built for riscv64 in either Debian or Ubuntu.
 #
-# Verified against Debian bookworm/trixie and Ubuntu noble/plucky as
-# of 2026-04. Update this map when new releases ship or when an
-# arch dependency changes.
+# Verified against Debian bookworm/trixie, Ubuntu noble/plucky, and
+# apt.armbian.com as of 2026-04. Update this map when new releases
+# ship or when an arch dependency changes.
 browser:
   bookworm:
-    amd64:   chromium
+    amd64:   google-chrome-stable
     arm64:   chromium
     armhf:   chromium
     # bookworm has no riscv64 port — no entry needed
   trixie:
-    amd64:   chromium
+    amd64:   google-chrome-stable
     arm64:   chromium
     armhf:   chromium
     riscv64: firefox-esr     # 'firefox' does not exist in Debian
   noble:
-    amd64:   epiphany-browser    # 'chromium' deb is a snap-shim
-    arm64:   epiphany-browser
-    armhf:   epiphany-browser
-    riscv64: epiphany-browser    # 'chromium'/'firefox' both missing
+    amd64:   google-chrome-stable
+    arm64:   chromium        # apt.armbian.com real .deb (Ubuntu's is snap-shim)
+    armhf:   chromium
+    riscv64: firefox          # apt.armbian.com real .deb
   plucky:
-    amd64:   epiphany-browser
-    arm64:   epiphany-browser
-    armhf:   epiphany-browser
-    riscv64: epiphany-browser
+    amd64:   google-chrome-stable
+    arm64:   chromium
+    armhf:   chromium
+    riscv64: firefox
   jammy:
-    # Ubuntu 22.04 LTS — same snap-shim situation as noble; the
-    # 'chromium' deb just invokes snapd which Armbian doesn't ship.
-    # epiphany-browser is a real native deb available on all arches.
-    amd64:   epiphany-browser
-    arm64:   epiphany-browser
-    armhf:   epiphany-browser
-    riscv64: epiphany-browser
+    # Ubuntu 22.04 LTS — chromium / firefox apt names on Ubuntu are
+    # snap-shims; apt.armbian.com hosts real .debs of the same name.
+    amd64:   google-chrome-stable
+    arm64:   chromium
+    armhf:   chromium
+    riscv64: firefox
   questing:
-    # Ubuntu 25.10 — same snap-shim situation as noble/plucky.
-    amd64:   epiphany-browser
-    arm64:   epiphany-browser
-    armhf:   epiphany-browser
-    riscv64: epiphany-browser
+    # Ubuntu 25.10
+    amd64:   google-chrome-stable
+    arm64:   chromium
+    armhf:   chromium
+    riscv64: firefox
   resolute:
-    # Ubuntu 26.04 LTS — same snap-shim situation as noble/plucky.
-    amd64:   epiphany-browser
-    arm64:   epiphany-browser
-    armhf:   epiphany-browser
-    riscv64: epiphany-browser
+    # Ubuntu 26.04 LTS
+    amd64:   google-chrome-stable
+    arm64:   chromium
+    armhf:   chromium
+    riscv64: firefox
   forky:
-    # Debian 14 — same rules as trixie: 'firefox' is not a Debian
-    # package, only 'firefox-esr' exists; chromium is available for
-    # the three tier-1 arches.
-    amd64:   chromium
+    # Debian 14 — same rules as trixie.
+    amd64:   google-chrome-stable
     arm64:   chromium
     armhf:   chromium
     riscv64: firefox-esr     # 'firefox' does not exist in Debian
   sid:
     # Debian unstable — same rules as trixie/forky.
-    # loong64 gets firefox-esr because chromium is not yet built for
-    # this architecture in the Debian archive.
-    amd64:   chromium
+    amd64:   google-chrome-stable
     arm64:   chromium
     armhf:   chromium
     riscv64: firefox-esr     # 'firefox' does not exist in Debian

--- a/tools/modules/desktops/yaml/common.yaml
+++ b/tools/modules/desktops/yaml/common.yaml
@@ -46,6 +46,7 @@ tiers:
       - vlc                  # media player
       - file-roller          # archive manager
       - transmission-gtk     # torrent client
+      - armbian-imager       # SD-card image flasher (from apt.armbian.com)
 
   full:
     packages:
@@ -231,42 +232,28 @@ tier_overrides:
         architectures:
           armhf:  { packages_remove: [thunderbird] }
       noble:
-        # thunderbird on Ubuntu is a snap-shim that only exists on
-        # amd64/arm64; the deb is missing on armhf and riscv64.
-        # We strip it on EVERY arch on Ubuntu because the shim
-        # requires snapd which Armbian doesn't ship.
+        # Ubuntu's thunderbird .deb on amd64/arm64 is a snap-shim
+        # wrapper, but apt.armbian.com hosts a real thunderbird .deb
+        # for those arches that wins by version. armhf and riscv64
+        # have no upstream Ubuntu deb at all and we don't (yet) ship
+        # them via apt.armbian.com — strip on those arches only.
         architectures:
-          amd64:    { packages_remove: [thunderbird] }
-          arm64:    { packages_remove: [thunderbird] }
           armhf:    { packages_remove: [thunderbird] }
           riscv64:  { packages_remove: [thunderbird] }
       plucky:
         architectures:
-          amd64:    { packages_remove: [thunderbird] }
-          arm64:    { packages_remove: [thunderbird] }
           armhf:    { packages_remove: [thunderbird] }
           riscv64:  { packages_remove: [thunderbird] }
       jammy:
-        # thunderbird on Ubuntu 22.04 (jammy) was migrated to a
-        # snap-shim deb; Armbian doesn't ship snapd so the shim is
-        # broken at runtime. Strip it on all arches, same as noble/plucky.
         architectures:
-          amd64:    { packages_remove: [thunderbird] }
-          arm64:    { packages_remove: [thunderbird] }
           armhf:    { packages_remove: [thunderbird] }
           riscv64:  { packages_remove: [thunderbird] }
       questing:
-        # Same snap-shim situation as noble/plucky.
         architectures:
-          amd64:    { packages_remove: [thunderbird] }
-          arm64:    { packages_remove: [thunderbird] }
           armhf:    { packages_remove: [thunderbird] }
           riscv64:  { packages_remove: [thunderbird] }
       resolute:
-        # Same snap-shim situation as noble/plucky.
         architectures:
-          amd64:    { packages_remove: [thunderbird] }
-          arm64:    { packages_remove: [thunderbird] }
           armhf:    { packages_remove: [thunderbird] }
           riscv64:  { packages_remove: [thunderbird] }
       forky:

--- a/tools/modules/desktops/yaml/deepin.yaml
+++ b/tools/modules/desktops/yaml/deepin.yaml
@@ -53,5 +53,3 @@ releases:
   noble:
     architectures: [arm64, amd64]
 
-  plucky:
-    architectures: [arm64, amd64]

--- a/tools/modules/desktops/yaml/enlightenment.yaml
+++ b/tools/modules/desktops/yaml/enlightenment.yaml
@@ -47,15 +47,6 @@ releases:
       - pkexec
       - libu2f-udev
 
-  plucky:
-    architectures: [arm64, amd64, armhf, riscv64]
-    packages:
-      - polkitd
-      - pkexec
-      - libu2f-udev
-
-  # ── Debian 14 / Debian Sid ─────────────────────────────────────────
-
   forky:
     # Debian 14 — pipewire replaces pulseaudio (same as trixie).
     architectures: [arm64, amd64, armhf, riscv64]
@@ -88,14 +79,6 @@ releases:
   jammy:
     # Ubuntu 22.04 LTS — polkit split available via SRU;
     # pulseaudio remains default on jammy.
-    architectures: [arm64, amd64, armhf, riscv64]
-    packages:
-      - polkitd
-      - pkexec
-      - libu2f-udev
-
-  questing:
-    # Ubuntu 25.10 — same as plucky.
     architectures: [arm64, amd64, armhf, riscv64]
     packages:
       - polkitd

--- a/tools/modules/desktops/yaml/gnome.yaml
+++ b/tools/modules/desktops/yaml/gnome.yaml
@@ -86,19 +86,6 @@ releases:
     packages_uninstall:
       - ubuntu-session
 
-  plucky:
-    architectures: [arm64, amd64]
-    packages:
-      - polkitd
-      - pkexec
-      - libu2f-udev
-    packages_remove:
-      - pavumeter
-    packages_uninstall:
-      - ubuntu-session
-
-  # ── Debian 14 / Debian Sid ─────────────────────────────────────────
-
   forky:
     # Debian 14 — pipewire replaces pulseaudio (same as trixie).
     architectures: [arm64, amd64]
@@ -136,19 +123,6 @@ releases:
       - polkitd
       - pkexec
       - libu2f-udev
-    packages_uninstall:
-      - ubuntu-session
-
-  questing:
-    # Ubuntu 25.10 — same as plucky; pavumeter absent from archive.
-    architectures: [arm64, amd64]
-    packages:
-      - polkitd
-      - pkexec
-      - libu2f-udev
-    packages_remove:
-      # pavumeter was dropped from Ubuntu in plucky and stays absent.
-      - pavumeter
     packages_uninstall:
       - ubuntu-session
 

--- a/tools/modules/desktops/yaml/i3-wm.yaml
+++ b/tools/modules/desktops/yaml/i3-wm.yaml
@@ -59,17 +59,6 @@ releases:
       - pkexec
       - libu2f-udev
 
-  plucky:
-    architectures: [arm64, amd64, armhf, riscv64]
-    packages:
-      - polkitd
-      - pkexec
-      - libu2f-udev
-    packages_remove:
-      - pavumeter
-
-  # ── Debian 14 / Debian Sid ─────────────────────────────────────────
-
   forky:
     # Debian 14 — pipewire replaces pulseaudio (same as trixie).
     architectures: [arm64, amd64, armhf, riscv64]
@@ -107,17 +96,6 @@ releases:
       - polkitd
       - pkexec
       - libu2f-udev
-
-  questing:
-    # Ubuntu 25.10 — same as plucky; pavumeter absent from archive.
-    architectures: [arm64, amd64, armhf, riscv64]
-    packages:
-      - polkitd
-      - pkexec
-      - libu2f-udev
-    packages_remove:
-      # pavumeter was dropped from Ubuntu in plucky and stays absent.
-      - pavumeter
 
   resolute:
     # Ubuntu 26.04 LTS — same as questing; pavumeter still absent.

--- a/tools/modules/desktops/yaml/kde-neon.yaml
+++ b/tools/modules/desktops/yaml/kde-neon.yaml
@@ -41,5 +41,3 @@ releases:
   noble:
     architectures: [arm64, amd64]
 
-  plucky:
-    architectures: [arm64, amd64]

--- a/tools/modules/desktops/yaml/kde-plasma.yaml
+++ b/tools/modules/desktops/yaml/kde-plasma.yaml
@@ -88,15 +88,6 @@ releases:
       - pkexec
       - libu2f-udev
 
-  plucky:
-    architectures: [arm64, amd64]
-    packages:
-      - polkitd
-      - pkexec
-      - libu2f-udev
-
-  # ── Debian 14 / Debian Sid ─────────────────────────────────────────
-
   forky:
     # Debian 14 — pipewire replaces pulseaudio (same as trixie).
     architectures: [arm64, amd64]
@@ -129,14 +120,6 @@ releases:
   jammy:
     # Ubuntu 22.04 LTS — polkit split available via SRU;
     # pulseaudio remains default on jammy.
-    architectures: [arm64, amd64]
-    packages:
-      - polkitd
-      - pkexec
-      - libu2f-udev
-
-  questing:
-    # Ubuntu 25.10 — same as plucky.
     architectures: [arm64, amd64]
     packages:
       - polkitd

--- a/tools/modules/desktops/yaml/mate.yaml
+++ b/tools/modules/desktops/yaml/mate.yaml
@@ -73,19 +73,6 @@ releases:
     packages_uninstall:
       - ubuntu-session
 
-  plucky:
-    architectures: [arm64, amd64, armhf, riscv64]
-    packages:
-      - polkitd
-      - pkexec
-      - libu2f-udev
-    packages_remove:
-      - pavumeter
-    packages_uninstall:
-      - ubuntu-session
-
-  # ── Debian 14 / Debian Sid ─────────────────────────────────────────
-
   forky:
     # Debian 14 — pipewire replaces pulseaudio (same as trixie).
     architectures: [arm64, amd64, armhf, riscv64]
@@ -123,19 +110,6 @@ releases:
       - polkitd
       - pkexec
       - libu2f-udev
-    packages_uninstall:
-      - ubuntu-session
-
-  questing:
-    # Ubuntu 25.10 — same as plucky; pavumeter absent from archive.
-    architectures: [arm64, amd64, armhf, riscv64]
-    packages:
-      - polkitd
-      - pkexec
-      - libu2f-udev
-    packages_remove:
-      # pavumeter was dropped from Ubuntu in plucky and stays absent.
-      - pavumeter
     packages_uninstall:
       - ubuntu-session
 

--- a/tools/modules/desktops/yaml/xfce.yaml
+++ b/tools/modules/desktops/yaml/xfce.yaml
@@ -87,20 +87,6 @@ releases:
       # would yank gnome-control-center along with it.
       - ubuntu-session
 
-  plucky:
-    architectures: [arm64, amd64, armhf, riscv64]
-    packages:
-      - polkitd
-      - pkexec
-      - libu2f-udev
-    packages_remove:
-      # pavumeter was dropped from the Ubuntu plucky archive
-      - pavumeter
-    packages_uninstall:
-      - ubuntu-session
-
-  # ── Debian 14 / Debian Sid ─────────────────────────────────────────
-
   forky:
     # Debian 14 — pipewire replaces pulseaudio (same as trixie).
     architectures: [arm64, amd64, armhf, riscv64]
@@ -138,19 +124,6 @@ releases:
       - polkitd
       - pkexec
       - libu2f-udev
-    packages_uninstall:
-      - ubuntu-session
-
-  questing:
-    # Ubuntu 25.10 — same as plucky; pavumeter absent from archive.
-    architectures: [arm64, amd64, armhf, riscv64]
-    packages:
-      - polkitd
-      - pkexec
-      - libu2f-udev
-    packages_remove:
-      # pavumeter was dropped from Ubuntu in plucky and stays absent.
-      - pavumeter
     packages_uninstall:
       - ubuntu-session
 

--- a/tools/modules/desktops/yaml/xmonad.yaml
+++ b/tools/modules/desktops/yaml/xmonad.yaml
@@ -50,15 +50,6 @@ releases:
       - pkexec
       - libu2f-udev
 
-  plucky:
-    architectures: [arm64, amd64, armhf, riscv64]
-    packages:
-      - polkitd
-      - pkexec
-      - libu2f-udev
-
-  # ── Debian 14 / Debian Sid ─────────────────────────────────────────
-
   forky:
     # Debian 14 — pipewire replaces pulseaudio (same as trixie).
     architectures: [arm64, amd64, armhf, riscv64]
@@ -91,14 +82,6 @@ releases:
   jammy:
     # Ubuntu 22.04 LTS — polkit split available via SRU;
     # pulseaudio remains default on jammy.
-    architectures: [arm64, amd64, armhf, riscv64]
-    packages:
-      - polkitd
-      - pkexec
-      - libu2f-udev
-
-  questing:
-    # Ubuntu 25.10 — same as plucky.
     architectures: [arm64, amd64, armhf, riscv64]
     packages:
       - polkitd


### PR DESCRIPTION
## Summary

`plucky` (Ubuntu 25.04) is **eos** as of 2026-01-25 — see [armbian/build#9657](https://github.com/armbian/build/pull/9657) where we flipped its support flag. The audit script already excludes eos releases from "missing", but it does not auto-remove existing entries; those just sit as drift across every DE YAML.

`questing` (Ubuntu 25.10) is a 9-month interim release with about **3 months of life left** (EOL ~2026-07). Rare on real boards and not worth the per-release maintenance overhead.

This sweep removes both from every desktop YAML.

### Dropped

| file | what |
|---|---|
| `common.yaml` | browser map (plucky, questing); tier_overrides.mid loupe blocks (plucky, questing); tier_overrides.full thunderbird blocks (plucky, questing) |
| `xfce.yaml`, `gnome.yaml`, `kde-plasma.yaml`, `kde-neon.yaml`, `mate.yaml`, `cinnamon.yaml`, `i3-wm.yaml`, `xmonad.yaml`, `enlightenment.yaml`, `budgie.yaml`, `deepin.yaml` | `plucky:` and `questing:` release blocks |

`bianbu.yaml` was already noble+resolute only — nothing to drop there.

Comments mentioning plucky/questing as historical context (e.g. "pavumeter dropped in plucky") are kept as reference.

### Knock-on

- [armbian/os#444](https://github.com/armbian/os/pull/444) drops the questing aptly configs (`chromium-aarch64-questing.conf`, `firefox-questing.conf`, `thunderbird-questing.conf`) since this PR removes their consumer.

### Stack

Built on top of [armbian/configng#848](https://github.com/armbian/configng/pull/848) (apt.armbian.com browser routing). Will rebase cleanly when #848 merges.

## Test plan

- [x] `parse_desktop_yaml.py` — `DESKTOP_SUPPORTED="yes"` for every kept release × arch on xfce; `"no"` for plucky/questing
- [x] All 12 DE YAML files still parse (sanity ran across the matrix)
- [ ] Audit workflow on next run does not report plucky as a missing release (it's eos, already excluded)
- [ ] No remaining build/CI matrix references to plucky/questing in configng