### PR TITLE
desktops: install runtime apt pin so apt.armbian.com .debs

### DIFF
--- a/tools/modules/desktops/module_desktops.sh
+++ b/tools/modules/desktops/module_desktops.sh
@@ -162,8 +162,15 @@ function module_desktops() {
 				echo "Warning: '${de}' is not supported on ${DISTROID}/$(dpkg --print-architecture)" >&2
 			fi
 
-			# suppress interactive prompts
-			echo "encfs encfs/security-information boolean true" | debconf-set-selections 2>/dev/null || true
+			# Suppress interactive prompts. The `code` (Microsoft VSCode)
+			# postinst asks whether to add the Microsoft apt repository
+			# — say no, because apt.armbian.com already hosts code and
+			# adding the parallel Microsoft source would race against
+			# our pin on every apt-get update.
+			debconf-set-selections 2>/dev/null <<- 'EOF' || true
+			encfs encfs/security-information boolean true
+			code code/add-microsoft-repo boolean false
+			EOF
 
 			# set up custom repo if needed
 			if ! module_desktop_repo "$de"; then

--- a/tools/modules/desktops/module_desktops.sh
+++ b/tools/modules/desktops/module_desktops.sh
@@ -30,6 +30,78 @@ _desktop_in_container() {
 }
 
 #
+# Write the apt pin that forces apt.armbian.com .debs to win over
+# Ubuntu's snap-transitional packages for desktop apps. Idempotent —
+# writes via temp + atomic mv so a partial write never leaves apt with
+# an unparseable preferences file.
+#
+# Lives at /etc/apt/preferences.d/armbian-desktops (note: NOT the
+# legacy `armbian` filename, which is a dpkg conffile shipped by the
+# BSP — that one gets preserved on upgrade once a user has it,
+# leaving stale content on the system. By using a distinct filename
+# managed entirely by armbian-config we can update the pin via
+# configng upgrades alone, no BSP rebuild required).
+#
+# Priority 1001 (not 990) is mandatory: Ubuntu's snap-transitional
+# packages have a higher epoch than Armbian's real .debs. 990 only
+# permits upgrades; 1001 also permits the downgrade required to swap
+# the snap-shim out for the real package. The Ubuntu-side priority
+# of 50 keeps the snap-shim from ever being auto-selected when the
+# real .deb is available.
+#
+# Non-fatal: a write failure warns and returns 1 but does not abort
+# the install — apt without the pin will pick whatever wins by
+# default, which is wrong but not catastrophic.
+#
+function _module_desktops_write_apt_pin() {
+	local pin_file="/etc/apt/preferences.d/armbian-desktops"
+	local pin_tmp="${pin_file}.tmp"
+
+	# Packages where apt.armbian.com hosts a real .deb that should
+	# always win over Ubuntu's snap-transitional / older Debian
+	# version. Wildcards cover the codec / l10n meta-packages.
+	local force_pkgs="chromium chromium-* firefox firefox-esr firefox-l10n-* thunderbird thunderbird-l10n-* google-chrome-stable code microsoft-edge-stable"
+
+	# Subset to deprioritize from the Ubuntu archive — only those
+	# that have a Ubuntu equivalent. `code` and `microsoft-edge-stable`
+	# are Microsoft-only, no Ubuntu version to push down.
+	local strip_pkgs="chromium chromium-* firefox firefox-esr firefox-l10n-* thunderbird thunderbird-l10n-* google-chrome-stable"
+
+	if ! cat > "$pin_tmp" <<- EOF
+	# Managed by armbian-config (module_desktops). Do not edit by hand.
+	#
+	# Force apt.armbian.com versions of these desktop packages over
+	# Ubuntu's snap-transitional ones. Priority 1001 is required
+	# (not 990) because the snap-shim packages have a higher epoch —
+	# 990 only allows upgrades; 1001 also permits the downgrade
+	# required to replace the snap-shim with the real .deb.
+	Package: ${force_pkgs}
+	Pin: release o=Armbian
+	Pin-Priority: 1001
+
+	# Push Ubuntu's snap-shim versions below the default 500 so they
+	# are never auto-selected when the real apt.armbian.com .deb is
+	# available.
+	Package: ${strip_pkgs}
+	Pin: release o=Ubuntu
+	Pin-Priority: 50
+	EOF
+	then
+		echo "Warning: failed to write ${pin_tmp}, desktop apt pin not installed" >&2
+		rm -f "$pin_tmp"
+		return 1
+	fi
+
+	if ! mv "$pin_tmp" "$pin_file"; then
+		echo "Warning: failed to install ${pin_file}" >&2
+		rm -f "$pin_tmp"
+		return 1
+	fi
+
+	return 0
+}
+
+#
 # Module to install and manage desktop environments (YAML-driven)
 #
 function module_desktops() {
@@ -98,6 +170,12 @@ function module_desktops() {
 				echo "Error: failed to set up repository for '${de}', aborting install" >&2
 				return 1
 			fi
+
+			# Install the apt pin BEFORE pkg_update / pkg_install so apt
+			# resolves the desktop package list with apt.armbian.com .debs
+			# winning over Ubuntu's snap-transitional packages. Non-fatal:
+			# the install continues even if the pin write fails.
+			_module_desktops_write_apt_pin || true
 
 			# update package list
 			pkg_update

--- a/tools/modules/desktops/yaml/common.yaml
+++ b/tools/modules/desktops/yaml/common.yaml
@@ -47,6 +47,9 @@ tiers:
       - file-roller          # archive manager
       - transmission-gtk     # torrent client
       - armbian-imager       # SD-card image flasher (from apt.armbian.com)
+      - cups-pk-helper       # polkit bridge — lets GNOME/KDE printer panels
+                             # unlock cups config without sudo. Other DEs
+                             # get this transitively via system-config-printer.
 
   full:
     packages:


### PR DESCRIPTION
## Summary

The desktop YAML lists `chromium` / `firefox` / `thunderbird` / `chrome` / `code` / `edge` expecting apt.armbian.com to host them as real .debs that should win over Ubuntu's snap-transitional packages. For that to actually happen, an apt pin must force `o=Armbian` to priority **1001** and push `o=Ubuntu` down to **50**.

Today that pin lives in the BSP at [packages/bsp/common/etc/apt/preferences.d/armbian](https://github.com/armbian/build/blob/main/packages/bsp/common/etc/apt/preferences.d/armbian). That file is a **dpkg conffile** — once a user has any version on disk (even the May-2023 → Feb-2026 era one which was shipped fully commented out), `armbian-bsp-cli` upgrades preserve the local copy instead of installing the new one. Result on those systems: the pin is inert and the snap-shim wins. Exactly the symptom we just debugged on a real test box.

## Fix

Move pin ownership to armbian-config and write to a **distinct path** so dpkg's conffile preservation is moot:

- `_module_desktops_write_apt_pin()` writes `/etc/apt/preferences.d/armbian-desktops` via temp + atomic `mv`. Idempotent — runs on every `install`, always reflects the current configng version.
- Wired into the `install` subcommand **before** `pkg_update` / `pkg_install` so apt resolves the desktop package list with the right priority from the first invocation.
- Non-fatal: pin write failure warns and continues — better than aborting a desktop install over a preferences file.

Pin block emitted:

```
Package: chromium chromium-* firefox firefox-esr firefox-l10n-* thunderbird thunderbird-l10n-* google-chrome-stable code microsoft-edge-stable
Pin: release o=Armbian
Pin-Priority: 1001

Package: chromium chromium-* firefox firefox-esr firefox-l10n-* thunderbird thunderbird-l10n-* google-chrome-stable
Pin: release o=Ubuntu
Pin-Priority: 50
```

### Why 1001, not 990

Ubuntu's snap-transitional packages have a higher epoch than Armbian's real .debs. Priority 990 only permits upgrades; 1001 also permits the downgrade required to swap an existing snap-shim install for the real .deb. The build-repo HEAD pin already uses 1001 — this matches.

### Stack

Built on top of:
- [armbian/configng#848](https://github.com/armbian/configng/pull/848) — apt.armbian.com browser routing
- [armbian/configng#849](https://github.com/armbian/configng/pull/849) — drop plucky/questing

Will rebase cleanly when those land.

### Build-repo follow-up

Newly-built images still install desktop packages via the build framework's own apt path, so they'd get the snap-shim until either:

1. The build invokes `module_desktops install` for desktop images (long-term — single source of truth), or
2. The build also writes the same pin file from its desktop hook (short-term bridge)

Separate PR. The BSP pin file at `packages/bsp/common/etc/apt/preferences.d/armbian` should also be deleted (or kept minimal) once the runtime pin is the source of truth.

## Test plan

- [x] Helper renders the expected pin file content (smoke-tested in isolation)
- [x] Bash syntax check of the modified module
- [ ] On a real Armbian noble system: `armbian-config --api module_desktops install de=xfce tier=full` produces `/etc/apt/preferences.d/armbian-desktops` with both pin blocks, and `apt-cache policy thunderbird` shows Armbian = 1001, Ubuntu = 50, snap-shim NOT installed
- [ ] On a system that already had the snap-shim installed: install path downgrades it to the apt.armbian.com real .deb (1001 forces the swap)
- [ ] Pin write failure (e.g. read-only `/etc`) warns and the install still proceeds