### PR TITLE
desktops/common: use epiphany-browser on Ubuntu/riscv64

### DIFF
--- a/tools/modules/desktops/yaml/common.yaml
+++ b/tools/modules/desktops/yaml/common.yaml
@@ -103,20 +103,24 @@ browser:
     amd64:   google-chrome-stable
     arm64:   chromium        # apt.armbian.com real .deb (Ubuntu's is snap-shim)
     armhf:   chromium
-    riscv64: firefox          # apt.armbian.com real .deb
+    # firefox / firefox-esr are not in the Ubuntu noble archive for
+    # riscv64 (Mozilla doesn't publish riscv64 binaries, and firefox-esr
+    # is a Debian-only package name). Fall back to GNOME Web (native
+    # GTK, no snap, small footprint, built for every Ubuntu arch).
+    riscv64: epiphany-browser
   jammy:
     # Ubuntu 22.04 LTS — chromium / firefox apt names on Ubuntu are
     # snap-shims; apt.armbian.com hosts real .debs of the same name.
     amd64:   google-chrome-stable
     arm64:   chromium
     armhf:   chromium
-    riscv64: firefox
+    riscv64: epiphany-browser   # same rationale as noble
   resolute:
     # Ubuntu 26.04 LTS
     amd64:   google-chrome-stable
     arm64:   chromium
     armhf:   chromium
-    riscv64: firefox
+    riscv64: epiphany-browser   # same rationale as noble
   forky:
     # Debian 14 — same rules as trixie.
     amd64:   google-chrome-stable


### PR DESCRIPTION
The `noble` / `jammy` / `resolute` entries in the `browser:` map resolved to `firefox` on riscv64, which doesn't install:

- Mozilla doesn't publish riscv64 binaries (tier-3 arch upstream), so apt.armbian.com has nothing to repackage.
- Ubuntu's `firefox` package is the snap-transitional shim — pulls snapd, which Armbian doesn't ship.
- `firefox-esr` is a Debian-only name; `packages.ubuntu.com/noble/riscv64/firefox-esr` returns 'No such package'.

Fall back to `epiphany-browser` (GNOME Web): native GTK, no snap, available for riscv64 on every Ubuntu release we support. Matches the file's own docstring recommendation for Ubuntu-snap-shim cases.

Smoke-tested via `parse_desktop_yaml.py xfce <release> riscv64 --tier mid`: all three releases now resolve `browser` to `epiphany-browser`.