### PR TITLE
desktops/gnome: fix gnome-bluetooth-sendto install failure on jammy

### DIFF
--- a/tools/modules/desktops/yaml/gnome.yaml
+++ b/tools/modules/desktops/yaml/gnome.yaml
@@ -117,11 +117,24 @@ releases:
   jammy:
     # Ubuntu 22.04 LTS — polkit split available via SRU;
     # pulseaudio remains default on jammy.
+    #
+    # gnome-bluetooth-sendto doesn't exist on jammy: GNOME 42 still
+    # shipped gnome-bluetooth as a single package containing the
+    # libgnome-bluetooth-3.0 library, the control-center Bluetooth
+    # panel, AND the sendto helper. The split into
+    # gnome-bluetooth + gnome-bluetooth-sendto +
+    # libgnome-bluetooth-3.0 landed with GNOME 43 (bookworm /
+    # noble+). Strip the split-out name here and pull in the
+    # monolithic package instead so the Quick Settings Bluetooth
+    # tile still has libgnome-bluetooth-3.0 to dlopen.
     architectures: [arm64, amd64]
     packages:
       - polkitd
       - pkexec
       - libu2f-udev
+      - gnome-bluetooth
+    packages_remove:
+      - gnome-bluetooth-sendto
     packages_uninstall:
       - ubuntu-session
 


### PR DESCRIPTION
## Summary

Jammy (Ubuntu 22.04 / GNOME 42) still shipped `gnome-bluetooth` as a single binary package containing the libgnome-bluetooth-3.0 library, the control-center Bluetooth panel, AND the sendto helper. The split into `gnome-bluetooth` + `gnome-bluetooth-sendto` + `libgnome-bluetooth-3.0` only landed with GNOME 43 (Debian bookworm, Ubuntu mantic/noble+).

Our minimal tier asks for `gnome-bluetooth-sendto` so gnome-shell can dlopen libgnome-bluetooth-3.0 for the Quick Settings Bluetooth tile. That name doesn't exist in jammy's archive, so the install hard-fails:

```
E: Unable to locate package gnome-bluetooth-sendto
Error: gnome package install failed; aborting before any system state is changed
```

Surfaced by a jammy uefi-x86 desktop build.

## Fix

In the `jammy:` release block:
- `packages_remove: [gnome-bluetooth-sendto]` — drop the split-out name
- `packages: [gnome-bluetooth]` — add the monolithic package back so the library dependency is still satisfied

Chose the release block over `tier_overrides` because this is a release-specific library reshuffle (the package exists upstream on every arch, just under a different name), not a package-availability hole. Keeps the annotation next to the other jammy-specific notes (polkit SRU, pulseaudio default).

Other releases unchanged — bookworm, trixie, noble, resolute, forky, sid all keep `gnome-bluetooth-sendto` because that's the correct name post-GNOME-43.

## Test plan

- [x] `parse_desktop_yaml.py gnome jammy amd64 --tier minimal` emits `gnome-bluetooth`, no `gnome-bluetooth-sendto`
- [x] `parse_desktop_yaml.py gnome noble amd64 --tier minimal` still emits `gnome-bluetooth-sendto` (unchanged)
- [ ] Rebuild jammy uefi-x86 desktop — install step no longer hits `E: Unable to locate package gnome-bluetooth-sendto`
- [ ] Post-boot on jammy/amd64: Quick Settings Bluetooth tile renders (verifies libgnome-bluetooth-3.0 is present from the monolithic `gnome-bluetooth`)