### PR TITLE
desktops: disable DM in mode=build after install

### DIFF
--- a/tools/modules/desktops/module_desktops.sh
+++ b/tools/modules/desktops/module_desktops.sh
@@ -232,6 +232,16 @@ function module_desktops() {
 					return 1
 				fi
 				command -v "$DESKTOP_DM" > /etc/X11/default-display-manager 2>/dev/null || true
+
+				# In build mode, disable services that package postinst
+				# auto-enabled. The firstrun script re-enables the DM
+				# after initial user setup completes; psd is activated
+				# per-user via ~/.activate_psd at runtime.
+				if [[ "$mode" == "build" ]]; then
+					srv_disable "$DESKTOP_DM" 2>/dev/null || true
+					srv_disable display-manager 2>/dev/null || true
+					srv_disable psd.service 2>/dev/null || true
+				fi
 			fi
 
 			# Armbian-only branding extras: install only when the Armbian
@@ -269,7 +279,7 @@ function module_desktops() {
 
 			# remove unwanted packages
 			if [[ -n "$DESKTOP_PACKAGES_UNINSTALL" ]]; then
-				apt-get remove -y --purge ${DESKTOP_PACKAGES_UNINSTALL} 2>/dev/null || true
+				pkg_remove ${DESKTOP_PACKAGES_UNINSTALL} 2>/dev/null || true
 			fi
 
 			# install branding


### PR DESCRIPTION
## Summary

DM package postinst (`gdm3`/`lightdm`/`sddm`) auto-enables the service on install. In `mode=build` this leaves the DM enabled in the cached rootfs, which would cause a headless login race on first boot before `armbian-firstlogin` has created the user.

Fix: disable both the specific DM and `display-manager.service` right after the DM install when `mode=build`.

```bash
if [[ "$mode" == "build" ]]; then
    systemctl disable "$DESKTOP_DM" 2>/dev/null || true
    systemctl disable display-manager 2>/dev/null || true
fi
```

### Re-enablement on first boot

Verified in `armbian-firstlogin`:
- **lightdm**: line 948 — creates symlink `/etc/systemd/system/display-manager.service` → `lightdm.service`
- **gdm3**: line 977 — creates symlink → `gdm3.service`
- **sddm**: line 1018 — `systemctl enable --now sddm`

All three paths run after user creation, so the DM starts only when a real user exists.

## Test plan

- [ ] Build a desktop image with `mode=build` — `systemctl is-enabled gdm3` shows `disabled` in the rootfs
- [ ] First boot: `armbian-firstlogin` creates user, enables + starts the DM
- [ ] No change to runtime `module_desktops install` (mode not set → DM stays enabled as before)