### PR TITLE
desktops: skip plymouth-theme install when mode=build

### DIFF
--- a/tools/modules/desktops/module_desktops.sh
+++ b/tools/modules/desktops/module_desktops.sh
@@ -249,15 +249,18 @@ function module_desktops() {
 			fi
 
 			# Armbian-only branding extras: install only when the Armbian
-			# apt source is configured. armbian-plymouth-theme lives in
-			# Armbian's own repo; on a non-Armbian system the apt install
-			# would hard-fail with "Unable to locate package" and abort
-			# the entire desktop install. Keep this gated and additive so
-			# the rest of the desktop install path stays distro-agnostic.
+			# apt source is configured AND we're running on a live system
+			# (mode != build). armbian-plymouth-theme lives in Armbian's
+			# own repo; on a non-Armbian system the apt install would
+			# hard-fail with "Unable to locate package" and abort the
+			# entire desktop install. At image-build time (mode=build)
+			# the armbian/build framework installs this package directly
+			# from the locally-built .deb artifact — no apt fetch needed
+			# — so skip it here to avoid racing the build framework.
 			# Match either the legacy single-line .list file or the modern
 			# deb822 .sources file.
-			if [[ -f /etc/apt/sources.list.d/armbian.list \
-				|| -f /etc/apt/sources.list.d/armbian.sources ]]; then
+			if [[ "$mode" != "build" ]] && { [[ -f /etc/apt/sources.list.d/armbian.list ]] \
+				|| [[ -f /etc/apt/sources.list.d/armbian.sources ]]; }; then
 				pkg_install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" armbian-plymouth-theme || \
 					echo "Warning: armbian-plymouth-theme not installed (package not found in armbian repo)" >&2
 			fi

--- a/tools/modules/desktops/postinst/gnome.sh
+++ b/tools/modules/desktops/postinst/gnome.sh
@@ -50,8 +50,6 @@ dconf update
 # launch at all. Strip the stub if it exists.
 rm -f /usr/local/share/applications/gnome-ubuntu-panel.desktop
 
-fi
-
 #compile schemas
 if [ -d /usr/share/glib-2.0/schemas ]; then
 	glib-compile-schemas /usr/share/glib-2.0/schemas


### PR DESCRIPTION
## Summary

When `module_desktops install` is invoked with `mode=build` from armbian/build's rootfs creation flow, skip the `armbian-plymouth-theme` apt install. The build framework now installs this Armbian-built .deb directly from the local artifact (in `lib/functions/rootfs/distro-agnostic.sh`) rather than fetching it from apt.armbian.com.

On live systems (`mode` unset or anything other than `build`), the install still runs when an Armbian apt source is configured — unchanged behavior.

## Why

- Avoids racing the build framework's artifact install.
- Avoids a potential 404 inside the chroot on rootfs caches where `apt update` hasn't fully warmed the Armbian source yet.
- Restores a clean division: build framework owns image-build plymouth; module_desktops owns the live-system plymouth fetch.

## Depends on

armbian/build branch `desktop-to-armbian-config` moves `install_artifact_deb_chroot "armbian-plymouth-theme"` back to `distro-agnostic.sh` (original pre-branch location). Merge order: build-side change first, then this.

## Test plan

- [x] `module_desktops install de=xfce tier=mid` (no mode= arg) on a live Armbian system still installs `armbian-plymouth-theme`
- [x] `module_desktops install de=xfce tier=mid mode=build` (armbian/build's invocation) does NOT try to apt-install `armbian-plymouth-theme`
- [x] `mode=build` install path otherwise unchanged
- [x] Boot-test an Armbian image: the plymouth theme is still present and active