### PR TITLE
desktops: fix forky minimal installs (drop obsoleted/moved pkgs)

### DIFF
--- a/tools/modules/desktops/yaml/cinnamon.yaml
+++ b/tools/modules/desktops/yaml/cinnamon.yaml
@@ -72,7 +72,6 @@ releases:
     architectures: [arm64, amd64, riscv64]
     packages:
       - accountsservice
-      - libu2f-udev
       - pipewire-audio
       - pipewire-pulse
       - wireplumber

--- a/tools/modules/desktops/yaml/common.yaml
+++ b/tools/modules/desktops/yaml/common.yaml
@@ -170,13 +170,16 @@ tier_overrides:
           armhf:    { packages_remove: [fonts-ubuntu] }
           riscv64:  { packages_remove: [fonts-ubuntu] }
       forky:
-        # fonts-ubuntu is Ubuntu-only; Debian 14 doesn't ship it.
-        # Same restriction as bookworm/trixie.
+        # fonts-ubuntu: Ubuntu-only.
+        # printer-driver-all: obsoleted in Debian 14, has no installation
+        #   candidate anymore ('referred to by another package' state).
+        # gtk2-engines-murrine: GTK2 is being phased out in Debian 14;
+        #   the murrine engine was removed from the archive.
         architectures:
-          amd64:    { packages_remove: [fonts-ubuntu] }
-          arm64:    { packages_remove: [fonts-ubuntu] }
-          armhf:    { packages_remove: [fonts-ubuntu] }
-          riscv64:  { packages_remove: [fonts-ubuntu] }
+          amd64:    { packages_remove: [fonts-ubuntu, printer-driver-all, gtk2-engines-murrine] }
+          arm64:    { packages_remove: [fonts-ubuntu, printer-driver-all, gtk2-engines-murrine] }
+          armhf:    { packages_remove: [fonts-ubuntu, printer-driver-all, gtk2-engines-murrine] }
+          riscv64:  { packages_remove: [fonts-ubuntu, printer-driver-all, gtk2-engines-murrine] }
       sid:
         # fonts-ubuntu is Ubuntu-only; Debian sid doesn't ship it.
         # Includes loong64, which is a sid-only Armbian arch.

--- a/tools/modules/desktops/yaml/enlightenment.yaml
+++ b/tools/modules/desktops/yaml/enlightenment.yaml
@@ -52,7 +52,6 @@ releases:
     architectures: [arm64, amd64, armhf, riscv64]
     packages:
       - accountsservice
-      - libu2f-udev
       - pipewire-audio
       - pipewire-pulse
       - wireplumber

--- a/tools/modules/desktops/yaml/gnome.yaml
+++ b/tools/modules/desktops/yaml/gnome.yaml
@@ -91,7 +91,6 @@ releases:
     architectures: [arm64, amd64]
     packages:
       - accountsservice
-      - libu2f-udev
       - pipewire-audio
       - pipewire-pulse
       - wireplumber

--- a/tools/modules/desktops/yaml/i3-wm.yaml
+++ b/tools/modules/desktops/yaml/i3-wm.yaml
@@ -64,7 +64,6 @@ releases:
     architectures: [arm64, amd64, armhf, riscv64]
     packages:
       - accountsservice
-      - libu2f-udev
       - pipewire-audio
       - pipewire-pulse
       - wireplumber

--- a/tools/modules/desktops/yaml/kde-plasma.yaml
+++ b/tools/modules/desktops/yaml/kde-plasma.yaml
@@ -93,7 +93,6 @@ releases:
     architectures: [arm64, amd64]
     packages:
       - accountsservice
-      - libu2f-udev
       - pipewire-audio
       - pipewire-pulse
       - wireplumber

--- a/tools/modules/desktops/yaml/mate.yaml
+++ b/tools/modules/desktops/yaml/mate.yaml
@@ -79,7 +79,6 @@ releases:
     architectures: [arm64, amd64, armhf, riscv64]
     packages:
       - accountsservice
-      - libu2f-udev
       - pipewire-audio
       - pipewire-pulse
       - wireplumber

--- a/tools/modules/desktops/yaml/xfce.yaml
+++ b/tools/modules/desktops/yaml/xfce.yaml
@@ -80,7 +80,6 @@ releases:
     architectures: [arm64, amd64, armhf, riscv64]
     packages:
       - accountsservice
-      - libu2f-udev
       - pipewire-audio
       - pipewire-pulse
       - wireplumber

--- a/tools/modules/desktops/yaml/xmonad.yaml
+++ b/tools/modules/desktops/yaml/xmonad.yaml
@@ -55,7 +55,6 @@ releases:
     architectures: [arm64, amd64, armhf, riscv64]
     packages:
       - accountsservice
-      - libu2f-udev
       - pipewire-audio
       - pipewire-pulse
       - wireplumber


### PR DESCRIPTION
Three packages broke every DE's minimal install on Debian forky:

| Package | Symptom | Fix |
|---|---|---|
| `printer-driver-all` | 'has no installation candidate' | drop via common.yaml tier_overrides |
| `gtk2-engines-murrine` | 'Unable to locate package' | drop via common.yaml tier_overrides |
| `libu2f-udev` | 'Unable to locate package' | remove from each DE's `releases.forky.packages` |

common.yaml carries the two packages shared by every DE; per-DE YAMLs each have the `libu2f-udev` line to remove from their forky release block (9 DEs × 1 line each). User-reported error was a cinnamon forky install; the same three packages appear in the minimal tier of every DE so the fix is broad.

`libu2f-udev` is replaced upstream by `libfido2-1` / `fido2-tools` for U2F/FIDO2 support in Debian 14 — if a board needs it, pull it back in via `EXTRA_PACKAGES_ROOTFS` or a family hook. Not adding it blindly to the DE YAMLs until someone has confirmed the right replacement across all four arches.

Smoke-tested on forky/arm64 for cinnamon and gnome — none of the three names appear in `DESKTOP_PACKAGES` any more.