### PR TITLE
desktops: brand Chromium / Chrome / Firefox(-esr) first-run + homepage

### DIFF
--- a/tools/modules/desktops/branding/browsers/etc/chromium.d/armbian-flags
+++ b/tools/modules/desktops/branding/browsers/etc/chromium.d/armbian-flags
@@ -1,0 +1,12 @@
+# Armbian: enable hardware VPU video decoder.
+#
+# Without this flag chromium falls back to software decoding even
+# when /dev/video-dec* is exposed by the BSP udev rules — works,
+# but burns CPU and limits resolution. AcceleratedVideoDecoder
+# turns on the v4l2-based path that uses the SBC's VPU.
+#
+# Sourced by the chromium launcher alongside every other file in
+# /etc/chromium.d/. Lives in its own file (not the chromium
+# package's own /etc/chromium.d/default-flags conffile) so apt
+# upgrades of chromium can never wipe this addition.
+export CHROMIUM_FLAGS="$CHROMIUM_FLAGS --enable-features=AcceleratedVideoDecoder"

--- a/tools/modules/desktops/branding/browsers/etc/chromium/master_preferences
+++ b/tools/modules/desktops/branding/browsers/etc/chromium/master_preferences
@@ -1,12 +1,12 @@
 {
-  "distribution": {
-    "import_bookmarks": false,
-    "import_history": false,
-    "import_search_engine": false,
-    "import_home_page": false,
-    "skip_first_run_ui": true,
-    "make_chrome_default": false,
-    "make_chrome_default_for_user": false,
-    "suppress_first_run_default_browser_prompt": true
-  }
+    "distribution": {
+        "import_bookmarks": false,
+        "import_history": false,
+        "import_search_engine": false,
+        "import_home_page": false,
+        "skip_first_run_ui": true,
+        "make_chrome_default": false,
+        "make_chrome_default_for_user": false,
+        "suppress_first_run_default_browser_prompt": true
+    }
 }

--- a/tools/modules/desktops/branding/browsers/etc/chromium/master_preferences
+++ b/tools/modules/desktops/branding/browsers/etc/chromium/master_preferences
@@ -1,0 +1,12 @@
+{
+  "distribution": {
+    "import_bookmarks": false,
+    "import_history": false,
+    "import_search_engine": false,
+    "import_home_page": false,
+    "skip_first_run_ui": true,
+    "make_chrome_default": false,
+    "make_chrome_default_for_user": false,
+    "suppress_first_run_default_browser_prompt": true
+  }
+}

--- a/tools/modules/desktops/branding/browsers/etc/chromium/policies/managed/armbian.json
+++ b/tools/modules/desktops/branding/browsers/etc/chromium/policies/managed/armbian.json
@@ -1,0 +1,24 @@
+{
+    "_comment": "Armbian managed bookmarks for Chromium. ManagedBookmarks is a mandatory-only policy per Chrome Enterprise docs — it creates a read-only `Managed bookmarks > Armbian` folder on the bookmarks bar.",
+    "ManagedBookmarks": [
+        {
+            "toplevel_name": "Armbian"
+        },
+        {
+            "name": "Armbian",
+            "url": "https://www.armbian.com"
+        },
+        {
+            "name": "Documentation",
+            "url": "https://docs.armbian.com"
+        },
+        {
+            "name": "Forum",
+            "url": "https://forum.armbian.com"
+        },
+        {
+            "name": "GitHub",
+            "url": "https://github.com/armbian"
+        }
+    ]
+}

--- a/tools/modules/desktops/branding/browsers/etc/chromium/policies/recommended/armbian.json
+++ b/tools/modules/desktops/branding/browsers/etc/chromium/policies/recommended/armbian.json
@@ -1,0 +1,17 @@
+{
+  "_comment": "Armbian default Chromium policies. `recommended/` means user can change these after first run. ManagedBookmarks creates a read-only Armbian folder on the bookmarks bar.",
+  "RestoreOnStartup": 4,
+  "RestoreOnStartupURLs": ["https://www.armbian.com/welcome"],
+  "HomepageLocation": "https://www.armbian.com",
+  "HomepageIsNewTabPage": false,
+  "ShowHomeButton": true,
+  "BookmarkBarEnabled": true,
+  "ManagedBookmarks": [
+    {"toplevel_name": "Armbian"},
+    {"name": "Armbian", "url": "https://www.armbian.com"},
+    {"name": "Documentation", "url": "https://docs.armbian.com"},
+    {"name": "Forum", "url": "https://forum.armbian.com"},
+    {"name": "GitHub", "url": "https://github.com/armbian"}
+  ],
+  "MetricsReportingEnabled": false
+}

--- a/tools/modules/desktops/branding/browsers/etc/chromium/policies/recommended/armbian.json
+++ b/tools/modules/desktops/branding/browsers/etc/chromium/policies/recommended/armbian.json
@@ -1,5 +1,5 @@
 {
-    "_comment": "Armbian default Chromium policies. `recommended/` means user can change these after first run. ManagedBookmarks creates a read-only Armbian folder on the bookmarks bar.",
+    "_comment": "Armbian default Chromium policies. `recommended/` means user can change these after first run. ManagedBookmarks lives in the sibling managed/ file (mandatory-only policy per Chrome Enterprise docs).",
     "RestoreOnStartup": 4,
     "RestoreOnStartupURLs": [
         "https://www.armbian.com/welcome"
@@ -8,26 +8,5 @@
     "HomepageIsNewTabPage": false,
     "ShowHomeButton": true,
     "BookmarkBarEnabled": true,
-    "ManagedBookmarks": [
-        {
-            "toplevel_name": "Armbian"
-        },
-        {
-            "name": "Armbian",
-            "url": "https://www.armbian.com"
-        },
-        {
-            "name": "Documentation",
-            "url": "https://docs.armbian.com"
-        },
-        {
-            "name": "Forum",
-            "url": "https://forum.armbian.com"
-        },
-        {
-            "name": "GitHub",
-            "url": "https://github.com/armbian"
-        }
-    ],
     "MetricsReportingEnabled": false
 }

--- a/tools/modules/desktops/branding/browsers/etc/chromium/policies/recommended/armbian.json
+++ b/tools/modules/desktops/branding/browsers/etc/chromium/policies/recommended/armbian.json
@@ -1,17 +1,33 @@
 {
-  "_comment": "Armbian default Chromium policies. `recommended/` means user can change these after first run. ManagedBookmarks creates a read-only Armbian folder on the bookmarks bar.",
-  "RestoreOnStartup": 4,
-  "RestoreOnStartupURLs": ["https://www.armbian.com/welcome"],
-  "HomepageLocation": "https://www.armbian.com",
-  "HomepageIsNewTabPage": false,
-  "ShowHomeButton": true,
-  "BookmarkBarEnabled": true,
-  "ManagedBookmarks": [
-    {"toplevel_name": "Armbian"},
-    {"name": "Armbian", "url": "https://www.armbian.com"},
-    {"name": "Documentation", "url": "https://docs.armbian.com"},
-    {"name": "Forum", "url": "https://forum.armbian.com"},
-    {"name": "GitHub", "url": "https://github.com/armbian"}
-  ],
-  "MetricsReportingEnabled": false
+    "_comment": "Armbian default Chromium policies. `recommended/` means user can change these after first run. ManagedBookmarks creates a read-only Armbian folder on the bookmarks bar.",
+    "RestoreOnStartup": 4,
+    "RestoreOnStartupURLs": [
+        "https://www.armbian.com/welcome"
+    ],
+    "HomepageLocation": "https://www.armbian.com",
+    "HomepageIsNewTabPage": false,
+    "ShowHomeButton": true,
+    "BookmarkBarEnabled": true,
+    "ManagedBookmarks": [
+        {
+            "toplevel_name": "Armbian"
+        },
+        {
+            "name": "Armbian",
+            "url": "https://www.armbian.com"
+        },
+        {
+            "name": "Documentation",
+            "url": "https://docs.armbian.com"
+        },
+        {
+            "name": "Forum",
+            "url": "https://forum.armbian.com"
+        },
+        {
+            "name": "GitHub",
+            "url": "https://github.com/armbian"
+        }
+    ],
+    "MetricsReportingEnabled": false
 }

--- a/tools/modules/desktops/branding/browsers/etc/firefox-esr/policies/policies.json
+++ b/tools/modules/desktops/branding/browsers/etc/firefox-esr/policies/policies.json
@@ -11,6 +11,7 @@
         "DisableFirefoxStudies": true,
         "DisablePocket": true,
         "NoDefaultBookmarks": true,
+        "DisplayBookmarksToolbar": "always",
         "Bookmarks": [
             {
                 "Title": "Armbian",

--- a/tools/modules/desktops/branding/browsers/etc/firefox-esr/policies/policies.json
+++ b/tools/modules/desktops/branding/browsers/etc/firefox-esr/policies/policies.json
@@ -1,0 +1,20 @@
+{
+  "policies": {
+    "Homepage": {
+      "URL": "https://www.armbian.com",
+      "Locked": false,
+      "StartPage": "homepage"
+    },
+    "OverrideFirstRunPage": "https://www.armbian.com/welcome",
+    "OverridePostUpdatePage": "",
+    "DisableTelemetry": true,
+    "DisableFirefoxStudies": true,
+    "DisablePocket": true,
+    "Bookmarks": [
+      {"Title": "Armbian",       "URL": "https://www.armbian.com",     "Placement": "toolbar", "Folder": "Armbian"},
+      {"Title": "Documentation", "URL": "https://docs.armbian.com",    "Placement": "toolbar", "Folder": "Armbian"},
+      {"Title": "Forum",         "URL": "https://forum.armbian.com",   "Placement": "toolbar", "Folder": "Armbian"},
+      {"Title": "GitHub",        "URL": "https://github.com/armbian",  "Placement": "toolbar", "Folder": "Armbian"}
+    ]
+  }
+}

--- a/tools/modules/desktops/branding/browsers/etc/firefox-esr/policies/policies.json
+++ b/tools/modules/desktops/branding/browsers/etc/firefox-esr/policies/policies.json
@@ -10,6 +10,7 @@
     "DisableTelemetry": true,
     "DisableFirefoxStudies": true,
     "DisablePocket": true,
+    "NoDefaultBookmarks": true,
     "Bookmarks": [
       {"Title": "Armbian",       "URL": "https://www.armbian.com",     "Placement": "toolbar", "Folder": "Armbian"},
       {"Title": "Documentation", "URL": "https://docs.armbian.com",    "Placement": "toolbar", "Folder": "Armbian"},

--- a/tools/modules/desktops/branding/browsers/etc/firefox-esr/policies/policies.json
+++ b/tools/modules/desktops/branding/browsers/etc/firefox-esr/policies/policies.json
@@ -1,21 +1,41 @@
 {
-  "policies": {
-    "Homepage": {
-      "URL": "https://www.armbian.com",
-      "Locked": false,
-      "StartPage": "homepage"
-    },
-    "OverrideFirstRunPage": "https://www.armbian.com/welcome",
-    "OverridePostUpdatePage": "",
-    "DisableTelemetry": true,
-    "DisableFirefoxStudies": true,
-    "DisablePocket": true,
-    "NoDefaultBookmarks": true,
-    "Bookmarks": [
-      {"Title": "Armbian",       "URL": "https://www.armbian.com",     "Placement": "toolbar", "Folder": "Armbian"},
-      {"Title": "Documentation", "URL": "https://docs.armbian.com",    "Placement": "toolbar", "Folder": "Armbian"},
-      {"Title": "Forum",         "URL": "https://forum.armbian.com",   "Placement": "toolbar", "Folder": "Armbian"},
-      {"Title": "GitHub",        "URL": "https://github.com/armbian",  "Placement": "toolbar", "Folder": "Armbian"}
-    ]
-  }
+    "policies": {
+        "Homepage": {
+            "URL": "https://www.armbian.com",
+            "Locked": false,
+            "StartPage": "homepage"
+        },
+        "OverrideFirstRunPage": "https://www.armbian.com/welcome",
+        "OverridePostUpdatePage": "",
+        "DisableTelemetry": true,
+        "DisableFirefoxStudies": true,
+        "DisablePocket": true,
+        "NoDefaultBookmarks": true,
+        "Bookmarks": [
+            {
+                "Title": "Armbian",
+                "URL": "https://www.armbian.com",
+                "Placement": "toolbar",
+                "Folder": "Armbian"
+            },
+            {
+                "Title": "Documentation",
+                "URL": "https://docs.armbian.com",
+                "Placement": "toolbar",
+                "Folder": "Armbian"
+            },
+            {
+                "Title": "Forum",
+                "URL": "https://forum.armbian.com",
+                "Placement": "toolbar",
+                "Folder": "Armbian"
+            },
+            {
+                "Title": "GitHub",
+                "URL": "https://github.com/armbian",
+                "Placement": "toolbar",
+                "Folder": "Armbian"
+            }
+        ]
+    }
 }

--- a/tools/modules/desktops/branding/browsers/etc/firefox/policies/policies.json
+++ b/tools/modules/desktops/branding/browsers/etc/firefox/policies/policies.json
@@ -11,6 +11,7 @@
         "DisableFirefoxStudies": true,
         "DisablePocket": true,
         "NoDefaultBookmarks": true,
+        "DisplayBookmarksToolbar": "always",
         "Bookmarks": [
             {
                 "Title": "Armbian",

--- a/tools/modules/desktops/branding/browsers/etc/firefox/policies/policies.json
+++ b/tools/modules/desktops/branding/browsers/etc/firefox/policies/policies.json
@@ -1,0 +1,20 @@
+{
+  "policies": {
+    "Homepage": {
+      "URL": "https://www.armbian.com",
+      "Locked": false,
+      "StartPage": "homepage"
+    },
+    "OverrideFirstRunPage": "https://www.armbian.com/welcome",
+    "OverridePostUpdatePage": "",
+    "DisableTelemetry": true,
+    "DisableFirefoxStudies": true,
+    "DisablePocket": true,
+    "Bookmarks": [
+      {"Title": "Armbian",       "URL": "https://www.armbian.com",     "Placement": "toolbar", "Folder": "Armbian"},
+      {"Title": "Documentation", "URL": "https://docs.armbian.com",    "Placement": "toolbar", "Folder": "Armbian"},
+      {"Title": "Forum",         "URL": "https://forum.armbian.com",   "Placement": "toolbar", "Folder": "Armbian"},
+      {"Title": "GitHub",        "URL": "https://github.com/armbian",  "Placement": "toolbar", "Folder": "Armbian"}
+    ]
+  }
+}

--- a/tools/modules/desktops/branding/browsers/etc/firefox/policies/policies.json
+++ b/tools/modules/desktops/branding/browsers/etc/firefox/policies/policies.json
@@ -10,6 +10,7 @@
     "DisableTelemetry": true,
     "DisableFirefoxStudies": true,
     "DisablePocket": true,
+    "NoDefaultBookmarks": true,
     "Bookmarks": [
       {"Title": "Armbian",       "URL": "https://www.armbian.com",     "Placement": "toolbar", "Folder": "Armbian"},
       {"Title": "Documentation", "URL": "https://docs.armbian.com",    "Placement": "toolbar", "Folder": "Armbian"},

--- a/tools/modules/desktops/branding/browsers/etc/firefox/policies/policies.json
+++ b/tools/modules/desktops/branding/browsers/etc/firefox/policies/policies.json
@@ -1,21 +1,41 @@
 {
-  "policies": {
-    "Homepage": {
-      "URL": "https://www.armbian.com",
-      "Locked": false,
-      "StartPage": "homepage"
-    },
-    "OverrideFirstRunPage": "https://www.armbian.com/welcome",
-    "OverridePostUpdatePage": "",
-    "DisableTelemetry": true,
-    "DisableFirefoxStudies": true,
-    "DisablePocket": true,
-    "NoDefaultBookmarks": true,
-    "Bookmarks": [
-      {"Title": "Armbian",       "URL": "https://www.armbian.com",     "Placement": "toolbar", "Folder": "Armbian"},
-      {"Title": "Documentation", "URL": "https://docs.armbian.com",    "Placement": "toolbar", "Folder": "Armbian"},
-      {"Title": "Forum",         "URL": "https://forum.armbian.com",   "Placement": "toolbar", "Folder": "Armbian"},
-      {"Title": "GitHub",        "URL": "https://github.com/armbian",  "Placement": "toolbar", "Folder": "Armbian"}
-    ]
-  }
+    "policies": {
+        "Homepage": {
+            "URL": "https://www.armbian.com",
+            "Locked": false,
+            "StartPage": "homepage"
+        },
+        "OverrideFirstRunPage": "https://www.armbian.com/welcome",
+        "OverridePostUpdatePage": "",
+        "DisableTelemetry": true,
+        "DisableFirefoxStudies": true,
+        "DisablePocket": true,
+        "NoDefaultBookmarks": true,
+        "Bookmarks": [
+            {
+                "Title": "Armbian",
+                "URL": "https://www.armbian.com",
+                "Placement": "toolbar",
+                "Folder": "Armbian"
+            },
+            {
+                "Title": "Documentation",
+                "URL": "https://docs.armbian.com",
+                "Placement": "toolbar",
+                "Folder": "Armbian"
+            },
+            {
+                "Title": "Forum",
+                "URL": "https://forum.armbian.com",
+                "Placement": "toolbar",
+                "Folder": "Armbian"
+            },
+            {
+                "Title": "GitHub",
+                "URL": "https://github.com/armbian",
+                "Placement": "toolbar",
+                "Folder": "Armbian"
+            }
+        ]
+    }
 }

--- a/tools/modules/desktops/branding/browsers/etc/opt/chrome/master_preferences
+++ b/tools/modules/desktops/branding/browsers/etc/opt/chrome/master_preferences
@@ -1,12 +1,12 @@
 {
-  "distribution": {
-    "import_bookmarks": false,
-    "import_history": false,
-    "import_search_engine": false,
-    "import_home_page": false,
-    "skip_first_run_ui": true,
-    "make_chrome_default": false,
-    "make_chrome_default_for_user": false,
-    "suppress_first_run_default_browser_prompt": true
-  }
+    "distribution": {
+        "import_bookmarks": false,
+        "import_history": false,
+        "import_search_engine": false,
+        "import_home_page": false,
+        "skip_first_run_ui": true,
+        "make_chrome_default": false,
+        "make_chrome_default_for_user": false,
+        "suppress_first_run_default_browser_prompt": true
+    }
 }

--- a/tools/modules/desktops/branding/browsers/etc/opt/chrome/master_preferences
+++ b/tools/modules/desktops/branding/browsers/etc/opt/chrome/master_preferences
@@ -1,0 +1,12 @@
+{
+  "distribution": {
+    "import_bookmarks": false,
+    "import_history": false,
+    "import_search_engine": false,
+    "import_home_page": false,
+    "skip_first_run_ui": true,
+    "make_chrome_default": false,
+    "make_chrome_default_for_user": false,
+    "suppress_first_run_default_browser_prompt": true
+  }
+}

--- a/tools/modules/desktops/branding/browsers/etc/opt/chrome/policies/managed/armbian.json
+++ b/tools/modules/desktops/branding/browsers/etc/opt/chrome/policies/managed/armbian.json
@@ -1,0 +1,24 @@
+{
+    "_comment": "Armbian managed bookmarks for Google Chrome. ManagedBookmarks is a mandatory-only policy per Chrome Enterprise docs — it creates a read-only `Managed bookmarks > Armbian` folder on the bookmarks bar.",
+    "ManagedBookmarks": [
+        {
+            "toplevel_name": "Armbian"
+        },
+        {
+            "name": "Armbian",
+            "url": "https://www.armbian.com"
+        },
+        {
+            "name": "Documentation",
+            "url": "https://docs.armbian.com"
+        },
+        {
+            "name": "Forum",
+            "url": "https://forum.armbian.com"
+        },
+        {
+            "name": "GitHub",
+            "url": "https://github.com/armbian"
+        }
+    ]
+}

--- a/tools/modules/desktops/branding/browsers/etc/opt/chrome/policies/recommended/armbian.json
+++ b/tools/modules/desktops/branding/browsers/etc/opt/chrome/policies/recommended/armbian.json
@@ -1,0 +1,17 @@
+{
+  "_comment": "Armbian default Google Chrome policies. Same schema as Chromium. `recommended/` lets the user change these after first run.",
+  "RestoreOnStartup": 4,
+  "RestoreOnStartupURLs": ["https://www.armbian.com/welcome"],
+  "HomepageLocation": "https://www.armbian.com",
+  "HomepageIsNewTabPage": false,
+  "ShowHomeButton": true,
+  "BookmarkBarEnabled": true,
+  "ManagedBookmarks": [
+    {"toplevel_name": "Armbian"},
+    {"name": "Armbian", "url": "https://www.armbian.com"},
+    {"name": "Documentation", "url": "https://docs.armbian.com"},
+    {"name": "Forum", "url": "https://forum.armbian.com"},
+    {"name": "GitHub", "url": "https://github.com/armbian"}
+  ],
+  "MetricsReportingEnabled": false
+}

--- a/tools/modules/desktops/branding/browsers/etc/opt/chrome/policies/recommended/armbian.json
+++ b/tools/modules/desktops/branding/browsers/etc/opt/chrome/policies/recommended/armbian.json
@@ -1,17 +1,33 @@
 {
-  "_comment": "Armbian default Google Chrome policies. Same schema as Chromium. `recommended/` lets the user change these after first run.",
-  "RestoreOnStartup": 4,
-  "RestoreOnStartupURLs": ["https://www.armbian.com/welcome"],
-  "HomepageLocation": "https://www.armbian.com",
-  "HomepageIsNewTabPage": false,
-  "ShowHomeButton": true,
-  "BookmarkBarEnabled": true,
-  "ManagedBookmarks": [
-    {"toplevel_name": "Armbian"},
-    {"name": "Armbian", "url": "https://www.armbian.com"},
-    {"name": "Documentation", "url": "https://docs.armbian.com"},
-    {"name": "Forum", "url": "https://forum.armbian.com"},
-    {"name": "GitHub", "url": "https://github.com/armbian"}
-  ],
-  "MetricsReportingEnabled": false
+    "_comment": "Armbian default Google Chrome policies. Same schema as Chromium. `recommended/` lets the user change these after first run.",
+    "RestoreOnStartup": 4,
+    "RestoreOnStartupURLs": [
+        "https://www.armbian.com/welcome"
+    ],
+    "HomepageLocation": "https://www.armbian.com",
+    "HomepageIsNewTabPage": false,
+    "ShowHomeButton": true,
+    "BookmarkBarEnabled": true,
+    "ManagedBookmarks": [
+        {
+            "toplevel_name": "Armbian"
+        },
+        {
+            "name": "Armbian",
+            "url": "https://www.armbian.com"
+        },
+        {
+            "name": "Documentation",
+            "url": "https://docs.armbian.com"
+        },
+        {
+            "name": "Forum",
+            "url": "https://forum.armbian.com"
+        },
+        {
+            "name": "GitHub",
+            "url": "https://github.com/armbian"
+        }
+    ],
+    "MetricsReportingEnabled": false
 }

--- a/tools/modules/desktops/branding/browsers/etc/opt/chrome/policies/recommended/armbian.json
+++ b/tools/modules/desktops/branding/browsers/etc/opt/chrome/policies/recommended/armbian.json
@@ -1,5 +1,5 @@
 {
-    "_comment": "Armbian default Google Chrome policies. Same schema as Chromium. `recommended/` lets the user change these after first run.",
+    "_comment": "Armbian default Google Chrome policies. Same schema as Chromium. `recommended/` lets the user change these after first run. ManagedBookmarks lives in the sibling managed/ file (mandatory-only per Chrome Enterprise docs).",
     "RestoreOnStartup": 4,
     "RestoreOnStartupURLs": [
         "https://www.armbian.com/welcome"
@@ -8,26 +8,5 @@
     "HomepageIsNewTabPage": false,
     "ShowHomeButton": true,
     "BookmarkBarEnabled": true,
-    "ManagedBookmarks": [
-        {
-            "toplevel_name": "Armbian"
-        },
-        {
-            "name": "Armbian",
-            "url": "https://www.armbian.com"
-        },
-        {
-            "name": "Documentation",
-            "url": "https://docs.armbian.com"
-        },
-        {
-            "name": "Forum",
-            "url": "https://forum.armbian.com"
-        },
-        {
-            "name": "GitHub",
-            "url": "https://github.com/armbian"
-        }
-    ],
     "MetricsReportingEnabled": false
 }

--- a/tools/modules/desktops/branding/browsers/etc/thunderbird/policies/policies.json
+++ b/tools/modules/desktops/branding/browsers/etc/thunderbird/policies/policies.json
@@ -1,0 +1,8 @@
+{
+  "policies": {
+    "DisableTelemetry": true,
+    "DisableFirefoxStudies": true,
+    "AppAutoUpdate": false,
+    "StartPageURL": "https://www.armbian.com"
+  }
+}

--- a/tools/modules/desktops/branding/browsers/etc/thunderbird/policies/policies.json
+++ b/tools/modules/desktops/branding/browsers/etc/thunderbird/policies/policies.json
@@ -1,8 +1,8 @@
 {
-  "policies": {
-    "DisableTelemetry": true,
-    "DisableFirefoxStudies": true,
-    "AppAutoUpdate": false,
-    "StartPageURL": "https://www.armbian.com"
-  }
+    "policies": {
+        "DisableTelemetry": true,
+        "DisableFirefoxStudies": true,
+        "AppAutoUpdate": false,
+        "StartPageURL": "https://www.armbian.com"
+    }
 }

--- a/tools/modules/desktops/module_desktop_branding.sh
+++ b/tools/modules/desktops/module_desktop_branding.sh
@@ -94,6 +94,22 @@ function module_desktop_branding() {
 				cp "$desktop_dir/branding/armbian.xml" /usr/share/gnome-background-properties/
 			fi
 
+			# Browser branding — system-wide policy files that set the
+			# Armbian welcome page on first run, an Armbian homepage,
+			# and a small bookmark folder. Files for browsers that are
+			# not installed sit harmlessly in /etc/<browser>/policies/
+			# (browsers only read them when they start up). `recommended/`
+			# means the user can change these defaults after first run.
+			# Single overlay tree under branding/browsers/etc/ rsync'd
+			# into /etc/ — each browser's canonical drop-in path:
+			#   chromium:    /etc/chromium/policies/recommended/armbian.json
+			#   chrome:      /etc/opt/chrome/policies/recommended/armbian.json
+			#   firefox:     /etc/firefox/policies/policies.json
+			#   firefox-esr: /etc/firefox-esr/policies/policies.json
+			if [[ -d "$desktop_dir/branding/browsers/etc" ]]; then
+				cp -a "$desktop_dir/branding/browsers/etc/." /etc/
+			fi
+
 			# SDDM theme (for desktops using sddm)
 			if [[ -d "$desktop_dir/greeters/sddm/themes" && "$DESKTOP_DM" == "sddm" ]]; then
 				mkdir -p /usr/share/sddm/themes

--- a/tools/modules/desktops/module_desktop_branding.sh
+++ b/tools/modules/desktops/module_desktop_branding.sh
@@ -105,10 +105,20 @@ function module_desktop_branding() {
 			# Single overlay tree under branding/browsers/etc/ rsync'd
 			# into /etc/ — each app's canonical drop-in path:
 			#   chromium:    /etc/chromium/policies/recommended/armbian.json
+			#                /etc/chromium/master_preferences
 			#   chrome:      /etc/opt/chrome/policies/recommended/armbian.json
+			#                /etc/opt/chrome/master_preferences
 			#   firefox:     /etc/firefox/policies/policies.json
 			#   firefox-esr: /etc/firefox-esr/policies/policies.json
 			#   thunderbird: /etc/thunderbird/policies/policies.json
+			#
+			# master_preferences suppresses the bundled default bookmark
+			# import on new profiles (xtradeb chromium ships Debian /
+			# Ubuntu / XtraDeb shortcuts; Google Chrome ships its own
+			# defaults). Existing profiles keep what they already have.
+			# The Armbian "Managed bookmarks" folder still appears via
+			# the policy file regardless — it lives in a separate read-
+			# only space.
 			if [[ -d "$desktop_dir/branding/browsers/etc" ]]; then
 				cp -a "$desktop_dir/branding/browsers/etc/." /etc/
 			fi

--- a/tools/modules/desktops/module_desktop_branding.sh
+++ b/tools/modules/desktops/module_desktop_branding.sh
@@ -94,18 +94,21 @@ function module_desktop_branding() {
 				cp "$desktop_dir/branding/armbian.xml" /usr/share/gnome-background-properties/
 			fi
 
-			# Browser branding — system-wide policy files that set the
-			# Armbian welcome page on first run, an Armbian homepage,
-			# and a small bookmark folder. Files for browsers that are
-			# not installed sit harmlessly in /etc/<browser>/policies/
-			# (browsers only read them when they start up). `recommended/`
-			# means the user can change these defaults after first run.
+			# Browser / mail branding — system-wide policy files that
+			# set the Armbian welcome page, homepage, and bookmarks for
+			# browsers, and disable telemetry / studies for Mozilla apps.
+			# Files for apps that aren't installed sit harmlessly in
+			# /etc/<app>/policies/ (each app only reads its own dir at
+			# startup). `recommended/` (Chromium-family) means the user
+			# can change defaults after first run; Mozilla's policies.json
+			# is a single combined file per app.
 			# Single overlay tree under branding/browsers/etc/ rsync'd
-			# into /etc/ — each browser's canonical drop-in path:
+			# into /etc/ — each app's canonical drop-in path:
 			#   chromium:    /etc/chromium/policies/recommended/armbian.json
 			#   chrome:      /etc/opt/chrome/policies/recommended/armbian.json
 			#   firefox:     /etc/firefox/policies/policies.json
 			#   firefox-esr: /etc/firefox-esr/policies/policies.json
+			#   thunderbird: /etc/thunderbird/policies/policies.json
 			if [[ -d "$desktop_dir/branding/browsers/etc" ]]; then
 				cp -a "$desktop_dir/branding/browsers/etc/." /etc/
 			fi

--- a/tools/modules/desktops/module_desktop_branding.sh
+++ b/tools/modules/desktops/module_desktop_branding.sh
@@ -123,7 +123,12 @@ function module_desktop_branding() {
 			# the policy file regardless — it lives in a separate read-
 			# only space.
 			if [[ -d "$desktop_dir/branding/browsers/etc" ]]; then
-				cp -a "$desktop_dir/branding/browsers/etc/." /etc/
+				# --no-preserve=ownership: keep mode + timestamps from the
+				# source tree but always land as root:root in /etc/. Defends
+				# against dev/test runs where the source files might be
+				# owned by the developer's UID rather than root (in
+				# production the deb deploys them as root anyway).
+				cp -a --no-preserve=ownership "$desktop_dir/branding/browsers/etc/." /etc/
 			fi
 
 			# SDDM theme (for desktops using sddm)

--- a/tools/modules/desktops/module_desktop_branding.sh
+++ b/tools/modules/desktops/module_desktop_branding.sh
@@ -107,6 +107,7 @@ function module_desktop_branding() {
 			#   chromium:    /etc/chromium/policies/recommended/armbian.json   (homepage, first-run, etc.)
 			#                /etc/chromium/policies/managed/armbian.json       (ManagedBookmarks — mandatory-only policy)
 			#                /etc/chromium/master_preferences                  (suppress bundled defaults)
+			#                /etc/chromium.d/armbian-flags                     (enable VPU hardware video decoder)
 			#   chrome:      /etc/opt/chrome/policies/recommended/armbian.json
 			#                /etc/opt/chrome/policies/managed/armbian.json
 			#                /etc/opt/chrome/master_preferences

--- a/tools/modules/desktops/module_desktop_branding.sh
+++ b/tools/modules/desktops/module_desktop_branding.sh
@@ -104,9 +104,11 @@ function module_desktop_branding() {
 			# is a single combined file per app.
 			# Single overlay tree under branding/browsers/etc/ rsync'd
 			# into /etc/ — each app's canonical drop-in path:
-			#   chromium:    /etc/chromium/policies/recommended/armbian.json
-			#                /etc/chromium/master_preferences
+			#   chromium:    /etc/chromium/policies/recommended/armbian.json   (homepage, first-run, etc.)
+			#                /etc/chromium/policies/managed/armbian.json       (ManagedBookmarks — mandatory-only policy)
+			#                /etc/chromium/master_preferences                  (suppress bundled defaults)
 			#   chrome:      /etc/opt/chrome/policies/recommended/armbian.json
+			#                /etc/opt/chrome/policies/managed/armbian.json
 			#                /etc/opt/chrome/master_preferences
 			#   firefox:     /etc/firefox/policies/policies.json
 			#   firefox-esr: /etc/firefox-esr/policies/policies.json


### PR DESCRIPTION
## Summary

Adds an Armbian welcome page, homepage, and small bookmark folder to the four browsers we support out of the box. New users see something Armbian-themed when they open a browser for the first time on a fresh desktop install — instead of the default vendor "sign in to Google" / "start up Firefox" page.

## What lands where

Single overlay tree at `tools/modules/desktops/branding/browsers/etc/` `rsync`'d into `/etc/` by `module_desktop_branding`. Each browser's canonical drop-in:

| browser | path | format |
|---|---|---|
| Chromium | `/etc/chromium/policies/recommended/armbian.json` | per-policy JSON |
| Google Chrome | `/etc/opt/chrome/policies/recommended/armbian.json` | (same schema) |
| Firefox | `/etc/firefox/policies/policies.json` | single combined JSON |
| Firefox-ESR | `/etc/firefox-esr/policies/policies.json` | (same) |

Edge intentionally left out per request — same schema as Chromium if needed later, just add `/etc/opt/edge/policies/recommended/`.

## Why `recommended/` (not `managed/`)

`recommended/` sets the default but the user can change it after first run — friendlier than locking the homepage. Power users keep full control.

## Policies set

| | URL / value |
|---|---|
| First-run page | `https://www.armbian.com/welcome` |
| Homepage / start page | `https://www.armbian.com` |
| Home button | shown |
| Bookmarks bar | enabled |
| `Armbian` bookmark folder | Armbian / Documentation / Forum / GitHub |
| Telemetry / studies / Pocket | disabled (Firefox) |
| Metrics reporting | disabled (Chromium / Chrome) |

Files for browsers that aren't installed sit harmlessly in `/etc/<browser>/policies/` — each browser only reads its own directory at startup.

## Test plan

- [ ] Fresh desktop install (xfce / gnome / kde-plasma): open chromium → first-run goes to armbian.com/welcome, homepage button works, "Armbian" bookmark folder visible
- [ ] Same on google-chrome (amd64 only)
- [ ] Same on firefox / firefox-esr
- [ ] User can change the homepage in browser settings (recommended policies don't lock)
- [ ] Policies survive browser update (`recommended/` is read every startup)