### PR TITLE
tests: enable resolute on every desktop test

### DIFF
--- a/tests/BUDG01.conf
+++ b/tests/BUDG01.conf
@@ -1,5 +1,5 @@
 ENABLED=false
-RELEASE="trixie:noble"
+RELEASE="trixie:noble:resolute"
 TESTNAME="Budgie desktop"
 
 testcase() {(

--- a/tests/CINM01.conf
+++ b/tests/CINM01.conf
@@ -1,5 +1,5 @@
 ENABLED=true
-RELEASE="bookworm:trixie:noble"
+RELEASE="bookworm:trixie:noble:resolute"
 TESTNAME="Cinnamon desktop"
 
 testcase() {(

--- a/tests/DEEP01.conf
+++ b/tests/DEEP01.conf
@@ -1,5 +1,5 @@
 ENABLED=false
-RELEASE="bookworm:trixie:noble"
+RELEASE="bookworm:trixie:noble:resolute"
 TESTNAME="Deepin desktop"
 
 testcase() {(

--- a/tests/ENLI01.conf
+++ b/tests/ENLI01.conf
@@ -1,5 +1,5 @@
 ENABLED=true
-RELEASE="bookworm:trixie:noble"
+RELEASE="bookworm:trixie:noble:resolute"
 TESTNAME="enlightenment desktop"
 
 testcase() {(

--- a/tests/GNME01.conf
+++ b/tests/GNME01.conf
@@ -1,5 +1,5 @@
 ENABLED=true
-RELEASE="bookworm:trixie:noble"
+RELEASE="bookworm:trixie:noble:resolute"
 TESTNAME="GNOME desktop"
 
 testcase() {(

--- a/tests/I3WM01.conf
+++ b/tests/I3WM01.conf
@@ -1,5 +1,5 @@
 ENABLED=true
-RELEASE="bookworm:trixie:noble"
+RELEASE="bookworm:trixie:noble:resolute"
 TESTNAME="i3-wm desktop"
 
 testcase() {(

--- a/tests/KDEN01.conf
+++ b/tests/KDEN01.conf
@@ -1,5 +1,5 @@
 ENABLED=true
-RELEASE="noble:resolute"
+RELEASE="noble"
 TESTNAME="KDE Neon desktop"
 
 testcase() {(

--- a/tests/KDEN01.conf
+++ b/tests/KDEN01.conf
@@ -1,5 +1,5 @@
 ENABLED=true
-RELEASE="noble:plucky"
+RELEASE="noble:resolute"
 TESTNAME="KDE Neon desktop"
 
 testcase() {(

--- a/tests/KDEP01.conf
+++ b/tests/KDEP01.conf
@@ -1,5 +1,5 @@
 ENABLED=true
-RELEASE="bookworm:trixie:noble"
+RELEASE="bookworm:trixie:noble:resolute"
 TESTNAME="KDE Plasma desktop"
 
 testcase() {(

--- a/tests/MATE01.conf
+++ b/tests/MATE01.conf
@@ -1,5 +1,5 @@
 ENABLED=true
-RELEASE="bookworm:trixie:noble"
+RELEASE="bookworm:trixie:noble:resolute"
 TESTNAME="Mate desktop"
 
 testcase() {(

--- a/tests/XFCE01.conf
+++ b/tests/XFCE01.conf
@@ -1,5 +1,5 @@
 ENABLED=true
-RELEASE="bookworm:trixie:noble"
+RELEASE="bookworm:trixie:noble:resolute"
 TESTNAME="XFCE desktop"
 
 testcase() {(

--- a/tests/XMON01.conf
+++ b/tests/XMON01.conf
@@ -1,5 +1,5 @@
 ENABLED=true
-RELEASE="bookworm:trixie:noble"
+RELEASE="bookworm:trixie:noble:resolute"
 TESTNAME="xmonad desktop"
 
 testcase() {(


### PR DESCRIPTION
## Summary

resolute (Ubuntu 26.04 LTS) was promoted to `supported` in [armbian/build#9657](https://github.com/armbian/build/pull/9657), and [armbian/os#444](https://github.com/armbian/os/pull/444) added apt.armbian.com coverage for the desktop snap-shim workarounds + vendor apps on resolute. Now exercise the desktop install path on resolute in CI.

| test | before | after |
|---|---|---|
| `BUDG01.conf` | `trixie:noble` | `trixie:noble:resolute` |
| `CINM01.conf` | `bookworm:trixie:noble` | `bookworm:trixie:noble:resolute` |
| `DEEP01.conf` | (same) | (same) |
| `ENLI01.conf` | (same) | (same) |
| `GNME01.conf` | (same) | (same) |
| `I3WM01.conf` | (same) | (same) |
| `KDEP01.conf` | (same) | (same) |
| `MATE01.conf` | (same) | (same) |
| `XFCE01.conf` | (same) | (same) |
| `XMON01.conf` | (same) | (same) |
| `KDEN01.conf` | `noble:plucky` | `noble:resolute` (plucky eos as of 2026-01-25) |

## Test plan

- [ ] CI matrix runs each desktop test against `resolute` and passes
- [ ] No regression on existing release coverage