### PR TITLE
desktops/common: strip armbian-imager on armhf/riscv64/loong64

### DIFF
--- a/tools/modules/desktops/postinst/gnome.sh
+++ b/tools/modules/desktops/postinst/gnome.sh
@@ -15,24 +15,39 @@ install -Dv /dev/null $keys
 install -Dv /dev/null $profile
 
 # set default shortcuts
-echo "
-[org/gnome/shell]
-favorite-apps = ['terminator.desktop', 'org.gnome.Nautilus.desktop', 'armbian-imager.desktop']
+# Build the favorites list dynamically — armbian-imager is only
+# published for amd64/arm64 (see common.yaml mid-tier arch gate),
+# so skip the shortcut on arches where the .desktop file isn't
+# going to exist. Uses the file presence at postinst time as the
+# single source of truth: if apt just installed armbian-imager,
+# the .desktop is there; if it was stripped via tier_overrides,
+# it isn't, and the favorites bar stays clean instead of showing
+# a broken shortcut.
+favorites="'terminator.desktop', 'org.gnome.Nautilus.desktop'"
+if [ -f /usr/share/applications/armbian-imager.desktop ]; then
+	favorites="${favorites}, 'armbian-imager.desktop'"
+fi
 
-[org/gnome/settings-daemon/plugins/power]
-sleep-inactive-ac-timeout='0'
+cat >> "$keys" <<- EOF
 
-[org/gnome/desktop/background]
-picture-uri='file:///usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-3840x2160.jpg'
-picture-options='zoom'
-primary-color='#456789'
-secondary-color='#FFFFFF'
+	[org/gnome/shell]
+	favorite-apps = [${favorites}]
 
-[org/gnome/desktop/screensaver]
-picture-uri='file:///usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-3840x2160.jpg'
-picture-options='zoom'
-primary-color='#456789'
-secondary-color='#FFFFFF'" >> $keys
+	[org/gnome/settings-daemon/plugins/power]
+	sleep-inactive-ac-timeout='0'
+
+	[org/gnome/desktop/background]
+	picture-uri='file:///usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-3840x2160.jpg'
+	picture-options='zoom'
+	primary-color='#456789'
+	secondary-color='#FFFFFF'
+
+	[org/gnome/desktop/screensaver]
+	picture-uri='file:///usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-3840x2160.jpg'
+	picture-options='zoom'
+	primary-color='#456789'
+	secondary-color='#FFFFFF'
+	EOF
 
 echo "user-db:user
 system-db:local" >> $profile

--- a/tools/modules/desktops/yaml/common.yaml
+++ b/tools/modules/desktops/yaml/common.yaml
@@ -183,6 +183,16 @@ tier_overrides:
           riscv64:  { packages_remove: [fonts-ubuntu] }
           loong64:  { packages_remove: [fonts-ubuntu] }
   mid:
+    # armbian-imager (apt.armbian.com) is only published for amd64
+    # and arm64 — strip it on every other arch. Arch-wide so the
+    # exclusion applies across all releases.
+    architectures:
+      armhf:
+        packages_remove: [armbian-imager]
+      riscv64:
+        packages_remove: [armbian-imager]
+      loong64:
+        packages_remove: [armbian-imager]
     releases:
       bookworm:
         # loupe is GNOME 46+; bookworm shipped with GNOME 43 era and


### PR DESCRIPTION
`armbian-imager` is only built for amd64 and arm64 on apt.armbian.com. Mid-tier installs on other arches were failing with `E: Unable to locate package armbian-imager`.

Add an arch-wide `tier_overrides.mid.architectures.<arch>.packages_remove` entry for armhf, riscv64, and loong64.

Smoke-tested by running `parse_desktop_yaml.py xfce <release> <arch> --tier mid`:
- amd64/arm64 → `armbian-imager` present in `DESKTOP_PACKAGES`
- armhf/riscv64/loong64 → `armbian-imager` filtered out