### PR TITLE
desktops: enable panthor-gpu DT overlay on rk3588 vendor-kernel desktops

### DIFF
--- a/tools/modules/desktops/module_desktops.sh
+++ b/tools/modules/desktops/module_desktops.sh
@@ -102,6 +102,86 @@ function _module_desktops_write_apt_pin() {
 }
 
 #
+# Enable the panthor-gpu DT overlay on Rockchip RK3588-family boards
+# running the vendor kernel, when a Wayland-capable desktop is being
+# installed. Mirrors the old extensions/network/… no, wait — mirrors
+# armbian/build's extensions/mesa-vpu.sh 'extension_prepare_config__3d'
+# hook so that install-on-minimal converges on the same overlay set
+# an image-built desktop would have.
+#
+# panthor-gpu is the Mesa panthor-kbase GPU driver overlay: required
+# for hardware-accelerated GL / Vulkan / GBM on rk3588 under Mesa +
+# vendor kernel, unused (and ignored) on everything else.
+#
+# Gating mirrors the upstream hook:
+#   - Skip on pre-bookworm / bookworm / jammy / older releases —
+#     panthor kernel bits didn't land there in a usable shape.
+#   - Skip on tier=minimal — the overlay is only useful with a
+#     compositor stack (Mesa/Vulkan loaders) that mid/full pulls in.
+#   - Skip on xfce / i3-wm — these are X11-only in our default
+#     configuration and don't benefit from a GBM GPU path.
+#   - Only fire on BOARDFAMILY rockchip-rk3588 / rk35xx and
+#     BRANCH=vendor.
+#
+# BOARDFAMILY + BRANCH are globals set at configng init time by
+# module_env_init.sh (which sources /etc/armbian-release); present
+# in the chroot under mode=build because armbian-base-files is
+# installed before module_desktops. Delegates the actual
+# armbianEnv.txt write to module_devicetree_overlays (atomic
+# temp+mv, .bak preserved, validates name against the discovered
+# .dtbo set, idempotent).
+#
+function _module_desktops_add_3d_overlay() {
+	# Board/branch gate.
+	if [[ ! "${BOARDFAMILY:-}" =~ ^(rockchip-rk3588|rk35xx)$ ]]; then
+		debug_log "_module_desktops_add_3d_overlay: BOARDFAMILY='${BOARDFAMILY:-}' — not rk3588-family, skipping"
+		return 0
+	fi
+	if [[ "${BRANCH:-}" != "vendor" ]]; then
+		debug_log "_module_desktops_add_3d_overlay: BRANCH='${BRANCH:-}' — not vendor, skipping"
+		return 0
+	fi
+
+	# Release gate — old releases ship kernels that don't have the
+	# panthor driver, or have a non-working version.
+	case "${DISTROID:-}" in
+		bookworm|bullseye|buster|focal|jammy)
+			debug_log "_module_desktops_add_3d_overlay: release '${DISTROID}' predates usable panthor, skipping"
+			return 0
+		;;
+	esac
+
+	# Tier gate — minimal doesn't install the Mesa/Vulkan stack that
+	# would use the overlay.
+	if [[ "${tier:-}" == "minimal" ]]; then
+		debug_log "_module_desktops_add_3d_overlay: tier=minimal, skipping"
+		return 0
+	fi
+
+	# X11-only DEs — no Wayland compositor, no GBM path.
+	case "${de:-}" in
+		xfce|i3-wm)
+			debug_log "_module_desktops_add_3d_overlay: de=${de} is X11-only, skipping"
+			return 0
+		;;
+	esac
+
+	# Delegate to the existing DT overlays module. It reads/writes
+	# /boot/armbianEnv.txt atomically, keeps a .bak, and silently
+	# no-ops if 'panthor-gpu' is already enabled. 'install' also
+	# validates the name against the .dtbo set discovered on the
+	# running / in-chroot system, so if the overlay isn't shipped
+	# (e.g. kernel without panthor), we get a loud error instead of
+	# a silently broken image.
+	display_alert "Enabling panthor-gpu DT overlay" "BOARDFAMILY=${BOARDFAMILY} BRANCH=vendor" "info" 2>/dev/null \
+		|| echo "Enabling panthor-gpu DT overlay (BOARDFAMILY=${BOARDFAMILY} BRANCH=vendor)"
+	module_devicetree_overlays install overlays=panthor-gpu || \
+		echo "Warning: failed to enable panthor-gpu overlay (see above)" >&2
+
+	return 0
+}
+
+#
 # Switch the host from systemd-networkd (the Armbian minimal image
 # baseline) to NetworkManager so the freshly-installed desktop's
 # NM-applet / Quick Settings tile actually control the network link.
@@ -400,6 +480,15 @@ function module_desktops() {
 			# otherwise the UI shows an always-disconnected state
 			# even though the machine is online.
 			_module_desktops_configure_networking
+
+			# Enable panthor-gpu DT overlay on rk3588-family boards
+			# running the vendor kernel when a Wayland-capable
+			# desktop is installed. No-op on every other board /
+			# branch / release / tier / DE combination. Mirrors
+			# armbian/build's extensions/mesa-vpu.sh 'Hook 1' so
+			# runtime-installed desktops converge on the same
+			# overlay set an image-built desktop would have.
+			_module_desktops_add_3d_overlay
 
 			# add user to desktop groups
 			# User-specific setup: group membership, skel propagation,


### PR DESCRIPTION
## Summary

Ports armbian/build's `extensions/mesa-vpu.sh` `extension_prepare_config__3d` hook into `module_desktops install` so the `panthor-gpu` DT overlay is enabled at the desktop-install layer, not only at image-build time.

Mesa's **panthor** driver needs the `panthor-gpu` DT overlay to claim the rk3588 Mali-G610 via the vendor kernel's kbase interface. Without it, GL / Vulkan / GBM fall back to llvmpipe software rendering. Previously the build-side extension appended `panthor-gpu` to `DEFAULT_OVERLAYS` at `extension_prepare_config` time — fine for image-built desktops, but desktops installed on top of a minimal image via `armbian-config` never got the overlay.

## Change

New helper `_module_desktops_add_3d_overlay` in `module_desktops.sh` with the same gating upstream has:

- `BOARDFAMILY` in `{rockchip-rk3588, rk35xx}`
- `BRANCH == vendor`
- release **not** in `{bookworm, bullseye, buster, focal, jammy}` (panthor kernel bits unusable on those)
- `tier != minimal` (overlay is only useful with a Mesa/Vulkan stack that mid/full pulls in)
- `DESKTOP_ENVIRONMENT` **not** in `{xfce, i3-wm}` (X11-only in our defaults, no GBM path)

All conditions match → delegate to the existing `module_devicetree_overlays install overlays=panthor-gpu`. That module already owns:

- atomic `/boot/armbianEnv.txt` rewrite (temp + mv, `.bak` preserved)
- validation against the discovered `.dtbo` set
- idempotence (silently no-op if `panthor-gpu` already enabled)

No reimplementation needed.

## Callsite

Wired into the install pipeline right after `_module_desktops_configure_networking`, so both build-mode (`armbian-config --api module_desktops install mode=build`) and runtime installs converge on the same overlay set image-built desktops already have.

## Environment

`BOARDFAMILY` and `BRANCH` are sourced from `/etc/armbian-release` at configng init time by `module_env_init.sh` — present in the chroot during `mode=build` because `armbian-base-files` (which ships the file) is installed before `module_desktops` on every build path.

## Companion PR

Pairs with armbian/build#9683 commit `deb764dc6`, which removes `extension_prepare_config__3d` from `extensions/mesa-vpu.sh` (and the `post_armbian_repo_customize_image__browser` hook — also redundant with configng's `browser` virtual token, and the cause of the chromium master_preferences dpkg prompt that kicked off this refactor).

## Test plan

- [x] `bash -n module_desktops.sh` passes.
- [x] Helper is a no-op on non-matching `BOARDFAMILY` / `BRANCH` / release / tier / DE (gating mirrors mesa-vpu exactly).
- [ ] Image build of noble/rk3588/vendor/gnome/mid ends with `panthor-gpu` in `/boot/armbianEnv.txt` `overlays=` line.
- [ ] Runtime `armbian-config --api module_desktops install de=gnome tier=mid` on a noble/rk3588/vendor minimal image writes `panthor-gpu` into `/boot/armbianEnv.txt` idempotently and keeps a `.bak`.
- [ ] Same call on an rk3566 or x86 board: helper early-returns silently, no overlay write.