### PR TITLE
desktops: availability + editorial-status filters, CSC menu

### DIFF
--- a/tools/json/config.system.json
+++ b/tools/json/config.system.json
@@ -339,18 +339,6 @@
                             "help": "Install Enlightenment (EFL-based) [community-supported, best-effort]."
                         },
                         {
-                            "id": "XMON01",
-                            "description": "Install Xmonad [CSC]",
-                            "short": "Xmonad [CSC]",
-                            "command": [
-                                "module_desktops install de=xmonad tier=minimal"
-                            ],
-                            "status": "Stable",
-                            "author": "@igorpecovnik",
-                            "condition": "! module_desktops installed && module_desktop_supported xmonad",
-                            "help": "Install Xmonad tiling WM [community-supported, best-effort]."
-                        },
-                        {
                             "id": "XFCE01",
                             "description": "Install XFCE (minimal)",
                             "short": "XFCE",
@@ -486,17 +474,6 @@
                             "help": "Uninstall the Enlightenment desktop environment"
                         },
                         {
-                            "id": "XMON02",
-                            "description": "Uninstall Xmonad [CSC]",
-                            "command": [
-                                "module_desktops remove de=xmonad"
-                            ],
-                            "status": "Stable",
-                            "author": "@igorpecovnik",
-                            "condition": "module_desktops status de=xmonad",
-                            "help": "Uninstall the Xmonad window manager"
-                        },
-                        {
                             "id": "XFCE02",
                             "description": "Uninstall XFCE",
                             "command": [
@@ -607,17 +584,6 @@
                             "help": "Enable automatic desktop login for Enlightenment"
                         },
                         {
-                            "id": "XMON03",
-                            "description": "Enable autologin (Xmonad) [CSC]",
-                            "command": [
-                                "module_desktops auto de=xmonad"
-                            ],
-                            "status": "Stable",
-                            "author": "@igorpecovnik",
-                            "condition": "module_desktops status de=xmonad && ! module_desktops login de=xmonad",
-                            "help": "Enable automatic desktop login for Xmonad"
-                        },
-                        {
                             "id": "XFCE03",
                             "description": "Enable autologin (XFCE)",
                             "command": [
@@ -726,17 +692,6 @@
                             "author": "@igorpecovnik",
                             "condition": "module_desktops status de=enlightenment && module_desktops login de=enlightenment",
                             "help": "Disable automatic desktop login for Enlightenment"
-                        },
-                        {
-                            "id": "XMON04",
-                            "description": "Disable autologin (Xmonad) [CSC]",
-                            "command": [
-                                "module_desktops manual de=xmonad"
-                            ],
-                            "status": "Stable",
-                            "author": "@igorpecovnik",
-                            "condition": "module_desktops status de=xmonad && module_desktops login de=xmonad",
-                            "help": "Disable automatic desktop login for Xmonad"
                         },
                         {
                             "id": "XFCE04",

--- a/tools/json/config.system.json
+++ b/tools/json/config.system.json
@@ -303,6 +303,54 @@
                             "help": "Install the KDE Neon desktop environment"
                         },
                         {
+                            "id": "BDGE01",
+                            "description": "Install Budgie [CSC]",
+                            "short": "Budgie [CSC]",
+                            "command": [
+                                "module_desktops install de=budgie tier=minimal"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "! module_desktops installed && module_desktop_supported budgie",
+                            "help": "Install Budgie [community-supported, best-effort]."
+                        },
+                        {
+                            "id": "DEEP01",
+                            "description": "Install Deepin [CSC]",
+                            "short": "Deepin [CSC]",
+                            "command": [
+                                "module_desktops install de=deepin tier=minimal"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "! module_desktops installed && module_desktop_supported deepin",
+                            "help": "Install Deepin DDE [community-supported, best-effort]."
+                        },
+                        {
+                            "id": "ENLT01",
+                            "description": "Install Enlightenment [CSC]",
+                            "short": "Enlightenment [CSC]",
+                            "command": [
+                                "module_desktops install de=enlightenment tier=minimal"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "! module_desktops installed && module_desktop_supported enlightenment",
+                            "help": "Install Enlightenment (EFL-based) [community-supported, best-effort]."
+                        },
+                        {
+                            "id": "XMON01",
+                            "description": "Install Xmonad [CSC]",
+                            "short": "Xmonad [CSC]",
+                            "command": [
+                                "module_desktops install de=xmonad tier=minimal"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "! module_desktops installed && module_desktop_supported xmonad",
+                            "help": "Install Xmonad tiling WM [community-supported, best-effort]."
+                        },
+                        {
                             "id": "XFCE01",
                             "description": "Install XFCE (minimal)",
                             "short": "XFCE",
@@ -405,6 +453,50 @@
                             "help": "Uninstall the KDE Neon desktop environment"
                         },
                         {
+                            "id": "BDGE02",
+                            "description": "Uninstall Budgie [CSC]",
+                            "command": [
+                                "module_desktops remove de=budgie"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_desktops status de=budgie",
+                            "help": "Uninstall the Budgie desktop environment"
+                        },
+                        {
+                            "id": "DEEP02",
+                            "description": "Uninstall Deepin [CSC]",
+                            "command": [
+                                "module_desktops remove de=deepin"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_desktops status de=deepin",
+                            "help": "Uninstall the Deepin desktop environment"
+                        },
+                        {
+                            "id": "ENLT02",
+                            "description": "Uninstall Enlightenment [CSC]",
+                            "command": [
+                                "module_desktops remove de=enlightenment"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_desktops status de=enlightenment",
+                            "help": "Uninstall the Enlightenment desktop environment"
+                        },
+                        {
+                            "id": "XMON02",
+                            "description": "Uninstall Xmonad [CSC]",
+                            "command": [
+                                "module_desktops remove de=xmonad"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_desktops status de=xmonad",
+                            "help": "Uninstall the Xmonad window manager"
+                        },
+                        {
                             "id": "XFCE02",
                             "description": "Uninstall XFCE",
                             "command": [
@@ -482,6 +574,50 @@
                             "help": "Enable automatic desktop login for KDE Neon"
                         },
                         {
+                            "id": "BDGE03",
+                            "description": "Enable autologin (Budgie) [CSC]",
+                            "command": [
+                                "module_desktops auto de=budgie"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_desktops status de=budgie && ! module_desktops login de=budgie",
+                            "help": "Enable automatic desktop login for Budgie"
+                        },
+                        {
+                            "id": "DEEP03",
+                            "description": "Enable autologin (Deepin) [CSC]",
+                            "command": [
+                                "module_desktops auto de=deepin"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_desktops status de=deepin && ! module_desktops login de=deepin",
+                            "help": "Enable automatic desktop login for Deepin"
+                        },
+                        {
+                            "id": "ENLT03",
+                            "description": "Enable autologin (Enlightenment) [CSC]",
+                            "command": [
+                                "module_desktops auto de=enlightenment"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_desktops status de=enlightenment && ! module_desktops login de=enlightenment",
+                            "help": "Enable automatic desktop login for Enlightenment"
+                        },
+                        {
+                            "id": "XMON03",
+                            "description": "Enable autologin (Xmonad) [CSC]",
+                            "command": [
+                                "module_desktops auto de=xmonad"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_desktops status de=xmonad && ! module_desktops login de=xmonad",
+                            "help": "Enable automatic desktop login for Xmonad"
+                        },
+                        {
                             "id": "XFCE03",
                             "description": "Enable autologin (XFCE)",
                             "command": [
@@ -557,6 +693,50 @@
                             "author": "@igorpecovnik",
                             "condition": "module_desktops status de=kde-neon && module_desktops login de=kde-neon",
                             "help": "Disable automatic desktop login for KDE Neon"
+                        },
+                        {
+                            "id": "BDGE04",
+                            "description": "Disable autologin (Budgie) [CSC]",
+                            "command": [
+                                "module_desktops manual de=budgie"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_desktops status de=budgie && module_desktops login de=budgie",
+                            "help": "Disable automatic desktop login for Budgie"
+                        },
+                        {
+                            "id": "DEEP04",
+                            "description": "Disable autologin (Deepin) [CSC]",
+                            "command": [
+                                "module_desktops manual de=deepin"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_desktops status de=deepin && module_desktops login de=deepin",
+                            "help": "Disable automatic desktop login for Deepin"
+                        },
+                        {
+                            "id": "ENLT04",
+                            "description": "Disable autologin (Enlightenment) [CSC]",
+                            "command": [
+                                "module_desktops manual de=enlightenment"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_desktops status de=enlightenment && module_desktops login de=enlightenment",
+                            "help": "Disable automatic desktop login for Enlightenment"
+                        },
+                        {
+                            "id": "XMON04",
+                            "description": "Disable autologin (Xmonad) [CSC]",
+                            "command": [
+                                "module_desktops manual de=xmonad"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_desktops status de=xmonad && module_desktops login de=xmonad",
+                            "help": "Disable automatic desktop login for Xmonad"
                         },
                         {
                             "id": "XFCE04",

--- a/tools/modules/desktops/github/audit.py
+++ b/tools/modules/desktops/github/audit.py
@@ -118,14 +118,17 @@ def list_desktops(yaml_dir: Path, include_unsupported: bool = False) -> tuple[li
 
     By default, DEs with `status: unsupported` in their YAML are
     excluded from the audit. These are typically vendor- or arch-
-    specific desktops (bianbu = SpacemiT riscv64, kde-neon = Ubuntu
-    only, deepin/budgie = community-maintained, often only available
-    on specific releases) where the audit script's "does this package
-    exist on every (release, arch)?" check would generate noise that
-    isn't actionable.
+    specific desktops (e.g. bianbu = SpacemiT riscv64 only) where the
+    audit script's "does this package exist on every (release, arch)?"
+    check would generate noise that isn't actionable.
 
-    Pass include_unsupported=True to audit them anyway (e.g. when
-    promoting one to `status: supported`).
+    DEs with `status: community` (best-effort, maintained outside the
+    first-class support tier) ARE audited — drift in a community DE is
+    still worth reporting even if a maintainer may choose not to act on
+    it immediately.
+
+    Pass include_unsupported=True to audit unsupported DEs anyway (e.g.
+    when evaluating promoting one to `status: community` / `supported`).
     """
     try:
         import yaml as pyyaml

--- a/tools/modules/desktops/github/audit.py
+++ b/tools/modules/desktops/github/audit.py
@@ -337,7 +337,7 @@ def audit(build_repo: Path, configng_repo: Path,
             for tier in tiers_to_check:
                 parsed = parse_desktop_yaml(yaml_dir, parser_path, de,
                                             codename, arch, tier)
-                if not parsed.get("DESKTOP_SUPPORTED") == "yes":
+                if not parsed.get("DESKTOP_AVAILABLE") == "yes":
                     # the YAML doesn't support this (DE, release, arch);
                     # skip it.
                     continue

--- a/tools/modules/desktops/github/audit_prompt.py
+++ b/tools/modules/desktops/github/audit_prompt.py
@@ -34,9 +34,11 @@ Your job is to propose minimal YAML edits that fix ALL the audit
 findings without breaking the existing matrix. Specifically:
 
 - Address EVERY missing release in the report, not just one. Each
-  missing release needs a release block added to every supported DE
-  YAML (the ones with `status: supported`, currently: xfce, gnome,
-  mate, cinnamon, kde-plasma, i3-wm, xmonad, enlightenment).
+  missing release needs a release block added to every DE YAML with
+  `status: supported`. Do NOT add release blocks to YAMLs with
+  `status: community` or `status: unsupported` — those are
+  opt-in / vendor-specific and should only grow coverage when a
+  maintainer explicitly asks for it.
 
 - For package holes, prefer adding entries to common.yaml's
   tier_overrides block (one place, applies to every DE) rather than
@@ -46,10 +48,12 @@ findings without breaking the existing matrix. Specifically:
   per-arch nesting (`tier_overrides.<tier>.architectures.<arch>.
   packages_remove`) for permanent arch-wide holes.
 
-- For missing releases, add a release block to each currently-
-  supported DE YAML (the ones with `status: supported`). Copy the
-  shape from an existing release block (e.g. trixie or noble) and
-  adjust per-release deltas only when needed.
+- For missing releases, add a release block to each DE YAML with
+  `status: supported`. Copy the shape from an existing release block
+  (e.g. trixie or noble) and adjust per-release deltas only when
+  needed. The list of currently-supported DEs can be inferred from
+  the YAMLs themselves — do not rely on hardcoded names in these
+  instructions, as the support tier of a DE can change over time.
 
 - Always add a comment explaining WHY a hole exists. Future readers
   should be able to tell whether the entry is a transient archive

--- a/tools/modules/desktops/module_desktop_supported.sh
+++ b/tools/modules/desktops/module_desktop_supported.sh
@@ -31,7 +31,7 @@ function module_desktop_supported() {
 		;;
 		*)
 			module_desktop_yamlparse "$de" "$arch" "$release" 2>/dev/null || return 1
-			[[ "$DESKTOP_SUPPORTED" == "yes" ]]
+			[[ "$DESKTOP_AVAILABLE" == "yes" ]]
 		;;
 	esac
 }

--- a/tools/modules/desktops/module_desktop_yamlparse.sh
+++ b/tools/modules/desktops/module_desktop_yamlparse.sh
@@ -11,7 +11,7 @@ module_options+=(
 # Parse YAML desktop definition via Python helper
 # Usage: module_desktop_yamlparse <de_name> [arch] [release] [tier]
 # Sets: DESKTOP_PACKAGES, DESKTOP_PACKAGES_UNINSTALL, DESKTOP_PRIMARY_PKG,
-#       DESKTOP_DM, DESKTOP_STATUS, DESKTOP_SUPPORTED, DESKTOP_DESC,
+#       DESKTOP_DM, DESKTOP_STATUS, DESKTOP_AVAILABLE, DESKTOP_DESC,
 #       DESKTOP_TIER, DESKTOP_REPO_URL, DESKTOP_REPO_KEY_URL,
 #       DESKTOP_REPO_KEYRING
 #
@@ -34,7 +34,7 @@ function module_desktop_yamlparse() {
 			echo "Parse a desktop YAML definition and set package variables."
 			echo "Variables set: DESKTOP_PACKAGES, DESKTOP_PACKAGES_UNINSTALL,"
 			echo "  DESKTOP_PRIMARY_PKG, DESKTOP_DM, DESKTOP_STATUS,"
-			echo "  DESKTOP_SUPPORTED, DESKTOP_DESC, DESKTOP_TIER, DESKTOP_REPO_*"
+			echo "  DESKTOP_AVAILABLE, DESKTOP_DESC, DESKTOP_TIER, DESKTOP_REPO_*"
 			echo ""
 			echo "tier is one of minimal|mid|full, defaults to minimal."
 			echo ""
@@ -56,7 +56,7 @@ function module_desktop_yamlparse() {
 			DESKTOP_PRIMARY_PKG=""
 			DESKTOP_DM=""
 			DESKTOP_STATUS=""
-			DESKTOP_SUPPORTED=""
+			DESKTOP_AVAILABLE=""
 			DESKTOP_DESC=""
 			DESKTOP_TIER=""
 			DESKTOP_REPO_URL=""

--- a/tools/modules/desktops/module_desktops.sh
+++ b/tools/modules/desktops/module_desktops.sh
@@ -13,7 +13,7 @@ module_options+=(
 	["module_desktops,help_auto"]="Enable auto-login (de=name)"
 	["module_desktops,help_manual"]="Disable auto-login (de=name)"
 	["module_desktops,help_login"]="Check auto-login status (de=name)"
-	["module_desktops,help_supported"]="JSON list or check one (de=name arch=X release=Y)"
+	["module_desktops,help_supported"]="JSON list or check one (de=name arch=X release=Y filter=available|unavailable|all status=csv-of-supported,community,unsupported)"
 	["module_desktops,help_installed"]="Returns 0 if any desktop is installed (no de=)"
 	["module_desktops,help_upgrade"]="Upgrade installed desktop to a higher tier (de=name tier=mid|full)"
 	["module_desktops,help_downgrade"]="Downgrade installed desktop to a lower tier (de=name tier=minimal|mid)"
@@ -111,6 +111,8 @@ function module_desktops() {
 	local query_release=""
 	local tier=""
 	local mode=""
+	local filter=""
+	local status=""
 	local selected
 	for selected in "${@:2}"; do
 		IFS='=' read -r -a split <<< "${selected}"
@@ -119,6 +121,8 @@ function module_desktops() {
 		[[ "${split[0]}" == "release" ]] && query_release="${split[1]}"
 		[[ "${split[0]}" == "tier" ]] && tier="${split[1]}"
 		[[ "${split[0]}" == "mode" ]] && mode="${split[1]}"
+		[[ "${split[0]}" == "filter" ]] && filter="${split[1]}"
+		[[ "${split[0]}" == "status" ]] && status="${split[1]}"
 	done
 
 	local commands
@@ -167,7 +171,7 @@ function module_desktops() {
 				return 1
 			fi
 
-			if [[ "$DESKTOP_SUPPORTED" != "yes" ]]; then
+			if [[ "$DESKTOP_AVAILABLE" != "yes" ]]; then
 				echo "Warning: '${de}' is not supported on ${DISTROID}/$(dpkg --print-architecture)" >&2
 			fi
 
@@ -579,8 +583,35 @@ function module_desktops() {
 			if [[ -z "$de" ]]; then
 				local yaml_dir="${desktops_dir}/yaml"
 				local parser="${desktops_dir}/scripts/parse_desktop_yaml.py"
+				local -a parser_args=("$yaml_dir" "--list-json" "$use_release" "$use_arch")
+				if [[ -n "$filter" ]]; then
+					case "$filter" in
+						available|unavailable|all) parser_args+=(--filter "$filter") ;;
+						*)
+							echo "Error: invalid filter '${filter}', must be available|unavailable|all" >&2
+							return 1
+						;;
+					esac
+				fi
+				if [[ -n "$status" ]]; then
+					# comma-separated keep-list of status values
+					# (supported, community, unsupported).
+					local _s _bad=0
+					IFS=',' read -r -a _s <<< "$status"
+					for _v in "${_s[@]}"; do
+						case "$_v" in
+							supported|community|unsupported) ;;
+							*) _bad=1; break ;;
+						esac
+					done
+					if (( _bad )); then
+						echo "Error: invalid status '${status}', must be CSV of supported|community|unsupported" >&2
+						return 1
+					fi
+					parser_args+=(--status "$status")
+				fi
 				local result
-				result=$(python3 "$parser" "$yaml_dir" "--list-json" "$use_release" "$use_arch")
+				result=$(python3 "$parser" "${parser_args[@]}")
 				echo "$result"
 				[[ "$result" == "[]" ]] && return 1
 				return 0
@@ -619,7 +650,7 @@ function module_desktops() {
 
 		"${commands[10]}")
 			show_module_help "module_desktops" "Desktops" \
-				"Examples:\n  module_desktops install de=xfce tier=minimal\n  module_desktops install de=gnome tier=full\n  module_desktops upgrade de=xfce tier=mid\n  module_desktops downgrade de=xfce tier=minimal\n  module_desktops status de=xfce\n  module_desktops supported arch=arm64 release=trixie" "native"
+				"Examples:\n  module_desktops install de=xfce tier=minimal\n  module_desktops install de=gnome tier=full\n  module_desktops upgrade de=xfce tier=mid\n  module_desktops downgrade de=xfce tier=minimal\n  module_desktops status de=xfce\n  module_desktops supported arch=arm64 release=trixie\n  module_desktops supported arch=arm64 release=trixie filter=all\n  module_desktops supported arch=riscv64 release=noble status=supported,community" "native"
 		;;
 
 		"${commands[11]}")

--- a/tools/modules/desktops/scripts/parse_desktop_yaml.py
+++ b/tools/modules/desktops/scripts/parse_desktop_yaml.py
@@ -31,8 +31,8 @@ tier filter and applies after all tier merging is done.
 Usage
 -----
   parse_desktop_yaml.py <yaml_dir> <de_name> <release> <arch> --tier <tier>
-  parse_desktop_yaml.py <yaml_dir> --list <release> <arch>
-  parse_desktop_yaml.py <yaml_dir> --list-json <release> <arch>
+  parse_desktop_yaml.py <yaml_dir> --list <release> <arch> [--filter <available|unavailable|all>] [--status <csv>]
+  parse_desktop_yaml.py <yaml_dir> --list-json <release> <arch> [--filter <available|unavailable|all>] [--status <csv>]
   parse_desktop_yaml.py <yaml_dir> --primaries <release> <arch>
 
 Output (bash eval-friendly):
@@ -41,7 +41,7 @@ Output (bash eval-friendly):
   DESKTOP_PRIMARY_PKG="xfce4"
   DESKTOP_DM="lightdm"
   DESKTOP_STATUS="supported"
-  DESKTOP_SUPPORTED="yes"
+  DESKTOP_AVAILABLE="yes"
   DESKTOP_DESC="..."
   DESKTOP_TIER="full"
   DESKTOP_REPO_URL="..."       (optional, for custom repos)
@@ -276,7 +276,7 @@ def parse_desktop(yaml_dir, de_name, release, arch, tier):
     releases = _as_dict(de_data.get("releases"))
     release_data = _as_dict(releases.get(release))
     supported_archs = _as_list(release_data.get("architectures"))
-    is_supported = arch in supported_archs and release in releases
+    is_available = arch in supported_archs and release in releases
 
     for pkg in _as_list(release_data.get("packages_remove")):
         if pkg in packages:
@@ -318,7 +318,7 @@ def parse_desktop(yaml_dir, de_name, release, arch, tier):
     print(f'DESKTOP_PRIMARY_PKG="{shell_escape(primary_pkg)}"')
     print(f'DESKTOP_DM="{shell_escape(de_data.get("display_manager", "lightdm"))}"')
     print(f'DESKTOP_STATUS="{shell_escape(de_data.get("status", "unsupported"))}"')
-    print(f'DESKTOP_SUPPORTED="{"yes" if is_supported else "no"}"')
+    print(f'DESKTOP_AVAILABLE="{"yes" if is_available else "no"}"')
     print(f'DESKTOP_DESC="{shell_escape(de_data.get("description", de_name))}"')
     print(f'DESKTOP_TIER="{shell_escape(tier)}"')
 
@@ -452,8 +452,25 @@ def list_primaries(yaml_dir, release, arch):
             print(f"{name}\t{effective[0]}")
 
 
-def list_desktops(yaml_dir, release, arch, fmt="tsv"):
-    """List all desktops with support status."""
+_VALID_STATUSES = {"supported", "community", "unsupported"}
+
+
+def list_desktops(yaml_dir, release, arch, fmt="tsv", avail_filter="available", status_keep=None):
+    """List desktops with availability + editorial status.
+
+    Two independent axes are emitted per entry:
+      - "status"    : editorial label from the DE's YAML (supported / community / unsupported).
+      - "available" : computed bool — does the YAML declare this release+arch combo?
+
+    avail_filter selects on the computed `available` axis only:
+      - "available"   : only DEs whose YAML declares this release+arch (default)
+      - "unavailable" : only DEs that do NOT declare this release+arch
+      - "all"         : every DE, regardless of release+arch availability
+
+    status_keep selects on the editorial `status` axis. It is either None
+    (no filtering, keep all) or an iterable of status values to KEEP
+    (e.g. ("supported","community") drops status=unsupported).
+    """
     import json as jsonlib
 
     entries = []
@@ -473,33 +490,50 @@ def list_desktops(yaml_dir, release, arch, fmt="tsv"):
         releases = _as_dict(de_data.get("releases"))
         release_data = _as_dict(releases.get(release))
         archs = _as_list(release_data.get("architectures"))
-        supported = arch in archs and release in releases
+        available = arch in archs and release in releases
 
         entries.append({
             "name": name,
             "description": desc,
             "display_manager": dm,
             "status": status,
-            "supported": supported,
+            "available": available,
             "architectures": archs,
         })
 
-    # filter to only supported entries
-    supported_entries = [e for e in entries if e["supported"]]
+    if avail_filter == "available":
+        entries = [e for e in entries if e["available"]]
+    elif avail_filter == "unavailable":
+        entries = [e for e in entries if not e["available"]]
+    elif avail_filter != "all":
+        print(f"Error: invalid --filter '{avail_filter}', must be available|unavailable|all", file=sys.stderr)
+        sys.exit(1)
+
+    if status_keep is not None:
+        keep = set(status_keep)
+        bad = keep - _VALID_STATUSES
+        if bad:
+            print(
+                f"Error: invalid --status value(s) {sorted(bad)}, must be in "
+                f"{sorted(_VALID_STATUSES)}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        entries = [e for e in entries if e["status"] in keep]
 
     if fmt == "json":
-        print(jsonlib.dumps(supported_entries, indent=2))
+        print(jsonlib.dumps(entries, indent=2))
     else:
-        for e in supported_entries:
+        for e in entries:
             arch_str = " ".join(e["architectures"]) if e["architectures"] else "-"
-            print(f"{e['name']}\t{e['status']}\t{'yes' if e['supported'] else 'no'}\t{arch_str}")
+            print(f"{e['name']}\t{e['status']}\t{'yes' if e['available'] else 'no'}\t{arch_str}")
 
 
 def _usage():
     prog = sys.argv[0]
     print(f"Usage: {prog} <yaml_dir> <de_name> <release> <arch> --tier <minimal|mid|full>", file=sys.stderr)
-    print(f"       {prog} <yaml_dir> --list <release> <arch>", file=sys.stderr)
-    print(f"       {prog} <yaml_dir> --list-json <release> <arch>", file=sys.stderr)
+    print(f"       {prog} <yaml_dir> --list <release> <arch> [--filter <available|unavailable|all>] [--status <csv>]", file=sys.stderr)
+    print(f"       {prog} <yaml_dir> --list-json <release> <arch> [--filter <available|unavailable|all>] [--status <csv>]", file=sys.stderr)
     print(f"       {prog} <yaml_dir> --primaries <release> <arch>", file=sys.stderr)
     sys.exit(1)
 
@@ -514,7 +548,29 @@ if __name__ == "__main__":
         if len(sys.argv) < 5:
             _usage()
         fmt = "json" if sys.argv[2] == "--list-json" else "tsv"
-        list_desktops(yaml_dir, sys.argv[3], sys.argv[4], fmt=fmt)
+        avail_filter = "available"
+        status_keep = None
+        # Optional flag pairs (order-independent): --filter <v>, --status <csv>.
+        extra = sys.argv[5:]
+        if len(extra) % 2 != 0:
+            _usage()
+        it = iter(extra)
+        for flag in it:
+            try:
+                value = next(it)
+            except StopIteration:
+                _usage()
+            if flag == "--filter":
+                avail_filter = value
+            elif flag == "--status":
+                # comma-separated list; empty entries dropped.
+                status_keep = [s.strip() for s in value.split(",") if s.strip()]
+                if not status_keep:
+                    _usage()
+            else:
+                _usage()
+        list_desktops(yaml_dir, sys.argv[3], sys.argv[4], fmt=fmt,
+                      avail_filter=avail_filter, status_keep=status_keep)
     elif sys.argv[2] == "--primaries":
         if len(sys.argv) < 5:
             _usage()

--- a/tools/modules/desktops/yaml/bianbu.yaml
+++ b/tools/modules/desktops/yaml/bianbu.yaml
@@ -1,6 +1,6 @@
 name: bianbu
 description: "Bianbu - SpacemiT RISC-V desktop"
-display_manager: none
+display_manager: gdm3
 status: unsupported
 repo:
   # SpacemiT's K1 RISC-V archive is a frozen per-release snapshot — the

--- a/tools/modules/desktops/yaml/budgie.yaml
+++ b/tools/modules/desktops/yaml/budgie.yaml
@@ -1,7 +1,7 @@
 name: budgie
 description: "Budgie - elegant desktop from Solus project"
 display_manager: lightdm
-status: unsupported
+status: community
 
 tiers:
   minimal:

--- a/tools/modules/desktops/yaml/deepin.yaml
+++ b/tools/modules/desktops/yaml/deepin.yaml
@@ -1,7 +1,7 @@
 name: deepin
 description: "Deepin - DDE desktop environment"
 display_manager: lightdm
-status: unsupported
+status: community
 
 tiers:
   minimal:

--- a/tools/modules/desktops/yaml/enlightenment.yaml
+++ b/tools/modules/desktops/yaml/enlightenment.yaml
@@ -1,7 +1,7 @@
 name: enlightenment
 description: "Enlightenment - EFL-based desktop"
 display_manager: lightdm
-status: supported
+status: community
 
 tiers:
   minimal:

--- a/tools/modules/desktops/yaml/kde-neon.yaml
+++ b/tools/modules/desktops/yaml/kde-neon.yaml
@@ -1,7 +1,7 @@
 name: kde-neon
 description: "KDE Neon - latest Plasma from KDE repos (Ubuntu only)"
 display_manager: sddm
-status: unsupported
+status: supported
 repo:
   url: "http://archive.neon.kde.org/testing"
   key_url: "https://archive.neon.kde.org/public.key"

--- a/tools/modules/desktops/yaml/xmonad.yaml
+++ b/tools/modules/desktops/yaml/xmonad.yaml
@@ -1,7 +1,7 @@
 name: xmonad
 description: "Xmonad - Haskell tiling window manager"
 display_manager: lightdm
-status: community
+status: unsupported
 
 tiers:
   minimal:

--- a/tools/modules/desktops/yaml/xmonad.yaml
+++ b/tools/modules/desktops/yaml/xmonad.yaml
@@ -1,7 +1,7 @@
 name: xmonad
 description: "Xmonad - Haskell tiling window manager"
 display_manager: lightdm
-status: supported
+status: community
 
 tiers:
   minimal:


### PR DESCRIPTION
## Summary
- Split the overloaded "supported" concept into two independent axes exposed through `module_desktops supported`:
  - `filter=available|unavailable|all` — computed bool (does the YAML declare this release+arch combo?)
  - `status=<csv of supported,community,unsupported>` — editorial label from the YAML (keep-list; omit = keep all)
- Rename for clarity: JSON field `supported`→`available`, bash var `DESKTOP_SUPPORTED`→`DESKTOP_AVAILABLE`, parser `--filter` values `supported|unsupported|both`→`available|unavailable|all`.
- YAML editorial-status reshuffle:
  - `kde-neon`: `unsupported` → `supported`
  - `budgie`, `deepin`, `enlightenment`, `xmonad`: `unsupported` → `community`
  - `bianbu`: gains `display_manager: gdm3` (was `none`)
- `config.system.json`: add menu entries for the 4 community DEs with a `[CSC]` marker, mirroring the `kde-neon` precedent (install-minimal + uninstall + auto/manual-login; no 3-tier install, no set-tier).

## Test plan
- [ ] `armbian-config --api module_desktops supported arch=arm64 release=noble` returns only DEs where the YAML declares this combo
- [ ] `filter=unavailable` returns the complement set; `filter=all` returns every DE
- [ ] `status=supported,community` drops `unsupported` entries; `status=supported` drops community too
- [ ] Combining flags works: `filter=all status=unsupported`
- [ ] Invalid values for `filter=`/`status=` are rejected with a clear error (exit 1)
- [ ] Community DEs (budgie/deepin/enlightenment/xmonad) appear in the Desktops submenu with `[CSC]`
- [ ] Install → uninstall flow works for at least one community DE end-to-end
- [ ] Existing supported DEs install/remove unaffected by the rename
- [ ] Build framework still calls the list correctly (`interactive_desktop_main_configuration` populates the dialog)