### PR TITLE
desktops/xfce: drop apport stack from packages_uninstall

### DIFF
--- a/tools/modules/desktops/postinst/gnome.sh
+++ b/tools/modules/desktops/postinst/gnome.sh
@@ -15,24 +15,39 @@ install -Dv /dev/null $keys
 install -Dv /dev/null $profile
 
 # set default shortcuts
-echo "
-[org/gnome/shell]
-favorite-apps = ['terminator.desktop', 'org.gnome.Nautilus.desktop', 'armbian-imager.desktop']
+# Build the favorites list dynamically — armbian-imager is only
+# published for amd64/arm64 (see common.yaml mid-tier arch gate),
+# so skip the shortcut on arches where the .desktop file isn't
+# going to exist. Uses the file presence at postinst time as the
+# single source of truth: if apt just installed armbian-imager,
+# the .desktop is there; if it was stripped via tier_overrides,
+# it isn't, and the favorites bar stays clean instead of showing
+# a broken shortcut.
+favorites="'terminator.desktop', 'org.gnome.Nautilus.desktop'"
+if [ -f /usr/share/applications/armbian-imager.desktop ]; then
+	favorites="${favorites}, 'armbian-imager.desktop'"
+fi
 
-[org/gnome/settings-daemon/plugins/power]
-sleep-inactive-ac-timeout='0'
+cat >> "$keys" <<- EOF
 
-[org/gnome/desktop/background]
-picture-uri='file:///usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-3840x2160.jpg'
-picture-options='zoom'
-primary-color='#456789'
-secondary-color='#FFFFFF'
+	[org/gnome/shell]
+	favorite-apps = [${favorites}]
 
-[org/gnome/desktop/screensaver]
-picture-uri='file:///usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-3840x2160.jpg'
-picture-options='zoom'
-primary-color='#456789'
-secondary-color='#FFFFFF'" >> $keys
+	[org/gnome/settings-daemon/plugins/power]
+	sleep-inactive-ac-timeout='0'
+
+	[org/gnome/desktop/background]
+	picture-uri='file:///usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-3840x2160.jpg'
+	picture-options='zoom'
+	primary-color='#456789'
+	secondary-color='#FFFFFF'
+
+	[org/gnome/desktop/screensaver]
+	picture-uri='file:///usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-3840x2160.jpg'
+	picture-options='zoom'
+	primary-color='#456789'
+	secondary-color='#FFFFFF'
+	EOF
 
 echo "user-db:user
 system-db:local" >> $profile

--- a/tools/modules/desktops/yaml/common.yaml
+++ b/tools/modules/desktops/yaml/common.yaml
@@ -183,6 +183,16 @@ tier_overrides:
           riscv64:  { packages_remove: [fonts-ubuntu] }
           loong64:  { packages_remove: [fonts-ubuntu] }
   mid:
+    # armbian-imager (apt.armbian.com) is only published for amd64
+    # and arm64 — strip it on every other arch. Arch-wide so the
+    # exclusion applies across all releases.
+    architectures:
+      armhf:
+        packages_remove: [armbian-imager]
+      riscv64:
+        packages_remove: [armbian-imager]
+      loong64:
+        packages_remove: [armbian-imager]
     releases:
       bookworm:
         # loupe is GNOME 46+; bookworm shipped with GNOME 43 era and

--- a/tools/modules/desktops/yaml/xfce.yaml
+++ b/tools/modules/desktops/yaml/xfce.yaml
@@ -42,18 +42,6 @@ tiers:
       - viewnior
       - xdg-user-dirs
       - xdg-user-dirs-gtk
-    packages_uninstall:
-      # IMPORTANT: do NOT list any package here that is a Depends of
-      # xfce4-goodies. apt removal of such a package yanks xfce4-goodies
-      # itself, and on systems with apt's autoremove behavior enabled
-      # the cascade then takes out half the desktop (xserver-xorg,
-      # pulseaudio, cups, evince, mousepad, ...). Keep this list strictly
-      # to packages that are *orthogonal* to the xfce dep tree.
-      # Ubuntu crash reporter — Armbian doesn't consume apport reports.
-      - apport
-      - python3-apport
-      - python3-problem-report
-      - libsnapd-glib-2-1
 
 releases:
   bookworm:


### PR DESCRIPTION
apport / python3-apport / python3-problem-report / libsnapd-glib-2-1 are only published on Ubuntu amd64/arm64. The batched `apt-get remove` in module_desktops aborts on the first 'Unable to locate package', so on armhf/riscv64 Ubuntu and on any Debian arch the purge failed and every other package in the list (currently none, but any future addition) would be left behind.

These 4 Ubuntu crash-reporter packages are harmless if they stay installed. Drop them from the list. The purge path now only carries `ubuntu-session` (via the Ubuntu release blocks), which exists on every Ubuntu arch and is safe to remove.

Follow-up note in the commit message: if a future need arises to purge packages that don't exist on every supported arch, the fix is a parser extension (arch-gated `packages_uninstall` in `tier_overrides`) or a bash-side per-package loop in module_desktops — not stuffing more arch-specific names into the shared list.