### PR TITLE
desktops: strip libreoffice on jammy/riscv64 (no upstream build)

### DIFF
--- a/tools/modules/desktops/yaml/common.yaml
+++ b/tools/modules/desktops/yaml/common.yaml
@@ -272,9 +272,18 @@ tier_overrides:
           armhf:    { packages_remove: [thunderbird] }
           riscv64:  { packages_remove: [thunderbird] }
       jammy:
+        # libreoffice + libreoffice-gtk3 were never built for
+        # jammy/riscv64 — Ubuntu 22.04's riscv64 port in
+        # ports.ubuntu.com/ubuntu-ports/dists/jammy/ has no
+        # libreoffice package in any component (main / universe /
+        # restricted / multiverse). Other jammy arches (amd64, arm64,
+        # armhf) ship it fine. noble/resolute riscv64 also ship it —
+        # this is a jammy-only hole. Strip on jammy/riscv64 so the
+        # full-tier install doesn't fail with 'E: Unable to locate
+        # package libreoffice'.
         architectures:
           armhf:    { packages_remove: [thunderbird] }
-          riscv64:  { packages_remove: [thunderbird] }
+          riscv64:  { packages_remove: [thunderbird, libreoffice, libreoffice-gtk3] }
       resolute:
         architectures:
           armhf:    { packages_remove: [thunderbird] }


### PR DESCRIPTION
## Summary

Ubuntu's jammy/riscv64 port archive (`ports.ubuntu.com/ubuntu-ports/dists/jammy/`) doesn't publish libreoffice. Verified by fetching `Packages.gz` for every component on that suite — `main`, `universe`, `restricted`, `multiverse` are all empty for the package. Other jammy arches (amd64, arm64, armhf) ship it fine; noble/resolute/trixie/forky riscv64 ship it fine. This is a jammy-only, riscv64-only gap.

Full-tier desktop installs on that one matrix cell fail with:

```
E: Unable to locate package libreoffice
E: Unable to locate package libreoffice-gtk3
```

## Fix

In `common.yaml`'s `tier_overrides.full.releases.jammy.architectures.riscv64` (the block that already strips thunderbird there), add `libreoffice` + `libreoffice-gtk3` to the `packages_remove` list.

```yaml
jammy:
  architectures:
    armhf:    { packages_remove: [thunderbird] }
    riscv64:  { packages_remove: [thunderbird, libreoffice, libreoffice-gtk3] }
```

## Test plan

- [x] `parse_desktop_yaml.py xfce jammy riscv64 --tier full` no longer emits `libreoffice` / `libreoffice-gtk3` in `DESKTOP_PACKAGES`.
- [x] Same parser call for every other `(release, arch)` tuple across `jammy | noble | resolute | trixie | forky | sid` × `amd64 | arm64 | armhf | riscv64` (where available) still emits `libreoffice` — 15/16 slots keep it, 1/16 drops it (jammy/riscv64). Verified via the grep loop; output:
  ```
  jammy riscv64 libreoffice_in_packages=0   ← only this one
  everything else    libreoffice_in_packages=1
  ```
- [ ] A real image build targeting jammy/riscv64 full completes the armbian-config `module_desktops install` step without apt's locate-package error.

## Notes

Users on jammy/riscv64 lose libreoffice on that combo specifically — but gain a working full-tier install. noble is the canonical Ubuntu riscv64 platform for serious desktop use, so this is a small cost. If Ubuntu ever backports libreoffice to the jammy/riscv64 ports archive, this override can be reverted.