### PR TITLE
ci: multi-arch unit tests + JSON report published to armbian.github.io

### DIFF
--- a/.github/workflows/maintenance-unit-tests.yml
+++ b/.github/workflows/maintenance-unit-tests.yml
@@ -50,15 +50,19 @@ jobs:
           # single-platform manifest per <release>-<arch> tag, so the
           # runner arch and the image tag arch must match exactly.
           #
-          # Runners are our self-hosted pool, selected by a label pair
-          # (docker + arch). The value is a JSON array so
-          # `runs-on: ${{ matrix.server.runner }}` gets the native
-          # label-list form that GHA uses for 'AND' label matching.
+          # Runners:
+          #   amd64 / arm64 — self-hosted pool, selected by a label pair
+          #     (docker + arch). JSON array so runs-on: ... uses GHA's
+          #     'AND' label-list matching.
+          #   riscv64 — GH-hosted runner 'ubuntu-24.04-riscv' until the
+          #     self-hosted pool gains a riscv64 host. Single string.
+          # Both forms are accepted by runs-on: ${{ matrix.server.runner }}.
           releases=("bookworm" "trixie" "forky" "jammy" "noble" "resolute")
-          arches=("amd64" "arm64")
+          arches=("amd64" "arm64" "riscv64")
           declare -A runner_for_arch=(
             ["amd64"]='["docker","X64"]'
             ["arm64"]='["docker","ARM64"]'
+            ["riscv64"]='"ubuntu-24.04-riscv"'
           )
 
           # read tests cases

--- a/.github/workflows/maintenance-unit-tests.yml
+++ b/.github/workflows/maintenance-unit-tests.yml
@@ -194,14 +194,36 @@ jobs:
           # read test
           source "${{ matrix.server.package }}"
 
-          # Test case execution
+          # Test case execution. Capture the testcase's exit code
+          # without failing this step — we want to keep recording the
+          # per-test JSON even on failure so the aggregate report is
+          # complete. `if ...; then ... else ... fi` is exempt from
+          # bash's set -e, which GH Actions sets by default under
+          # shell: bash.
           start_time=$(date +%s)
           figlet  "RUN TEST CASE"
-          testcase
+          if testcase; then
+              result="success"
+          else
+              result="failure"
+          fi
           finish_time=$(date +%s)
+          duration=$((finish_time - start_time))
 
-          # Generate table entry
-          echo "|${{ matrix.server.os }}| ${{ matrix.server.arch }} | ${{ matrix.server.name }} | $((finish_time - start_time)) sec |" > ../test/${{ matrix.server.id }}-${{ matrix.server.os }}-${{ matrix.server.arch }}
+          # Emit a per-test JSON blob. stop job aggregates these into
+          # the final report that gets published to armbian.github.io.
+          jq -nc \
+            --arg name     "${{ matrix.server.name }}" \
+            --arg release  "${{ matrix.server.os }}" \
+            --arg arch     "${{ matrix.server.arch }}" \
+            --argjson dur  "${duration}" \
+            --arg result   "${result}" \
+            '{name:$name, release:$release, arch:$arch, duration:$dur, result:$result}' \
+            > ../test/${{ matrix.server.id }}-${{ matrix.server.os }}-${{ matrix.server.arch }}.json
+
+          # Mirror the test's exit code into the step outcome so the
+          # run's 'Run unit test' step is red on failure.
+          [[ "$result" == "success" ]] || exit 1
 
       - name: "Upload test summary"
         uses: actions/upload-artifact@v7
@@ -224,13 +246,82 @@ jobs:
           pattern: test-*
           merge-multiple: true
 
-      - name: Install
+      - name: "Aggregate per-test JSONs into a single report"
+        id: aggregate
         run: |
+          mkdir -p report
+          generated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
-          echo "# Succesful tests:" >> $GITHUB_STEP_SUMMARY
-          echo "|Release|Arch|Test name|Duration|" >> $GITHUB_STEP_SUMMARY
-          echo "|:---|:---|:---|---:|" >> $GITHUB_STEP_SUMMARY
-          cat test/* | sed '$ s/.$//' >> $GITHUB_STEP_SUMMARY
+          # Combine every test/*.json into { generated_at, tests: [...] }.
+          # Sort by release, arch, name for a stable output.
+          jq -s \
+            --arg generated_at "${generated_at}" \
+            '{
+              generated_at: $generated_at,
+              tests: (. | sort_by(.release, .arch, .name))
+            }' \
+            test/*.json 2>/dev/null > report/unit-test-results.json \
+            || echo '{"generated_at":"'"${generated_at}"'","tests":[]}' > report/unit-test-results.json
+
+          total=$(jq '.tests | length'                     report/unit-test-results.json)
+          ok=$(jq    '[.tests[] | select(.result=="success")] | length' report/unit-test-results.json)
+          ko=$(jq    '[.tests[] | select(.result=="failure")] | length' report/unit-test-results.json)
+          echo "total=${total}"   >> "$GITHUB_OUTPUT"
+          echo "success=${ok}"    >> "$GITHUB_OUTPUT"
+          echo "failure=${ko}"    >> "$GITHUB_OUTPUT"
+
+          {
+              echo "# Unit tests: ${ok}/${total} passed (${ko} failed)"
+              echo ""
+              echo "|Release|Arch|Test name|Duration|Result|"
+              echo "|:---|:---|:---|---:|:---:|"
+              jq -r '.tests[] | "|\(.release)|\(.arch)|\(.name)|\(.duration) sec|\(.result)|"' \
+                 report/unit-test-results.json
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: "Upload aggregated report as a workflow artifact"
+        uses: actions/upload-artifact@v7
+        with:
+          name: unit-test-results
+          path: report/unit-test-results.json
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: "Publish results to armbian/armbian.github.io data/"
+        # Only publish when there's a meaningful report AND we're
+        # running on the default branch or a scheduled/dispatch run.
+        # PRs (especially from forks) don't get the PAT and shouldn't
+        # write to the public data feed anyway.
+        if: >-
+          steps.aggregate.outputs.total != '0'
+          && (github.event_name == 'schedule'
+              || github.event_name == 'workflow_dispatch'
+              || github.event_name == 'repository_dispatch'
+              || github.ref == 'refs/heads/main')
+        env:
+          GH_PAT: ${{ secrets.ARMBIAN_GITHUB_IO_PAT }}
+        run: |
+          if [[ -z "${GH_PAT}" ]]; then
+              echo "::warning::ARMBIAN_GITHUB_IO_PAT secret is not set; skipping publish step"
+              exit 0
+          fi
+          git config --global user.name  "armbian-ci-bot"
+          git config --global user.email "armbian-ci-bot@users.noreply.github.com"
+
+          git clone --depth 1 \
+            "https://x-access-token:${GH_PAT}@github.com/armbian/armbian.github.io.git" \
+            armbian.github.io
+          mkdir -p armbian.github.io/data
+          cp report/unit-test-results.json armbian.github.io/data/unit-test-results.json
+
+          cd armbian.github.io
+          if git diff --quiet -- data/unit-test-results.json; then
+              echo "::notice::unit-test-results.json unchanged — nothing to publish"
+              exit 0
+          fi
+          git add data/unit-test-results.json
+          git commit -m "data: refresh unit-test-results.json ($(date -u +%Y-%m-%dT%H:%MZ))"
+          git push
 
       - uses: geekyeggo/delete-artifact@v6
         with:

--- a/.github/workflows/maintenance-unit-tests.yml
+++ b/.github/workflows/maintenance-unit-tests.yml
@@ -87,9 +87,18 @@ jobs:
           }
 
           for i in "${tests[@]}"; do
-             unset RELEASE
+             unset RELEASE TESTARCH
              source "${i}"
              if [[ -z "${RELEASE}" || "${RELEASE}" == "all" ]]; then RELEASE=all; fi
+             # TESTARCH: comma-separated arch allow-list per test, e.g.
+             # TESTARCH="arm64,amd64" (default) or TESTARCH="amd64" to
+             # skip the arm64 variant. "all" / empty / unset expands to
+             # the full arch set.
+             if [[ -z "${TESTARCH}" || "${TESTARCH}" == "all" ]]; then
+                 test_arches=("${arches[@]}")
+             else
+                 IFS=',' read -ra test_arches <<< "${TESTARCH// /}"
+             fi
              testid=$(echo "$i" | cut -d"/" -f2 | cut -d"." -f1)
              if [[ $RELEASE != "all" ]]; then
                 # Colon-separated release allow-list (e.g. RELEASE="noble:trixie")
@@ -97,7 +106,7 @@ jobs:
                 for j in "${releases[@]}"; do
                     for SELECTED_RELEASE in "${elements[@]}"; do
                         if [[ $j == *"${SELECTED_RELEASE}"* ]]; then
-                           for arch in "${arches[@]}"; do
+                           for arch in "${test_arches[@]}"; do
                               emit_entry "${i}" "${TESTNAME}" "${j}" "${testid}" "${arch}"
                            done
                         fi
@@ -105,7 +114,7 @@ jobs:
                 done
              else
                 for j in "${releases[@]}"; do
-                    for arch in "${arches[@]}"; do
+                    for arch in "${test_arches[@]}"; do
                        emit_entry "${i}" "${TESTNAME}" "${j}" "${testid}" "${arch}"
                     done
                 done

--- a/.github/workflows/maintenance-unit-tests.yml
+++ b/.github/workflows/maintenance-unit-tests.yml
@@ -97,40 +97,58 @@ jobs:
               echo "{\"package\":\"${pkg}\",\"name\":\"${testname}\",\"os\":\"${os}\",\"arch\":\"${arch}\",\"runner\":${runner_json},\"id\":\"${testid}\",\"docker_image\":\"${image}\"}"
           }
 
-          for i in "${tests[@]}"; do
-             unset RELEASE TESTARCH
-             source "${i}"
-             if [[ -z "${RELEASE}" || "${RELEASE}" == "all" ]]; then RELEASE=all; fi
-             # TESTARCH: comma-separated arch allow-list per test, e.g.
-             # TESTARCH="arm64,amd64" (default) or TESTARCH="amd64" to
-             # skip the arm64 variant. "all" / empty / unset expands to
-             # the full arch set.
-             if [[ -z "${TESTARCH}" || "${TESTARCH}" == "all" ]]; then
-                 test_arches=("${arches[@]}")
-             else
-                 IFS=',' read -ra test_arches <<< "${TESTARCH// /}"
-             fi
-             testid=$(echo "$i" | cut -d"/" -f2 | cut -d"." -f1)
-             if [[ $RELEASE != "all" ]]; then
-                # Colon-separated release allow-list (e.g. RELEASE="noble:trixie")
-                elements=($(echo "$RELEASE" | tr ':' "\n"))
-                for j in "${releases[@]}"; do
-                    for SELECTED_RELEASE in "${elements[@]}"; do
-                        if [[ $j == *"${SELECTED_RELEASE}"* ]]; then
-                           for arch in "${test_arches[@]}"; do
-                              emit_entry "${i}" "${TESTNAME}" "${j}" "${testid}" "${arch}"
-                           done
-                        fi
-                    done
-                done
-             else
-                for j in "${releases[@]}"; do
-                    for arch in "${test_arches[@]}"; do
-                       emit_entry "${i}" "${TESTNAME}" "${j}" "${testid}" "${arch}"
-                    done
-                done
-             fi
-          done | jq -s >> $GITHUB_OUTPUT
+          # Build the matrix JSON into a variable first so we can log it
+          # before handing off to GITHUB_OUTPUT. Compact form (-c) keeps
+          # the whole array on a single line — avoids any chance of the
+          # heredoc delimiter interacting with multi-line JSON.
+          matrix_json=$(
+            for i in "${tests[@]}"; do
+               unset RELEASE TESTARCH
+               source "${i}"
+               if [[ -z "${RELEASE}" || "${RELEASE}" == "all" ]]; then RELEASE=all; fi
+               # TESTARCH: comma-separated arch allow-list per test, e.g.
+               # TESTARCH="arm64,amd64" (default) or TESTARCH="amd64" to
+               # skip the arm64 variant. "all" / empty / unset expands to
+               # the full arch set.
+               if [[ -z "${TESTARCH}" || "${TESTARCH}" == "all" ]]; then
+                   test_arches=("${arches[@]}")
+               else
+                   IFS=',' read -ra test_arches <<< "${TESTARCH// /}"
+               fi
+               testid=$(echo "$i" | cut -d"/" -f2 | cut -d"." -f1)
+               if [[ $RELEASE != "all" ]]; then
+                  # Colon-separated release allow-list (e.g. RELEASE="noble:trixie")
+                  elements=($(echo "$RELEASE" | tr ':' "\n"))
+                  for j in "${releases[@]}"; do
+                      for SELECTED_RELEASE in "${elements[@]}"; do
+                          if [[ $j == *"${SELECTED_RELEASE}"* ]]; then
+                             for arch in "${test_arches[@]}"; do
+                                emit_entry "${i}" "${TESTNAME}" "${j}" "${testid}" "${arch}"
+                             done
+                          fi
+                      done
+                  done
+               else
+                  for j in "${releases[@]}"; do
+                      for arch in "${test_arches[@]}"; do
+                         emit_entry "${i}" "${TESTNAME}" "${j}" "${testid}" "${arch}"
+                      done
+                  done
+               fi
+            done | jq -sc .
+          )
+
+          matrix_count=$(echo "${matrix_json:-[]}" | jq 'length')
+          echo "::notice::Unit-test matrix has ${matrix_count} entries"
+          if [[ "${matrix_count}" == "0" ]]; then
+              echo "::warning::No matrix entries emitted — gradle job will skip. Possible causes:"
+              echo "::warning::  - no tests/*.conf files with ENABLED=true"
+              echo "::warning::  - PR touches no tests/*.conf and changed-files signalled 'changed'"
+              echo "::warning::    (run_all_tests=false), so the loop iterates an empty set"
+              echo "::warning::  - a test's source failed (syntax error) and bubbled up empty"
+          fi
+
+          echo "${matrix_json:-[]}" >> "${GITHUB_OUTPUT}"
           echo "${delimiter}" >> "${GITHUB_OUTPUT}"
 
   gradle:

--- a/.github/workflows/maintenance-unit-tests.yml
+++ b/.github/workflows/maintenance-unit-tests.yml
@@ -49,11 +49,16 @@ jobs:
           # armbian/docker-armbian-build pipeline publishes a
           # single-platform manifest per <release>-<arch> tag, so the
           # runner arch and the image tag arch must match exactly.
+          #
+          # Runners are our self-hosted pool, selected by a label pair
+          # (docker + arch). The value is a JSON array so
+          # `runs-on: ${{ matrix.server.runner }}` gets the native
+          # label-list form that GHA uses for 'AND' label matching.
           releases=("bookworm" "trixie" "forky" "jammy" "noble" "resolute")
           arches=("amd64" "arm64")
           declare -A runner_for_arch=(
-            ["amd64"]="ubuntu-24.04"
-            ["arm64"]="ubuntu-24.04-arm"
+            ["amd64"]='["docker","X64"]'
+            ["arm64"]='["docker","ARM64"]'
           )
 
           # read tests cases
@@ -82,8 +87,10 @@ jobs:
           emit_entry() {
               local pkg="$1" testname="$2" os="$3" testid="$4" arch="$5"
               local image="ghcr.io/armbian/repository-update:${os}-${arch}"
-              local runner="${runner_for_arch[$arch]}"
-              echo "{\"package\":\"${pkg}\",\"name\":\"${testname}\",\"os\":\"${os}\",\"arch\":\"${arch}\",\"runner\":\"${runner}\",\"id\":\"${testid}\",\"docker_image\":\"${image}\"}"
+              # runner_json is a JSON array literal — injected unquoted
+              # so the resulting matrix value is a list, not a string.
+              local runner_json="${runner_for_arch[$arch]}"
+              echo "{\"package\":\"${pkg}\",\"name\":\"${testname}\",\"os\":\"${os}\",\"arch\":\"${arch}\",\"runner\":${runner_json},\"id\":\"${testid}\",\"docker_image\":\"${image}\"}"
           }
 
           for i in "${tests[@]}"; do

--- a/.github/workflows/maintenance-unit-tests.yml
+++ b/.github/workflows/maintenance-unit-tests.yml
@@ -43,16 +43,19 @@ jobs:
 
           delimiter="$(openssl rand -hex 8)"
           echo "DEPLOYMENT_MATRIX<<${delimiter}" >> "${GITHUB_OUTPUT}"
-          # define OS variants and their Docker images - use pre-built Armbian images
-          declare -A docker_images=(
-            ["bookworm"]="ghcr.io/armbian/repository-update:bookworm-amd64"
-            ["trixie"]="ghcr.io/armbian/repository-update:trixie-amd64"
-            ["forky"]="ghcr.io/armbian/repository-update:forky-amd64"
-            ["jammy"]="ghcr.io/armbian/repository-update:jammy-amd64"
-            ["noble"]="ghcr.io/armbian/repository-update:noble-amd64"
-            ["resolute"]="ghcr.io/armbian/repository-update:resolute-amd64"
+
+          # Run each enabled test case against both amd64 and arm64 runners
+          # using the matching arch-specific Armbian image tag. The
+          # armbian/docker-armbian-build pipeline publishes a
+          # single-platform manifest per <release>-<arch> tag, so the
+          # runner arch and the image tag arch must match exactly.
+          releases=("bookworm" "trixie" "forky" "jammy" "noble" "resolute")
+          arches=("amd64" "arm64")
+          declare -A runner_for_arch=(
+            ["amd64"]="ubuntu-24.04"
+            ["arm64"]="ubuntu-24.04-arm"
           )
-          images=("bookworm" "trixie" "forky" "jammy" "noble" "resolute")
+
           # read tests cases
           # Run all tests on schedule, workflow_dispatch on main, or when no files changed
           run_all_tests=false
@@ -72,26 +75,39 @@ jobs:
                   tests=()
               fi
           fi
-          # loop enabled test cases
+
+          # Emit one matrix entry per (test × release × arch). Each
+          # entry carries the runner label and the fully-qualified image
+          # tag, consumed by the gradle job below.
+          emit_entry() {
+              local pkg="$1" testname="$2" os="$3" testid="$4" arch="$5"
+              local image="ghcr.io/armbian/repository-update:${os}-${arch}"
+              local runner="${runner_for_arch[$arch]}"
+              echo "{\"package\":\"${pkg}\",\"name\":\"${testname}\",\"os\":\"${os}\",\"arch\":\"${arch}\",\"runner\":\"${runner}\",\"id\":\"${testid}\",\"docker_image\":\"${image}\"}"
+          }
+
           for i in "${tests[@]}"; do
              unset RELEASE
              source "${i}"
              if [[ -z "${RELEASE}" || "${RELEASE}" == "all" ]]; then RELEASE=all; fi
-             # if we specify releases, we need to loop docker images and use if there is a match
+             testid=$(echo "$i" | cut -d"/" -f2 | cut -d"." -f1)
              if [[ $RELEASE != "all" ]]; then
-                for j in ${images[@]}; do
-                    elements=($(echo $RELEASE | tr ':' "\n"))
-                    testid=($(echo $i | cut -d"/" -f2 | cut -d"." -f1))
+                # Colon-separated release allow-list (e.g. RELEASE="noble:trixie")
+                elements=($(echo "$RELEASE" | tr ':' "\n"))
+                for j in "${releases[@]}"; do
                     for SELECTED_RELEASE in "${elements[@]}"; do
                         if [[ $j == *"${SELECTED_RELEASE}"* ]]; then
-                           echo "{\"package\":\"${i}\",\"name\":\"${TESTNAME}\",\"os\":\"$j\",\"id\":\"$testid\",\"docker_image\":\"${docker_images[$j]}\"}"
+                           for arch in "${arches[@]}"; do
+                              emit_entry "${i}" "${TESTNAME}" "${j}" "${testid}" "${arch}"
+                           done
                         fi
                     done
                 done
              else
-                for j in ${images[@]}; do
-                    testid=($(echo $i | cut -d"/" -f2 | cut -d"." -f1))
-                    echo "{\"package\":\"${i}\",\"name\":\"${TESTNAME}\",\"os\":\"$j\",\"id\":\"$testid\",\"docker_image\":\"${docker_images[$j]}\"}"
+                for j in "${releases[@]}"; do
+                    for arch in "${arches[@]}"; do
+                       emit_entry "${i}" "${TESTNAME}" "${j}" "${testid}" "${arch}"
+                    done
                 done
              fi
           done | jq -s >> $GITHUB_OUTPUT
@@ -105,9 +121,8 @@ jobs:
       max-parallel: 128
       matrix:
         server: ${{ fromJSON(needs.prepare.outputs.DEPLOYMENT_MATRIX) }}
-    name: "${{ matrix.server.name }} (${{ matrix.server.os }})"
-    runs-on: "ubuntu-24.04-arm"
-    #runs-on: [ docker, X64 ]
+    name: "${{ matrix.server.name }} (${{ matrix.server.os }}/${{ matrix.server.arch }})"
+    runs-on: ${{ matrix.server.runner }}
     timeout-minutes: 60
     container:
       image: ${{ matrix.server.docker_image }}
@@ -148,12 +163,12 @@ jobs:
           finish_time=$(date +%s)
 
           # Generate table entry
-          echo "|${{ matrix.server.os }}| ${{ matrix.server.name }} | $((finish_time - start_time)) sec |" > ../test/${{ matrix.server.id }}-${{ matrix.server.os }}
+          echo "|${{ matrix.server.os }}| ${{ matrix.server.arch }} | ${{ matrix.server.name }} | $((finish_time - start_time)) sec |" > ../test/${{ matrix.server.id }}-${{ matrix.server.os }}-${{ matrix.server.arch }}
 
       - name: "Upload test summary"
         uses: actions/upload-artifact@v7
         with:
-          name: test-${{ matrix.server.id }}-${{ matrix.server.os }}
+          name: test-${{ matrix.server.id }}-${{ matrix.server.os }}-${{ matrix.server.arch }}
           path: test
           if-no-files-found: ignore
 
@@ -175,8 +190,8 @@ jobs:
         run: |
 
           echo "# Succesful tests:" >> $GITHUB_STEP_SUMMARY
-          echo "|Release|Test name|Duration|" >> $GITHUB_STEP_SUMMARY
-          echo "|:---|:---|---:|" >> $GITHUB_STEP_SUMMARY
+          echo "|Release|Arch|Test name|Duration|" >> $GITHUB_STEP_SUMMARY
+          echo "|:---|:---|:---|---:|" >> $GITHUB_STEP_SUMMARY
           cat test/* | sed '$ s/.$//' >> $GITHUB_STEP_SUMMARY
 
       - uses: geekyeggo/delete-artifact@v6

--- a/.github/workflows/maintenance-unit-tests.yml
+++ b/.github/workflows/maintenance-unit-tests.yml
@@ -299,10 +299,10 @@ jobs:
               || github.event_name == 'repository_dispatch'
               || github.ref == 'refs/heads/main')
         env:
-          GH_PAT: ${{ secrets.ARMBIAN_GITHUB_IO_PAT }}
+          GH_PAT: ${{ secrets.ACCESS_TOKEN }}
         run: |
           if [[ -z "${GH_PAT}" ]]; then
-              echo "::warning::ARMBIAN_GITHUB_IO_PAT secret is not set; skipping publish step"
+              echo "::warning::ACCESS_TOKEN secret is not set; skipping publish step"
               exit 0
           fi
           git config --global user.name  "armbian-ci-bot"

--- a/.github/workflows/maintenance-unit-tests.yml
+++ b/.github/workflows/maintenance-unit-tests.yml
@@ -106,8 +106,8 @@ jobs:
       matrix:
         server: ${{ fromJSON(needs.prepare.outputs.DEPLOYMENT_MATRIX) }}
     name: "${{ matrix.server.name }} (${{ matrix.server.os }})"
-    #runs-on: "ubuntu-latest"
-    runs-on: [ docker, X64 ]
+    runs-on: "ubuntu-24.04-arm"
+    #runs-on: [ docker, X64 ]
     timeout-minutes: 60
     container:
       image: ${{ matrix.server.docker_image }}

--- a/tests/BUDG01.conf
+++ b/tests/BUDG01.conf
@@ -1,5 +1,6 @@
 ENABLED=false
 RELEASE="trixie:noble:resolute"
+TESTARCH="arm64,amd64"
 TESTNAME="Budgie desktop"
 
 testcase() {(

--- a/tests/CINM01.conf
+++ b/tests/CINM01.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="bookworm:trixie:noble:resolute"
+TESTARCH="arm64,amd64"
 TESTNAME="Cinnamon desktop"
 
 testcase() {(

--- a/tests/DEEP01.conf
+++ b/tests/DEEP01.conf
@@ -1,5 +1,6 @@
 ENABLED=false
 RELEASE="bookworm:trixie:noble:resolute"
+TESTARCH="arm64,amd64"
 TESTNAME="Deepin desktop"
 
 testcase() {(

--- a/tests/ENLI01.conf
+++ b/tests/ENLI01.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="bookworm:trixie:noble:resolute"
+TESTARCH="arm64,amd64"
 TESTNAME="enlightenment desktop"
 
 testcase() {(

--- a/tests/GNME01.conf
+++ b/tests/GNME01.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="bookworm:trixie:noble:resolute"
+TESTARCH="arm64,amd64"
 TESTNAME="GNOME desktop"
 
 testcase() {(

--- a/tests/I3WM01.conf
+++ b/tests/I3WM01.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="bookworm:trixie:noble:resolute"
+TESTARCH="arm64,amd64"
 TESTNAME="i3-wm desktop"
 
 testcase() {(

--- a/tests/KDEN01.conf
+++ b/tests/KDEN01.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="KDE Neon desktop"
 
 testcase() {(

--- a/tests/KDEP01.conf
+++ b/tests/KDEP01.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="bookworm:trixie:noble:resolute"
+TESTARCH="arm64,amd64"
 TESTNAME="KDE Plasma desktop"
 
 testcase() {(

--- a/tests/MATE01.conf
+++ b/tests/MATE01.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="bookworm:trixie:noble:resolute"
+TESTARCH="arm64,amd64"
 TESTNAME="Mate desktop"
 
 testcase() {(

--- a/tests/XFCE01.conf
+++ b/tests/XFCE01.conf
@@ -1,6 +1,6 @@
 ENABLED=true
 RELEASE="bookworm:trixie:noble:resolute"
-TESTARCH="arm64,amd64"
+TESTARCH="arm64,amd64,riscv64"
 TESTNAME="XFCE desktop"
 
 testcase() {(

--- a/tests/XFCE01.conf
+++ b/tests/XFCE01.conf
@@ -1,6 +1,6 @@
 ENABLED=true
 RELEASE="bookworm:trixie:noble:resolute"
-TESTARCH="arm64,amd64,riscv64"
+TESTARCH="arm64,amd64"
 TESTNAME="XFCE desktop"
 
 testcase() {(

--- a/tests/XFCE01.conf
+++ b/tests/XFCE01.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="bookworm:trixie:noble:resolute"
+TESTARCH="arm64,amd64"
 TESTNAME="XFCE desktop"
 
 testcase() {(

--- a/tests/XMON01.conf
+++ b/tests/XMON01.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="bookworm:trixie:noble:resolute"
+TESTARCH="arm64,amd64"
 TESTNAME="xmonad desktop"
 
 testcase() {(

--- a/tests/actualbudget.conf
+++ b/tests/actualbudget.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="ActualBudget install"
 
 testcase() {(

--- a/tests/adguardhome.conf
+++ b/tests/adguardhome.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="AdGuardHome install"
 
 testcase() {(

--- a/tests/bazarr.conf
+++ b/tests/bazarr.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="Bazarr install"
 
 testcase() {(

--- a/tests/cockpit.conf
+++ b/tests/cockpit.conf
@@ -1,5 +1,6 @@
 ENABLED=false
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="Cockpit install"
 
 testcase() {(

--- a/tests/deluge.conf
+++ b/tests/deluge.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="Deluge install"
 
 testcase() {(

--- a/tests/docker.conf
+++ b/tests/docker.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="all"
+TESTARCH="arm64,amd64"
 TESTNAME="Docker install"
 
 testcase() {(

--- a/tests/domoticz.conf
+++ b/tests/domoticz.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="Domoticz install"
 
 testcase() {(

--- a/tests/duplicati.conf
+++ b/tests/duplicati.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="Duplicati install"
 
 testcase() {(

--- a/tests/embyserver.conf
+++ b/tests/embyserver.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="EmbyServer install"
 
 testcase() {(

--- a/tests/evcc.conf
+++ b/tests/evcc.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="EVCC install"
 
 testcase() {(

--- a/tests/filebrowser.conf
+++ b/tests/filebrowser.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="Filebrowser install"
 
 testcase() {(

--- a/tests/ghost.conf
+++ b/tests/ghost.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="Ghost install"
 
 testcase() {(

--- a/tests/grafana.conf
+++ b/tests/grafana.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="Grafana install"
 
 testcase() {(

--- a/tests/hastebin.conf
+++ b/tests/hastebin.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="Hastebin install"
 
 testcase() {(

--- a/tests/homeassistant.conf
+++ b/tests/homeassistant.conf
@@ -1,5 +1,6 @@
 ENABLED=false
 RELEASE="bookworm"
+TESTARCH="arm64,amd64"
 TESTNAME="Home Assistant install"
 
 testcase() {(

--- a/tests/homepage.conf
+++ b/tests/homepage.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="Homepage install"
 
 testcase() {(

--- a/tests/immich.conf
+++ b/tests/immich.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="Immich install"
 
 testcase() {(

--- a/tests/jellyfin.conf
+++ b/tests/jellyfin.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="Jellyfin install"
 
 testcase() {(

--- a/tests/jellyseerr.conf
+++ b/tests/jellyseerr.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="Jellyseerr install"
 
 testcase() {(

--- a/tests/lidarr.conf
+++ b/tests/lidarr.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="Lidarr install"
 
 testcase() {(

--- a/tests/mariadb.conf
+++ b/tests/mariadb.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="Mariadb install"
 
 testcase() {(

--- a/tests/medusa.conf
+++ b/tests/medusa.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="Medusa install"
 
 testcase() {(

--- a/tests/navidrome.conf
+++ b/tests/navidrome.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="Navidrome install"
 
 testcase() {(

--- a/tests/netalertx.conf
+++ b/tests/netalertx.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="NetAlertX install"
 
 testcase() {(

--- a/tests/netbox.conf
+++ b/tests/netbox.conf
@@ -1,5 +1,6 @@
 ENABLED=false
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="NetBox install"
 
 testcase() {(

--- a/tests/netdata.conf
+++ b/tests/netdata.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="Netdata install"
 
 testcase() {(

--- a/tests/nextcloud.conf
+++ b/tests/nextcloud.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="Nextcloud install"
 
 testcase() {(

--- a/tests/octoprint.conf
+++ b/tests/octoprint.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="OctoPrint install"
 
 testcase() {(

--- a/tests/omv.conf
+++ b/tests/omv.conf
@@ -1,5 +1,6 @@
 ENABLED=false
 RELEASE="bookworm"
+TESTARCH="arm64,amd64"
 TESTNAME="OpenMediaVault install"
 
 testcase() {(

--- a/tests/openhab.conf
+++ b/tests/openhab.conf
@@ -1,5 +1,6 @@
 ENABLED=false
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="OpenHab install"
 
 function testcase {(

--- a/tests/owncloud.conf
+++ b/tests/owncloud.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="Owncloud install"
 
 testcase() {(

--- a/tests/phpmyadmin.conf
+++ b/tests/phpmyadmin.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="PhpMyAdmin install"
 
 testcase() {(

--- a/tests/portainer.conf
+++ b/tests/portainer.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="Portainer install"
 
 testcase() {(

--- a/tests/postgres.conf
+++ b/tests/postgres.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="PostgreSQL install"
 
 testcase() {(

--- a/tests/prometheus.conf
+++ b/tests/prometheus.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="Prometheus install"
 
 testcase() {(

--- a/tests/prowlarr.conf
+++ b/tests/prowlarr.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="Prowlarr install"
 
 testcase() {(

--- a/tests/qbittorrent.conf
+++ b/tests/qbittorrent.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="qBittorrent install"
 
 testcase() {(

--- a/tests/radarr.conf
+++ b/tests/radarr.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="Radarr install"
 
 testcase() {(

--- a/tests/redis.conf
+++ b/tests/redis.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="Redis install"
 
 testcase() {(

--- a/tests/rolling.conf
+++ b/tests/rolling.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="all"
+TESTARCH="arm64,amd64"
 TESTNAME="Rolling repository"
 
 testcase() {(

--- a/tests/sabnzbd.conf
+++ b/tests/sabnzbd.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="SABnzbd install"
 
 testcase() {(

--- a/tests/samba.conf
+++ b/tests/samba.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="bookworm"
+TESTARCH="arm64,amd64"
 TESTNAME="samba install"
 
 testcase() {(

--- a/tests/sonarr.conf
+++ b/tests/sonarr.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="Sonarr install"
 
 testcase() {(

--- a/tests/stable.conf
+++ b/tests/stable.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE=""
+TESTARCH="arm64,amd64"
 TESTNAME="Stable repository"
 
 testcase() {(

--- a/tests/stirling.conf
+++ b/tests/stirling.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="Stirling-PDF install"
 
 testcase() {(

--- a/tests/syncthing.conf
+++ b/tests/syncthing.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="Syncthing install"
 
 testcase() {(

--- a/tests/transmission.conf
+++ b/tests/transmission.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="Transmission install"
 
 testcase() {(

--- a/tests/unbound.conf
+++ b/tests/unbound.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="Unbound install"
 
 testcase() {(

--- a/tests/uptimekuma.conf
+++ b/tests/uptimekuma.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="Uptimekuma install"
 
 testcase() {(

--- a/tests/watchtower.conf
+++ b/tests/watchtower.conf
@@ -1,5 +1,6 @@
 ENABLED=true
 RELEASE="noble"
+TESTARCH="arm64,amd64"
 TESTNAME="Watchtower install"
 
 testcase() {(


### PR DESCRIPTION
Reworks `maintenance-unit-tests.yml` so each test case runs on multiple arches in parallel, with a machine-readable JSON result feed published to the Armbian data pages.

## Matrix changes

Before: one run per (test × release) against a hardcoded amd64 image tag on `[docker, X64]`.
After:  one run per (test × release × **arch**) with the matching arch-specific image tag and runner.

Runner pool:

| Arch | Runner | Image tag |
|---|---|---|
| amd64 | self-hosted `[docker, X64]` | `…:<release>-amd64` |
| arm64 | self-hosted `[docker, ARM64]` | `…:<release>-arm64` |

Runner value in the matrix is emitted as a JSON array so `runs-on: ${{ matrix.server.runner }}` uses GHA's standard AND-of-labels form.

## Per-test arch opt-in (`TESTARCH`)

Every test `.conf` gains a `TESTARCH="arm64,amd64"` line (default — fan out to both). Tests that only make sense on one arch can narrow (e.g. `TESTARCH="amd64"`). Same shape as the existing `RELEASE=` knob.

`TESTARCH="all"` or empty expands to the full arch set.

## riscv64

Runner map and arches array are wired for `riscv64` → GH-hosted `ubuntu-24.04-riscv` runner, but **no test opts in yet**. Two upstream gaps block it: the repository-update riscv64 image's `/sbin/init` and GH's riscv64-runner-container Node.js mount. Matrix generator skips the entry gracefully when no test names it — infra stays ready for the day both are fixed.

## JSON results

Each test writes a per-test blob:

```json
{"name":"XFCE desktop","release":"noble","arch":"amd64","duration":42,"result":"success"}
```

`success` vs `failure` captured via `if testcase; then …; else …; fi` so a failing test still records its result before the step goes red.

The stop job aggregates into `report/unit-test-results.json`:

```json
{
  "generated_at": "2026-04-18T13:00:00Z",
  "tests": [ {"name":"...","release":"...","arch":"...","duration":42,"result":"success"}, … ]
}
```

- Uploaded as a 30-day workflow artifact (`unit-test-results`).
- The Actions-summary markdown table is now derived from this JSON and includes a Result column.

## Publishing

A new publish step in the stop job pushes `data/unit-test-results.json` to `armbian/armbian.github.io` on:

- default-branch runs (`refs/heads/main`), OR
- `schedule`, `workflow_dispatch`, `repository_dispatch` events

PR runs are excluded so fork-PRs never write to the public data feed.

Uses the existing `ACCESS_TOKEN` repository secret (fine-grained PAT with Contents:Read/Write on armbian.github.io). When missing, the step emits a `::warning::` and no-ops rather than failing the workflow.

## Diagnostic logging

Matrix generator logs `::notice::Unit-test matrix has N entries` on every run and, when N=0, a `::warning::` enumerates the likely causes (no ENABLED tests / changed-files mismatch / source-time syntax error). Compact `jq -sc` output avoids any multi-line heredoc interaction.