### PR TITLE
desktops/postinst: drop stray 'fi' from five scripts that fail bash -n

### DIFF
--- a/tools/modules/desktops/postinst/cinnamon.sh
+++ b/tools/modules/desktops/postinst/cinnamon.sh
@@ -132,7 +132,5 @@ system-db:local" >> $profile
 
 dconf update
 
-fi
-
 #re-compile schemas
 if [ -d /usr/share/glib-2.0/schemas ]; then glib-compile-schemas /usr/share/glib-2.0/schemas; fi

--- a/tools/modules/desktops/postinst/i3-wm.sh
+++ b/tools/modules/desktops/postinst/i3-wm.sh
@@ -46,5 +46,3 @@ if [ -f /etc/i3/config ]; then
 		fi
 	done
 fi
-
-fi

--- a/tools/modules/desktops/postinst/kde-neon.sh
+++ b/tools/modules/desktops/postinst/kde-neon.sh
@@ -40,5 +40,3 @@ for home in /etc/skel /home/*; do
 		chown "$user:$user" "$home/.config/plasma-org.kde.plasma.desktop-appletsrc" 2>/dev/null
 	fi
 done
-
-fi

--- a/tools/modules/desktops/postinst/kde-plasma.sh
+++ b/tools/modules/desktops/postinst/kde-plasma.sh
@@ -40,5 +40,3 @@ for home in /etc/skel /home/*; do
 		chown "$user:$user" "$home/.config/plasma-org.kde.plasma.desktop-appletsrc" 2>/dev/null
 	fi
 done
-
-fi

--- a/tools/modules/desktops/postinst/mate.sh
+++ b/tools/modules/desktops/postinst/mate.sh
@@ -151,7 +151,5 @@ trash-icon-visible=false
 volumes-visible=false
 GSEOF
 
-fi
-
 #re-compile schemas
 if [ -d /usr/share/glib-2.0/schemas ]; then glib-compile-schemas /usr/share/glib-2.0/schemas; fi


### PR DESCRIPTION
## Summary

Five of the eleven per-DE postinst scripts under `tools/modules/desktops/postinst/` fail `bash -n` with:

```
syntax error near unexpected token 'fi'
```

All five are leftover from commit `051cebf2` (*desktops: drop NetworkManager override from postinst scripts*) which removed the `if [ … ]; then` wrapper that used to guard the whole script body, but left the closing `fi` behind:

| Script | Line | Where the stray `fi` lives |
|---|---|---|
| `kde-plasma.sh` | 44 | EOF, after the Plasma appletsrc write loop |
| `kde-neon.sh` | 44 | EOF, after the Plasma appletsrc write loop |
| `i3-wm.sh` | 50 | EOF, after the per-user i3 config copy loop |
| `cinnamon.sh` | 135 | Between `dconf update` and the trailing glib-schemas recompile |
| `mate.sh` | 154 | Right after the `GSEOF` heredoc that writes Marco/caja defaults |

Not caught by the unit-test matrix because `module_desktop_branding` skips postinst execution inside containers/CI (where the tests run). The parse error only surfaces on a real-hardware install where `bash` source-loads the script during the install's branding step.

## Fix

Remove the stray `fi` line (plus the preceding blank) in each of the five files. No other changes.

## Test plan

- [x] `bash -n tools/modules/desktops/postinst/*.sh` exits 0 for all 11 files (was: 5 failing).
- [ ] Install one of the previously-broken DEs (e.g. `kde-plasma`) on a real image and confirm the postinst hook runs cleanly, applies the plasma-chili SDDM theme + Armbian wallpaper.
- [ ] Same for mate and cinnamon to confirm the mid-file fixes don't affect the later glib-schemas recompile.