### PR TITLE
pkg: prevent interactive dpkg prompts in automated builds

### DIFF
--- a/tools/modules/desktops/module_desktops.sh
+++ b/tools/modules/desktops/module_desktops.sh
@@ -280,23 +280,19 @@ function module_desktops() {
 				echo "Warning: '${de}' is not supported on ${DISTROID}/$(dpkg --print-architecture)" >&2
 			fi
 
-			# Suppress interactive prompts end-to-end. apt + dpkg both
-			# need coaxing:
-			#   - DEBIAN_FRONTEND=noninteractive: stops apt opening a
-			#     TUI for debconf questions.
-			#   - `--force-confdef --force-confold` on pkg_install
-			#     (below): when a conffile differs from both the
-			#     shipped version AND any local edit, dpkg normally
-			#     prompts "keep / replace / diff / shell". These
-			#     flags say "always pick the default (=keep local)"
-			#     silently. Without `--force-confdef`, `--force-confold`
-			#     alone still prompts when both sides have diverged.
-			#   - debconf-set-selections pre-seeds known interactive
-			#     package questions: the `code` (Microsoft VSCode)
-			#     postinst asks about adding Microsoft's apt repo —
-			#     say no, apt.armbian.com already hosts code and a
-			#     parallel source would race against our pin.
-			export DEBIAN_FRONTEND=noninteractive
+			# Suppress interactive prompts during automated installation:
+			#   - pkg_install / apt_operation_progress handle DEBIAN_FRONTEND=noninteractive
+			#     internally to prevent apt/dpkg prompts (works in chroot and build envs)
+			#   - `--force-confdef --force-confold` on pkg_install (below): when a
+			#     conffile differs from both the shipped version AND any local edit,
+			#     dpkg normally prompts "keep / replace / diff / shell". These flags
+			#     say "always pick the default (=keep local)" silently. Without
+			#     `--force-confdef`, `--force-confold` alone still prompts when both
+			#     sides have diverged.
+			#   - debconf-set-selections pre-seeds known interactive package questions:
+			#     the `code` (Microsoft VSCode) postinst asks about adding Microsoft's
+			#     apt repo — say no, apt.armbian.com already hosts code and a parallel
+			#     source would race against our pin.
 			debconf-set-selections 2>/dev/null <<- 'EOF' || true
 			encfs encfs/security-information boolean true
 			code code/add-microsoft-repo boolean false

--- a/tools/modules/functions/module_package.sh
+++ b/tools/modules/functions/module_package.sh
@@ -52,11 +52,11 @@ apt_operation_progress() {
 	if [[ "$DIALOG" == "read" ]]; then
 		# For read mode, just run without progress
 		if [[ "$operation" == "fix-broken" ]]; then
-			apt-get -y --fix-broken install "$@" 2>&1 | tee "$error_file"
+			DEBIAN_FRONTEND=noninteractive apt-get -y --fix-broken install "$@" 2>&1 | tee "$error_file"
 		elif [[ "$operation" == "autopurge" ]]; then
-			apt-get -y autopurge "$@" 2>&1 | tee "$error_file"
+			DEBIAN_FRONTEND=noninteractive apt-get -y autopurge "$@" 2>&1 | tee "$error_file"
 		else
-			apt-get -y "$operation" "$@" 2>&1 | tee "$error_file"
+			DEBIAN_FRONTEND=noninteractive apt-get -y "$operation" "$@" 2>&1 | tee "$error_file"
 		fi
 		exit_code=${PIPESTATUS[0]}
 	else
@@ -196,7 +196,7 @@ pkg_install()
 	exit_code=$?
 
 	if [[ $exit_code == 100 ]]; then
-		dpkg --configure -a
+		DEBIAN_FRONTEND=noninteractive dpkg --configure -a
 		apt_operation_progress install "$@"
 		exit_code=$?
 	fi
@@ -252,7 +252,7 @@ pkg_remove()
 	exit_code=$?
 
 	if [[ $exit_code == 100 ]]; then
-		dpkg --configure -a
+		DEBIAN_FRONTEND=noninteractive dpkg --configure -a
 		apt_operation_progress autopurge "$@"
 		exit_code=$?
 	fi


### PR DESCRIPTION
## Summary
Fixes "end of file on stdin at conffile prompt" errors during automated builds by ensuring all apt-get and dpkg operations run non-interactively.

## Problem
During automated builds, dpkg was prompting for conffile decisions (e.g., chromium master_preferences), causing the build to fail with "end of file on stdin at conffile prompt" errors.

## Root Cause
The package management functions had inconsistent handling of `DEBIAN_FRONTEND=noninteractive`:
- Dialog mode had it explicitly set
- Read mode (used in automated builds) was missing it
- dpkg --configure fallbacks were missing it
- An export in desktops.sh wouldn't work in chroot environments

## Solution
- Added `DEBIAN_FRONTEND=noninteractive` to all apt-get commands in read mode
- Added `DEBIAN_FRONTEND=noninteractive` to dpkg --configure fallbacks
- Removed redundant export from desktops module (now handled centrally)

## Benefits
- ✅ Works in all contexts: chroot, subshells, automated builds
- ✅ No reliance on environment variable exports
- ✅ Centralized handling in package functions
- ✅ Prevents all interactive prompts during package operations

## Test Plan
- [x] Bash syntax check passes
- [x] Changes verified in both files
- [ ] Test in automated build environment with chromium or similar package that has conffile prompts
