### PR TITLE
desktops: flip netplan renderer to NetworkManager on live install

### DIFF
--- a/tools/modules/desktops/module_desktops.sh
+++ b/tools/modules/desktops/module_desktops.sh
@@ -102,6 +102,111 @@ function _module_desktops_write_apt_pin() {
 }
 
 #
+# Switch the host from systemd-networkd (the Armbian minimal image
+# baseline) to NetworkManager so the freshly-installed desktop's
+# NM-applet / Quick Settings tile actually control the network link.
+#
+# Armbian's build-time desktop images use armbian/build's
+# extensions/network/net-network-manager.sh to do this at image
+# assembly; a desktop installed after the fact on top of a minimal
+# image needs the same transition, but at runtime. This mirrors
+# those files exactly — same netplan renderer flip, same
+# NetworkManager conf.d drop-ins, same NetworkManager-wait-online
+# disable — so the two paths converge on the same end state.
+#
+# Idempotent. Safe to run on a system that is already on
+# NetworkManager (files overwrite to identical content, netplan
+# generate is a no-op). Safe to run in mode=build (skips the
+# netplan apply; the image's first boot will drive it).
+# Safe inside a container (skips apply + service start).
+#
+# Arguments: none. Uses SRC path via $desktops_dir for asset
+# resolution, same as module_desktop_branding.
+#
+function _module_desktops_configure_networking() {
+	local src_dir="${desktops_dir}/networking"
+	if [[ ! -d "$src_dir" ]]; then
+		debug_log "_module_desktops_configure_networking: no ${src_dir}, skipping"
+		return 0
+	fi
+
+	# NetworkManager binary must exist, otherwise the renderer flip
+	# would orphan the network. The minimal tier now declares
+	# network-manager in common.yaml so the pkg_install step already
+	# brought it in; this is a belt-and-suspenders check in case a
+	# YAML override ever drops it.
+	if ! command -v NetworkManager > /dev/null 2>&1; then
+		echo "Warning: NetworkManager binary not found; skipping netplan renderer flip" >&2
+		return 0
+	fi
+
+	# Drop the networkd-renderer netplan file shipped by minimal
+	# images. Leaving it in place next to our NetworkManager-renderer
+	# one makes `netplan generate` emit for both backends and the two
+	# race to claim each interface at boot.
+	if [[ -f /etc/netplan/10-dhcp-all-interfaces.yaml ]]; then
+		debug_log "_module_desktops_configure_networking: removing /etc/netplan/10-dhcp-all-interfaces.yaml (was networkd renderer)"
+		rm -f /etc/netplan/10-dhcp-all-interfaces.yaml
+	fi
+
+	# Install the NetworkManager-renderer netplan + NM conf.d drop-ins.
+	mkdir -p /etc/netplan /etc/NetworkManager/conf.d
+	cp "${src_dir}/netplan/00-default-use-network-manager.yaml" \
+		/etc/netplan/00-default-use-network-manager.yaml
+	chmod 600 /etc/netplan/00-default-use-network-manager.yaml
+
+	for conf in "${src_dir}"/NetworkManager/*.conf; do
+		[[ -f "$conf" ]] || continue
+		cp "$conf" "/etc/NetworkManager/conf.d/$(basename "$conf")"
+	done
+
+	# NetworkManager-wait-online holds boot for up to 90s waiting
+	# for carrier on every managed device — on a desktop with an
+	# unplugged Ethernet port that's 90s of visible "why is this so
+	# slow" at every boot. The NM tile in the DE catches up within
+	# seconds of login anyway.
+	srv_disable NetworkManager-wait-online.service 2>/dev/null || true
+
+	# systemd-resolved is typically already enabled on minimal images;
+	# ensure it stays that way. NetworkManager uses it as the DNS
+	# resolver/cache when /etc/resolv.conf points at the stub.
+	srv_enable systemd-resolved.service 2>/dev/null || true
+
+	# Build mode: don't apply. The image is offline; netplan will
+	# generate + apply on first boot via armbian-firstrun. We only
+	# laid the config files.
+	if [[ "$mode" == "build" ]]; then
+		debug_log "_module_desktops_configure_networking: mode=build, skipping netplan apply"
+		return 0
+	fi
+
+	# Container mode: no real network to flip, no systemd to drive
+	# NM. Just lay the files (done above) and exit.
+	if _desktop_in_container; then
+		debug_log "_module_desktops_configure_networking: in container, skipping netplan apply + NM start"
+		return 0
+	fi
+
+	# Live install. Regenerate netplan output and apply it. netplan
+	# apply stops systemd-networkd.service on interfaces it hands
+	# over to NetworkManager, so the user's current SSH session over
+	# those interfaces can stall briefly — that's expected.
+	if command -v netplan > /dev/null 2>&1; then
+		netplan generate 2>&1 || echo "Warning: netplan generate failed" >&2
+		netplan apply    2>&1 || echo "Warning: netplan apply failed" >&2
+	fi
+
+	# Make sure NM is enabled + started. On a minimal image the
+	# service was installed a moment ago and masked/not enabled by
+	# default on some distros; enabling + starting here is
+	# idempotent.
+	srv_enable NetworkManager.service 2>/dev/null || true
+	srv_start  NetworkManager.service 2>/dev/null || true
+
+	return 0
+}
+
+#
 # Module to install and manage desktop environments (YAML-driven)
 #
 function module_desktops() {
@@ -291,6 +396,14 @@ function module_desktops() {
 
 			# install branding
 			module_desktop_branding "$de"
+
+			# Flip netplan renderer from systemd-networkd to
+			# NetworkManager. On a minimal-image base the baseline
+			# is systemd-networkd; the desktop's NM-applet / Quick
+			# Settings tile needs NM to be driving the link,
+			# otherwise the UI shows an always-disconnected state
+			# even though the machine is online.
+			_module_desktops_configure_networking
 
 			# add user to desktop groups
 			# User-specific setup: group membership, skel propagation,

--- a/tools/modules/desktops/networking/NetworkManager/00-armbian-readme.conf
+++ b/tools/modules/desktops/networking/NetworkManager/00-armbian-readme.conf
@@ -1,0 +1,3 @@
+# Added by armbian-config module_desktops
+# The NetworkManager configuration is mainly managed by Netplan
+# See /etc/netplan/

--- a/tools/modules/desktops/networking/NetworkManager/zz-10-override-wifi-random-mac-disable.conf
+++ b/tools/modules/desktops/networking/NetworkManager/zz-10-override-wifi-random-mac-disable.conf
@@ -1,0 +1,5 @@
+[connection]
+wifi.mac-address-randomization=1
+
+[device]
+wifi.scan-rand-mac-address=no

--- a/tools/modules/desktops/networking/NetworkManager/zz-20-override-wifi-powersave-disable.conf
+++ b/tools/modules/desktops/networking/NetworkManager/zz-20-override-wifi-powersave-disable.conf
@@ -1,0 +1,2 @@
+[connection]
+wifi.powersave = 2

--- a/tools/modules/desktops/networking/netplan/00-default-use-network-manager.yaml
+++ b/tools/modules/desktops/networking/netplan/00-default-use-network-manager.yaml
@@ -1,0 +1,18 @@
+# Installed by armbian-config module_desktops when transitioning a
+# minimal image (systemd-networkd renderer) to a desktop install
+# (NetworkManager renderer).
+#
+# Matches the netplan drop-in shipped by armbian/build's
+# extensions/network/config-nm/netplan/00-default-use-network-manager.yaml
+# so a field-installed desktop on top of a minimal image converges
+# to the same network stack an image-built desktop would have.
+#
+# Reference: https://netplan.readthedocs.io/en/stable/netplan-yaml/
+#
+# Let NetworkManager manage all devices on this system. Any device
+# will come up with DHCP once carrier is detected. This is netplan
+# passing control over to NetworkManager at boot time.
+
+network:
+  version: 2
+  renderer: NetworkManager

--- a/tools/modules/desktops/yaml/common.yaml
+++ b/tools/modules/desktops/yaml/common.yaml
@@ -36,6 +36,16 @@ tiers:
       - profile-sync-daemon
       - terminator
       - upower
+      # Networking stack. Armbian minimal images ship with netplan
+      # driving systemd-networkd; a desktop install flips the netplan
+      # renderer to NetworkManager (see _module_desktops_configure_networking
+      # in module_desktops.sh). The daemon and netplan itself are
+      # required system-wide; per-DE applets (network-manager-gnome
+      # for Xfce/MATE/Cinnamon/i3/etc, plasma-nm for KDE) stay in each
+      # DE's own YAML so the Wayland-native GNOME Shell doesn't pull
+      # in the GTK applet for nothing.
+      - network-manager
+      - netplan.io
 
   mid:
     packages:


### PR DESCRIPTION
## Summary

When a desktop is installed **on top of a minimal Armbian image**, the image's networking baseline is `netplan.io` driving `systemd-networkd`. The desktop's NM-applet / GNOME Quick Settings / Plasma plasma-nm all talk to NetworkManager, and with NM not actually driving the link the Wi-Fi/Wired tile stays in "disconnected" state even though the machine is online. Worse, if the user clicks *Connect* in the tile, NM and `networkd` race for the interface.

armbian/build's [extensions/network/net-network-manager.sh](https://github.com/armbian/build/blob/main/extensions/network/net-network-manager.sh) already does this flip at image-assembly time for image-built desktop variants. This PR runs the equivalent transition at **runtime** for the install-on-minimal path so the two paths converge on the same end state.

## What happens during install

After `module_desktop_branding` copies branding assets, a new helper `_module_desktops_configure_networking` runs:

1. Removes `/etc/netplan/10-dhcp-all-interfaces.yaml` (the networkd drop-in that minimal images ship).
2. Installs `/etc/netplan/00-default-use-network-manager.yaml` (`renderer: NetworkManager`).
3. Installs three `/etc/NetworkManager/conf.d/` drop-ins that match build's extension exactly: readme stub, wifi MAC randomisation, wifi powersave disable.
4. Disables `NetworkManager-wait-online.service` (otherwise boots hang 90s waiting for carrier on every managed interface).
5. Keeps `systemd-resolved` enabled (NM uses it as DNS cache when `/etc/resolv.conf` points at the stub).
6. `netplan generate && netplan apply` — unless `mode=build` (deferred to first-boot) or we're in a container (no real network to flip).

Idempotent: safe to re-run on a system already on NetworkManager.

## YAML change

`common.yaml`'s minimal tier now pulls in `network-manager` + `netplan.io` directly. Previous coverage was inconsistent — gnome/mate/cinnamon/kde-plasma/i3-wm/xmonad had the daemon in their per-DE yamls, xfce/enlightenment/budgie/deepin/kde-neon didn't, so the first group would have had NM installed while the second group's transition would have failed at the `command -v NetworkManager` gate. Moving it to common closes that hole.

Per-DE applets (`network-manager-gnome` for GTK DEs, KDE's `plasma-nm` via `kde-plasma-desktop` metapackage) stay in the per-DE yamls — only the DEs that need them pull them.

## Files

- `tools/modules/desktops/networking/netplan/00-default-use-network-manager.yaml` — mirrors build's `config-nm/netplan/00-default-use-network-manager.yaml`
- `tools/modules/desktops/networking/NetworkManager/00-armbian-readme.conf`
- `tools/modules/desktops/networking/NetworkManager/zz-10-override-wifi-random-mac-disable.conf`
- `tools/modules/desktops/networking/NetworkManager/zz-20-override-wifi-powersave-disable.conf`
- `tools/modules/desktops/module_desktops.sh` — new helper + install-path call
- `tools/modules/desktops/yaml/common.yaml` — minimal tier gets network-manager + netplan.io

## Test plan

- [x] Parser sanity: every DE now emits `network-manager` + `netplan.io` in `DESKTOP_PACKAGES` at the minimal tier (verified via `parse_desktop_yaml.py`).
- [x] Parser dedup: gnome.yaml still declares `network-manager` in its minimal tier alongside common's; parser emits it once.
- [x] `bash -n module_desktops.sh` passes.
- [ ] Fresh install of any DE on a minimal Ubuntu/Debian image: Wi-Fi tile in the DE controls the link after the install completes.
- [ ] `/etc/netplan/` ends up with only `00-default-use-network-manager.yaml`, `10-dhcp-all-interfaces.yaml` is gone.
- [ ] `systemctl is-enabled NetworkManager-wait-online.service` reports `masked` or `disabled`.
- [ ] `mode=build` path lays the netplan + conf.d files but doesn't try to `netplan apply`.
- [ ] CI unit-test matrix (container): helper runs, writes files, skips `netplan apply` cleanly.