### PR TITLE
readme: add desktops bullet to the feature list

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Armbian Config provides interactive and scriptable routines for:
 - Sandboxed software installation and system updates  
 - Kernel selection, switching, and firmware management  
 - Enabling and managing hardware-specific features  
+- Desktop environment installation, tiered management, and branding (XFCE, GNOME, KDE Plasma, MATE, Cinnamon, and more)  
 
 It is especially useful for single board computers (SBCs), helping users quickly prepare a ready-to-use system without manual intervention.
 


### PR DESCRIPTION
Adds one line to the top-level `README.md` feature list under *Armbian Config provides interactive and scriptable routines for:*:

> Desktop environment installation, tiered management, and branding (XFCE, GNOME, KDE Plasma, MATE, Cinnamon, and more)

Matches the tone / length of the other bullets. Full technical detail lives in the [Developer Guide: Desktops](https://docs.armbian.com/Developer-Guide_Desktops/) page.