### PR TITLE
desktops/mate: drop brisk-menu + mate-applet-trash from minimal

### DIFF
--- a/tools/modules/desktops/yaml/mate.yaml
+++ b/tools/modules/desktops/yaml/mate.yaml
@@ -39,11 +39,12 @@ tiers:
       - viewnior
       - xdg-user-dirs
       - xdg-user-dirs-gtk
-    packages_uninstall:
+    packages_remove:
       - brisk-menu
+      - mate-applet-trash
+    packages_uninstall:
       - mate-indicator-applet
       - mate-indicator-applet-common
-      - mate-applet-trash
 
 releases:
   bookworm:


### PR DESCRIPTION
Small trim to the MATE minimal tier — add `brisk-menu` and `mate-applet-trash` to `tiers.minimal.packages_remove` alongside the existing `packages_uninstall` purge.

Belt-and-suspenders: `packages_remove` filters them out of the merged install list if ever named explicitly (common or release blocks); `packages_uninstall` still catches them when `mate-desktop-environment` pulls them in via Recommends.