### PR TITLE
desktops: drop NetworkManager override from postinst scripts

### DIFF
--- a/tools/modules/desktops/postinst/cinnamon.sh
+++ b/tools/modules/desktops/postinst/cinnamon.sh
@@ -132,14 +132,6 @@ system-db:local" >> $profile
 
 dconf update
 
-# Let NetworkManager coexist with systemd-networkd (only if networkd is active)
-if command -v NetworkManager > /dev/null 2>&1 && systemctl is-active --quiet systemd-networkd 2>/dev/null; then
-	mkdir -p /etc/NetworkManager/conf.d
-	cat > /etc/NetworkManager/conf.d/10-armbian-unmanaged.conf <<- NMEOF
-	[keyfile]
-	unmanaged-devices=type:ethernet
-	NMEOF
-	systemctl restart NetworkManager 2>/dev/null || true
 fi
 
 #re-compile schemas

--- a/tools/modules/desktops/postinst/gnome.sh
+++ b/tools/modules/desktops/postinst/gnome.sh
@@ -50,14 +50,6 @@ dconf update
 # launch at all. Strip the stub if it exists.
 rm -f /usr/local/share/applications/gnome-ubuntu-panel.desktop
 
-# Let NetworkManager coexist with systemd-networkd (only if networkd is active)
-if command -v NetworkManager > /dev/null 2>&1 && systemctl is-active --quiet systemd-networkd 2>/dev/null; then
-	mkdir -p /etc/NetworkManager/conf.d
-	cat > /etc/NetworkManager/conf.d/10-armbian-unmanaged.conf <<- NMEOF
-	[keyfile]
-	unmanaged-devices=type:ethernet
-	NMEOF
-	systemctl restart NetworkManager 2>/dev/null || true
 fi
 
 #compile schemas

--- a/tools/modules/desktops/postinst/i3-wm.sh
+++ b/tools/modules/desktops/postinst/i3-wm.sh
@@ -47,12 +47,4 @@ if [ -f /etc/i3/config ]; then
 	done
 fi
 
-# Let NetworkManager coexist with systemd-networkd (only if networkd is active)
-if command -v NetworkManager > /dev/null 2>&1 && systemctl is-active --quiet systemd-networkd 2>/dev/null; then
-	mkdir -p /etc/NetworkManager/conf.d
-	cat > /etc/NetworkManager/conf.d/10-armbian-unmanaged.conf <<- NMEOF
-	[keyfile]
-	unmanaged-devices=type:ethernet
-	NMEOF
-	systemctl restart NetworkManager 2>/dev/null || true
 fi

--- a/tools/modules/desktops/postinst/kde-neon.sh
+++ b/tools/modules/desktops/postinst/kde-neon.sh
@@ -41,12 +41,4 @@ for home in /etc/skel /home/*; do
 	fi
 done
 
-# Let NetworkManager coexist with systemd-networkd (only if networkd is active)
-if command -v NetworkManager > /dev/null 2>&1 && systemctl is-active --quiet systemd-networkd 2>/dev/null; then
-	mkdir -p /etc/NetworkManager/conf.d
-	cat > /etc/NetworkManager/conf.d/10-armbian-unmanaged.conf <<- NMEOF
-	[keyfile]
-	unmanaged-devices=type:ethernet
-	NMEOF
-	systemctl restart NetworkManager 2>/dev/null || true
 fi

--- a/tools/modules/desktops/postinst/kde-plasma.sh
+++ b/tools/modules/desktops/postinst/kde-plasma.sh
@@ -41,12 +41,4 @@ for home in /etc/skel /home/*; do
 	fi
 done
 
-# Let NetworkManager coexist with systemd-networkd (only if networkd is active)
-if command -v NetworkManager > /dev/null 2>&1 && systemctl is-active --quiet systemd-networkd 2>/dev/null; then
-	mkdir -p /etc/NetworkManager/conf.d
-	cat > /etc/NetworkManager/conf.d/10-armbian-unmanaged.conf <<- NMEOF
-	[keyfile]
-	unmanaged-devices=type:ethernet
-	NMEOF
-	systemctl restart NetworkManager 2>/dev/null || true
 fi

--- a/tools/modules/desktops/postinst/mate.sh
+++ b/tools/modules/desktops/postinst/mate.sh
@@ -151,14 +151,6 @@ trash-icon-visible=false
 volumes-visible=false
 GSEOF
 
-# Let NetworkManager coexist with systemd-networkd (only if networkd is active)
-if command -v NetworkManager > /dev/null 2>&1 && systemctl is-active --quiet systemd-networkd 2>/dev/null; then
-	mkdir -p /etc/NetworkManager/conf.d
-	cat > /etc/NetworkManager/conf.d/10-armbian-unmanaged.conf <<- NMEOF
-	[keyfile]
-	unmanaged-devices=type:ethernet
-	NMEOF
-	systemctl restart NetworkManager 2>/dev/null || true
 fi
 
 #re-compile schemas


### PR DESCRIPTION
## Summary

Removes the duplicated NetworkManager/systemd-networkd coexistence block from 6 DE postinst scripts. The block wrote `/etc/NetworkManager/conf.d/10-armbian-unmanaged.conf` to tell NM to leave networkd-managed interfaces alone.

This is handled by the build framework's `network/net-network-manager.sh` extension, not by armbian-config's desktop postinst — the duplication here was a leftover.

### Files cleaned

`cinnamon.sh`, `gnome.sh`, `i3-wm.sh`, `kde-neon.sh`, `kde-plasma.sh`, `mate.sh` — 8 lines removed from each (48 total).

The `network-manager` and `network-manager-gnome` packages in the DE YAMLs are unchanged — they're still installed as part of the desktop; only the postinst override is removed.