### PR TITLE
desktops: enable Widevine DRM out of the box on ARM64 desktops

### DIFF
--- a/tools/modules/desktops/branding/browsers/etc/chromium.d/armbian-widevine
+++ b/tools/modules/desktops/branding/browsers/etc/chromium.d/armbian-widevine
@@ -1,0 +1,39 @@
+# Armbian: Widevine / HTML5 DRM support for Chromium
+#
+# Two flags, two independent concerns.
+#
+# 1. --enable-unsafe-swiftshader
+#
+# Chromium 128+ removed the silent software WebGL fallback
+# (crbug.com/242999). Modern EME-based streaming players — the Netflix
+# "Akira" client, Disney+, Amazon Prime Video — rely on a working
+# WebGL context for client-side initialisation even when hardware
+# acceleration is otherwise present. Without an explicit opt-in the
+# context creation fails silently and the player aborts with opaque
+# errors (Netflix surfaces it as error code E100).
+# The flag is a no-op where hardware WebGL works; it only matters as a
+# fallback when the GPU sandbox rejects the context.
+#
+# 2. --user-agent (ChromeOS spoof)
+#
+# Netflix's Akira player is the only mainstream service that rejects
+# the legacy Linux User-Agent server-side — `osname=linux` is not on
+# its supported-platform whitelist regardless of architecture, while
+# `osname=cros` (ChromeOS) is. Spoofing a ChromeOS UA is the same
+# workaround Raspberry Pi OS hardcodes in its Chromium build.
+#
+# Safe to do because Chromium 107+ already freezes navigator.platform
+# to "Linux x86_64" on every Linux host including ARM64 (UA Reduction
+# policy), and Netflix does not query Sec-CH-UA-Arch via Accept-CH.
+# So the fiction is contained to the legacy UA string; Client Hints
+# headers and JS APIs keep reporting the real platform.
+#
+# IMPORTANT: the stock Chromium launcher (/usr/bin/chromium) applies
+# word-splitting to $CHROMIUM_FLAGS and cannot pass a flag that
+# contains spaces — which any valid User-Agent string does. Armbian
+# ships a drop-in replacement wrapper at /usr/bin/chromium that execs
+# via `eval` so quoted flags survive; the upstream wrapper is
+# preserved via dpkg-divert at /usr/bin/chromium.upstream. This drop-in
+# file is only fully effective when that wrapper is in place.
+export CHROMIUM_FLAGS="$CHROMIUM_FLAGS --enable-unsafe-swiftshader"
+export CHROMIUM_FLAGS="$CHROMIUM_FLAGS --user-agent=\"Mozilla/5.0 (X11; CrOS aarch64 15359.58.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36\""

--- a/tools/modules/desktops/branding/browsers/usr/bin/chromium.armbian
+++ b/tools/modules/desktops/branding/browsers/usr/bin/chromium.armbian
@@ -1,0 +1,73 @@
+#!/bin/sh
+# Armbian Chromium launcher
+# =========================
+# Drop-in replacement for /usr/bin/chromium that exists for one
+# reason: the stock launcher shipped by Debian/Ubuntu applies plain
+# POSIX word-splitting to $CHROMIUM_FLAGS before passing it to the
+# browser binary, which makes it impossible to put any flag with a
+# quoted spaced value into /etc/chromium.d/ drop-ins.
+#
+# That matters because Armbian needs to set things like
+# --user-agent="Mozilla/5.0 (X11; CrOS aarch64 15359.58.0) ..." from
+# /etc/chromium.d/armbian-widevine so Netflix and other DRM players
+# work out of the box on ARM64 desktops. The upstream wrapper throws
+# those quotes away; this one preserves them by exec'ing through eval.
+#
+# Activation: /usr/bin/chromium is dpkg-diverted to
+# /usr/bin/chromium.upstream at branding time, and a symlink
+# /usr/bin/chromium -> /usr/bin/chromium.armbian (this file) takes its
+# place. Apt upgrades of the chromium package land in .upstream and
+# leave the symlink untouched.
+#
+# The behavioural contract with the caller matches the upstream
+# wrapper closely: same env vars, same /etc/chromium.d/ sourcing
+# rules, same CHROME_WRAPPER / CHROME_DESKTOP exports. Features the
+# upstream wrapper adds that we intentionally skip (they're not
+# expected to be used in an Armbian desktop default flow):
+#   * SSE3 / NEON instruction-set preflight — Armbian only ships on
+#     ARM with NEON and on amd64 with SSE3, always.
+#   * -g / --debug gdb harness — available via
+#     /usr/bin/chromium.upstream -g if the user wants it.
+#   * --temp-profile, --enable-remote-extensions flag pre-parsing —
+#     users who need them can still pass them through; they reach
+#     chromium unmodified as part of "$@".
+#
+# If /usr/bin/chromium.upstream is missing (branding never ran, or
+# the divert was removed), we exec the non-diverted path directly so
+# the script degrades to a thin pass-through rather than breaking.
+
+APPNAME=chromium
+LIBDIR=/usr/lib/$APPNAME
+CHROMIUM_FLAGS=""
+
+# Crash report rotation mirrors the upstream wrapper (Debian #1015931).
+if [ -d "$HOME/.config/chromium/Crash Reports/pending/" ]; then
+	find "$HOME/.config/chromium/Crash Reports/pending/" -mtime +30 \
+		\( -name "*.meta" -o -name "*.dmp" \) -exec rm {} \; 2>/dev/null
+fi
+
+# Source /etc/chromium.d/ drop-ins (README and *.dpkg-* backups excluded,
+# same logic as upstream).
+if [ -d /etc/chromium.d ]; then
+	for file in /etc/chromium.d/*; do
+		[ "$file" = /etc/chromium.d/README ] && continue
+		case "$file" in
+			*.dpkg-*) continue ;;
+		esac
+		[ -r "$file" ] && . "$file"
+	done
+fi
+
+# Match the export surface the upstream wrapper sets so chromium's
+# auto-discovery of its own launcher and .desktop file keeps working.
+[ -z "$CHROME_WRAPPER" ] && export CHROME_WRAPPER=/usr/bin/$APPNAME
+export CHROME_DESKTOP=chromium.desktop
+
+# If a caller wants to tag the chromium "about" version label, they can
+# set CHROME_VERSION_EXTRA themselves. We don't override an upstream one.
+
+# The whole reason this wrapper exists: exec through eval so any flag
+# in $CHROMIUM_FLAGS that contains quoted spaces (e.g.
+# --user-agent="Mozilla/5.0 ...") is word-split correctly rather than
+# shattered into garbage tokens.
+eval "exec \"\$LIBDIR/\$APPNAME\" $CHROMIUM_FLAGS \"\$@\""

--- a/tools/modules/desktops/module_desktop_branding.sh
+++ b/tools/modules/desktops/module_desktop_branding.sh
@@ -108,6 +108,7 @@ function module_desktop_branding() {
 			#                /etc/chromium/policies/managed/armbian.json       (ManagedBookmarks — mandatory-only policy)
 			#                /etc/chromium/master_preferences                  (suppress bundled defaults)
 			#                /etc/chromium.d/armbian-flags                     (enable VPU hardware video decoder)
+			#                /etc/chromium.d/armbian-widevine                  (WebGL fallback + Netflix CrOS UA spoof)
 			#   chrome:      /etc/opt/chrome/policies/recommended/armbian.json
 			#                /etc/opt/chrome/policies/managed/armbian.json
 			#                /etc/opt/chrome/master_preferences
@@ -129,6 +130,42 @@ function module_desktop_branding() {
 				# owned by the developer's UID rather than root (in
 				# production the deb deploys them as root anyway).
 				cp -a --no-preserve=ownership "$desktop_dir/branding/browsers/etc/." /etc/
+			fi
+
+			# Parallel overlay under branding/browsers/usr/ — currently carries
+			# /usr/bin/chromium.armbian, the Armbian-owned replacement for the
+			# stock Chromium launcher. The stock wrapper word-splits
+			# $CHROMIUM_FLAGS and cannot pass flags whose value contains
+			# spaces (like --user-agent="..."), which makes
+			# /etc/chromium.d/armbian-widevine's CrOS UA ineffective on its
+			# own. Our wrapper is a near-identical drop-in that execs through
+			# `eval` instead, preserving quoted values.
+			if [[ -d "$desktop_dir/branding/browsers/usr" ]]; then
+				cp -a --no-preserve=ownership "$desktop_dir/branding/browsers/usr/." /usr/
+			fi
+
+			# If we've shipped the Armbian Chromium wrapper and the chromium
+			# package is installed, swap /usr/bin/chromium to point at it.
+			# The swap uses dpkg-divert so a future `apt upgrade chromium`
+			# lands the upstream wrapper in /usr/bin/chromium.upstream
+			# instead of clobbering the symlink we created here.
+			# Skipped inside containers / CI where dpkg is typically not
+			# operational on the live rootfs.
+			if [[ -x /usr/bin/chromium.armbian && -x /usr/bin/chromium ]] \
+				&& command -v dpkg-divert >/dev/null 2>&1 \
+				&& ! _desktop_in_container 2>/dev/null; then
+				if ! dpkg-divert --list /usr/bin/chromium 2>/dev/null | grep -q "diversion of /usr/bin/chromium"; then
+					dpkg-divert --local --rename \
+						--divert /usr/bin/chromium.upstream \
+						--add /usr/bin/chromium >/dev/null 2>&1 || true
+				fi
+				# The divert renamed the original file out of the way;
+				# put our wrapper in its place as a symlink so future
+				# updates to /usr/bin/chromium.armbian (via branding
+				# re-runs) propagate automatically.
+				if [[ ! -L /usr/bin/chromium || "$(readlink /usr/bin/chromium)" != "/usr/bin/chromium.armbian" ]]; then
+					ln -sf /usr/bin/chromium.armbian /usr/bin/chromium
+				fi
 			fi
 
 			# SDDM theme (for desktops using sddm)

--- a/tools/modules/desktops/scripts/parse_desktop_yaml.py
+++ b/tools/modules/desktops/scripts/parse_desktop_yaml.py
@@ -15,9 +15,12 @@ common.yaml carries the per-tier defaults that apply to every desktop
 tier or remove ones inherited from common, via `tiers.<tier>.packages`
 and `tiers.<tier>.packages_remove`.
 
-The literal token `browser` inside any tier resolves to the per-arch
-package name from common.yaml's `browser:` map (e.g. chromium on
-arm64/amd64/armhf, firefox on riscv64).
+Virtual tokens (`browser`, `widevine`, ...) inside any tier resolve to
+the per-arch package name from the matching top-level map in
+common.yaml (e.g. chromium on arm64/amd64/armhf, firefox on riscv64
+for `browser`; libwidevinecdm0 on noble arm64/armhf for `widevine`).
+A token with no mapping for the current (release, arch) pair is
+silently dropped rather than passed to apt as a literal package name.
 
 Per-DE per-tier per-arch overrides live under `tier_overrides:`, with
 the same shape as the release block. Use this to drop packages that
@@ -121,50 +124,53 @@ def _merge_tier(packages, removes, source, tier):
             removes.append(pkg)
 
 
-def _resolve_browser(packages, common, release, arch):
-    """Substitute the literal token `browser` with the right package per release+arch.
+def _resolve_virtual_token(packages, common, release, arch, token):
+    """Substitute a virtual token (`browser`, `widevine`, ...) with the right
+    package per release+arch.
 
-    The browser map in common.yaml has two layers:
+    Each virtual-token map in common.yaml has two layers:
 
-      browser:
-        amd64: chromium       # default fallback for any release on this arch
+      <token>:
+        amd64: pkg-default    # default fallback for any release on this arch
         ...
-        bookworm:
-          amd64: chromium     # per-release per-arch override
-          riscv64: firefox-esr
+        <release>:
+          amd64: pkg-override # per-release per-arch override
+          riscv64: other-pkg
 
     Lookup order:
-      1. browser.<release>.<arch>  (most specific)
-      2. browser.<arch>             (per-arch fallback)
+      1. <token>.<release>.<arch>  (most specific)
+      2. <token>.<arch>             (per-arch fallback)
       3. drop the token altogether (silently — install proceeds without
-         a browser rather than failing on a literal 'browser' apt name)
+         the optional component rather than failing on a literal token
+         name that no apt repo knows about)
 
     The per-release layer is needed because the same arch can resolve
-    differently across releases:
-      - Debian has 'firefox-esr' but no 'firefox'
-      - Ubuntu's 'chromium' is a snap-shim deb that requires snapd
-      - 'chromium' isn't built for riscv64 in Debian or Ubuntu
+    differently across releases — e.g. Debian has 'firefox-esr' but no
+    'firefox'; Ubuntu's 'chromium' is a snap-shim that requires snapd;
+    'chromium' isn't built for riscv64 in Debian or Ubuntu. The same
+    mechanism lets a token like 'widevine' map only on the release+arch
+    combinations where apt.armbian.com actually hosts the .deb.
     """
-    browser_map = _as_dict(common.get("browser"))
-    if "browser" not in packages:
+    token_map = _as_dict(common.get(token))
+    if token not in packages:
         return
-    # Try per-release per-arch first (browser.<release> is a dict of arch->pkg).
-    release_map = _as_dict(browser_map.get(release))
+    # Try per-release per-arch first (<token>.<release> is a dict of arch->pkg).
+    release_map = _as_dict(token_map.get(release))
     pkg = release_map.get(arch) if release_map else None
     # Fall back to top-level per-arch if no per-release entry exists. Only
     # consider top-level keys that are arch names — skip release-name keys
     # by checking that the value is a string, not a dict.
     if not pkg:
-        candidate = browser_map.get(arch)
+        candidate = token_map.get(arch)
         if isinstance(candidate, str):
             pkg = candidate
     if not pkg:
-        # No browser defined for this combo — silently drop the token rather
-        # than passing 'browser' to apt and breaking the install. The dialog
-        # layer can warn the user separately if it cares.
-        packages.remove("browser")
+        # No mapping for this combo — silently drop the token rather than
+        # passing the literal string to apt and breaking the install. The
+        # dialog layer can warn the user separately if it cares.
+        packages.remove(token)
         return
-    idx = packages.index("browser")
+    idx = packages.index(token)
     packages[idx] = pkg
 
 
@@ -268,8 +274,9 @@ def parse_desktop(yaml_dir, de_name, release, arch, tier):
         _apply_tier_overrides(packages, common, t, release, arch)
         _apply_tier_overrides(packages, de_data, t, release, arch)
 
-    # 2. Resolve the `browser` virtual token per release+arch.
-    _resolve_browser(packages, common, release, arch)
+    # 2. Resolve virtual tokens (browser, widevine) per release+arch.
+    _resolve_virtual_token(packages, common, release, arch, "browser")
+    _resolve_virtual_token(packages, common, release, arch, "widevine")
 
     # 4. Apply the orthogonal release block — packages_remove + packages
     #    declared per release. The release block is independent of tier.

--- a/tools/modules/desktops/yaml/common.yaml
+++ b/tools/modules/desktops/yaml/common.yaml
@@ -40,6 +40,7 @@ tiers:
   mid:
     packages:
       - browser              # virtual — resolved per-arch from `browser:` below
+      - widevine             # virtual — resolved per-arch from `widevine:` below
       - gnome-text-editor    # text editor (modern GTK4 successor to gedit)
       - gnome-calculator
       - loupe                # GTK4 image viewer; on bookworm fall back via release block
@@ -134,6 +135,33 @@ browser:
     armhf:   chromium
     riscv64: firefox-esr     # 'firefox' does not exist in Debian
     loong64: firefox-esr     # chromium not yet built for loong64
+
+# Widevine CDM substitution table for the literal `widevine` token in
+# any tier. Same lookup rules as `browser:` above:
+#   1. widevine.<release>.<arch>  — most specific
+#   2. widevine.<arch>             — per-arch fallback
+#   3. drop the token entirely (silent — install proceeds without
+#                               the CDM rather than failing on a literal
+#                               'widevine' apt name)
+#
+# Widevine is Google's proprietary HTML5 Encrypted Media Extensions
+# (EME) decryption module — required by Netflix, Disney+, Amazon Prime
+# Video, Spotify Web Player and similar streaming services that gate
+# their content behind DRM. The .so binary is licensed by Google for
+# redistribution only to OEM partners; the Raspberry Pi Foundation
+# maintains the only arm64/armhf glibc-compatible build (David Turner
+# at archive.raspberrypi.com, currently 4.10.2662.3 with the
+# Hector Martin glibc fixup applied). apt.armbian.com mirrors that
+# .deb so installs do not need to add a third-party PPA.
+#
+# Coverage as of 2026-04: noble arm64/armhf only. Every other
+# (release, arch) combination has no entry here, so the parser
+# silently drops the token and the install proceeds CDM-less. Update
+# this map as more releases are published on apt.armbian.com.
+widevine:
+  noble:
+    arm64:   libwidevinecdm0
+    armhf:   libwidevinecdm0
 
 # Per-tier holes that exist in the upstream repos and need to be
 # stripped before they reach apt. Common.yaml carries the holes that


### PR DESCRIPTION
### Problem

HTML5 DRM streaming is broken on Armbian ARM64 desktop images — `libwidevinecdm0` isn't installed by default (currently only via `extensions/mesa-vpu.sh` gated to rk3588/rk35xx + noble + vendor), and Chromium 128+ lost its silent software WebGL fallback ([crbug.com/242999](https://issues.chromium.org/issues/40277080) · [blink-dev Intent to Remove](https://groups.google.com/a/chromium.org/g/blink-dev/c/yhFguWS_3pM)), breaking Netflix Akira / Disney+ / Prime Video init with opaque errors. Netflix on top of that gates on a ChromeOS UA — `osname=linux` is denied server-side regardless of architecture.

### What this PR changes

Two commits, one goal: Netflix and every other HTML5 DRM player just work on ARM64 desktop images without launchers, extensions, or per-user setup.

**Commit 1 — `desktops/yaml: add widevine virtual token`**
- `_resolve_browser` in `parse_desktop_yaml.py` generalised to `_resolve_virtual_token(token)` so additional virtual tokens are cheap to add
- New `widevine:` map in `common.yaml` (noble arm64/armhf → `libwidevinecdm0`)
- `widevine` token added to the `mid` tier next to `browser`
- Combos with no mapping silently drop the token (same pattern as `browser`), so pre-populating this ahead of `apt.armbian.com` publishing the `.deb` is safe

**Commit 2 — `desktops/branding: chromium DRM drop-in + eval-aware wrapper`**
- New `/etc/chromium.d/armbian-widevine` drop-in with `--enable-unsafe-swiftshader` (fix WebGL) and `--user-agent="...CrOS aarch64..."` (fix Netflix `osname=linux` block)
- New `/usr/bin/chromium.armbian` wrapper — near-identical copy of the stock launcher but execs via `eval` so `CHROMIUM_FLAGS` entries containing spaces (any valid UA string) survive word-splitting
- `module_desktop_branding.sh` copies `branding/browsers/usr/` to `/usr/` and uses `dpkg-divert` to swap `/usr/bin/chromium` with a symlink to our wrapper, preserving the upstream at `/usr/bin/chromium.upstream`
- Future `apt upgrade chromium` lands the upstream wrapper in `.upstream` thanks to the divert; our symlink stays intact

### Why these specific choices

- `--enable-unsafe-swiftshader` is a no-op where hardware WebGL works, only matters as fallback. Safe on every board. Rationale documented in the [Chromium SwiftShader removal tracker](https://issues.chromium.org/issues/40277080) and the [Chrome Enterprise Policy page](https://chromeenterprise.google/policies/enable-unsafe-swift-shader/).
- The CrOS UA spoof is the **only** known workaround for Netflix's `osname=linux` server-side block. Raspberry Pi OS already hardcodes the same spoof in its chromium build ([rpi-firmware discussion](https://forums.raspberrypi.com/viewtopic.php?t=347736) · [Raspberry-Pi-OS-64bit#248](https://github.com/raspberrypi/Raspberry-Pi-OS-64bit/issues/248)). Asahi Linux documented the same workaround independently ([da.vidbuchanan.co.uk blog](https://www.da.vidbuchanan.co.uk/blog/netflix-on-asahi.html) · [AsahiLinux/widevine-installer](https://github.com/AsahiLinux/widevine-installer)). Fedora ARM users reached the same conclusion ([fedora discussion](https://discussion.fedoraproject.org/t/firefox-and-widevine-aarch64-support/86797/22)). We can't rebuild chromium, so the drop-in is the next-best surface.
- Safe because Chromium 107+ already freezes \`navigator.platform\` to \`"Linux x86_64"\` on every Linux host including ARM64 per the [UA Reduction policy](https://www.chromium.org/updates/ua-reduction/) (Firefox followed with [bugzilla #1861847](https://bugzilla.mozilla.org/show_bug.cgi?id=1861847)), and Netflix does not request \`Sec-CH-UA-Arch\` via \`Accept-CH\` ([MDN reference](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-CH-UA-Arch)). So the fiction is contained to the legacy UA string; Client Hints headers and JS APIs keep reporting real values.
- The wrapper detour is needed because the stock `/usr/bin/chromium` does plain word-splitting on `$CHROMIUM_FLAGS` — a flag with spaces in its value (any `--user-agent=...`) gets shattered into garbage tokens. `eval` fixes it without rewriting the whole wrapper.

### Verified on

- Board: Youyeetoo R1 v3 (RK3588), Armbian nightly 26.2.0-trunk.747, Ubuntu Noble, GNOME 46 on Wayland
- Stack: chromium 132.0.6834.159 (PPA `liujianfeng1994/rockchip-multimedia`), libwidevinecdm0 4.10.2662.3 (Raspberry Pi Foundation upstream repacked for noble — [upstream pool](https://archive.raspberrypi.com/debian/pool/main/w/widevine/))
- Opened Chromium from the normal desktop menu → Netflix loads, any title plays at SD quality (Widevine L3 ceiling). Disney+ / Prime Video / Spotify / YouTube DRM all work too.
- No launcher, no browser extension, no manual UA tweaking, no DevTools.

### Scope / non-goals

- `apt.armbian.com` hosting of `libwidevinecdm0` is handled separately (tracked with @igorpecovnik). Until the `.deb` is published the `widevine:` token resolves to a package name that doesn't exist on apt — **this PR depends on that hosting being in place**. Marking as DRAFT until then.
- Does not compile chromium in-house (`apt.armbian.com` mirrors xtradeb; this approach avoids taking over that).
- Widevine L1 / L2 impossible on ARM64 Linux in general (no TEE + OEMCrypto + Google-signed keybox) — L3 is the ceiling, which caps Netflix to ~480p. Confirmed by the [Arch Linux Netflix E109 thread](https://bbs.archlinux.org/viewtopic.php?id=300797) and the Asahi Linux Netflix post above. Out of scope here.
- Coverage currently noble arm64/armhf only. Other releases gain DRM automatically as soon as their entry is added to the `widevine:` map.

### Depends on

- `apt.armbian.com` publishing `libwidevinecdm0` for noble arm64/armhf