### PR TITLE
desktops/gnome: drop loong64 from sid

### DIFF
--- a/tools/modules/desktops/yaml/gnome.yaml
+++ b/tools/modules/desktops/yaml/gnome.yaml
@@ -100,8 +100,13 @@ releases:
 
   sid:
     # Debian unstable — pipewire replaces pulseaudio (same as trixie/forky).
-    # loong64 is included: it is a 64-bit arch capable of running GNOME.
-    architectures: [arm64, amd64, loong64]
+    # loong64 is intentionally dropped: GNOME on loong64 isn't viable
+    # for Armbian right now. The sid/loong64 port frequently skews
+    # behind the main sid archive (e.g. gnupg2 gets bumped before
+    # dirmngr is rebuilt for loong64), which breaks rootfs bootstrap
+    # before module_desktops even runs. Keeping a lean CLI-only
+    # loong64 story until the port stabilises.
+    architectures: [arm64, amd64]
     packages:
       - accountsservice
       - libu2f-udev


### PR DESCRIPTION
## Summary

GNOME on loong64 isn't viable for Armbian right now. sid's loong64 port routinely skews behind the main sid archive — one package gets bumped before its rebuilt dep catches up — and GNOME pulls in enough transitive deps that builds get blocked on the first stale one. A recent failure on the rootfs-bootstrap side:

```
gnupg2:loong64=2.4.9-4 is selected for install
gnupg2:loong64 Depends gnupg (>= 2.4.9-4)
gnupg:loong64 Breaks dirmngr (< 2.4.9-4)
dirmngr:loong64 is available in version 2.4.8-4
E: setup failed: … gnupg2 … ?architecture(loong64) failed: process exited with 100
```

That fires during \`mmdebstrap\` setup (before \`module_desktops\` even runs) so a desktop YAML can't unstick it, but dropping GNOME from loong64/sid at least means we stop trying to target the \`loong64/sid/gnome\` matrix slot.

Leaving the lighter DEs (xfce, mate, cinnamon, enlightenment, i3-wm, kde-plasma, xmonad) still declaring loong64 on sid — their transitive dep sets are small enough that the port-sync lag is usually tolerable.

## Fix

In \`gnome.yaml\`'s \`sid:\` release block:
- \`architectures: [arm64, amd64, loong64]\` → \`[arm64, amd64]\`

## Test plan

- [x] \`parse_desktop_yaml.py gnome sid loong64 --tier minimal\` emits \`DESKTOP_AVAILABLE=\"no\"\`
- [x] \`parse_desktop_yaml.py gnome sid arm64 --tier minimal\` still emits \`DESKTOP_AVAILABLE=\"yes\"\` (no regression on arm64/amd64)
- [x] Other DEs' loong64/sid entries untouched — xfce, mate, cinnamon, enlightenment, i3-wm, kde-plasma, xmonad still report \`available=True\` via \`--list-json sid loong64\`