### PR TITLE
desktops: install libv4l-0 before rockchip-multimedia packages

### DIFF
--- a/tools/modules/desktops/module_desktops.sh
+++ b/tools/modules/desktops/module_desktops.sh
@@ -222,6 +222,14 @@ function _module_desktops_rockchip_multimedia() {
 		# Refresh apt with the PPA now in sources + the pin in place.
 		pkg_update
 
+		# libv4l-0 must be installed BEFORE rockchip-multimedia-config
+		# — the latter's postinst expects the V4L2 userspace library to
+		# already be on the system. Mirrors the ordering in
+		# armbian/build's extensions/mesa-vpu.sh (separate apt-get
+		# install call before the rockchip-multimedia-* batch).
+		pkg_install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" libv4l-0 || \
+			echo "Warning: libv4l-0 install failed; rockchip-multimedia postinst may fail" >&2
+
 		# Install the Rockchip multimedia + Widevine stack. These
 		# packages all come from the PPA (except libwidevinecdm0 on
 		# arm64, which the PPA specifically republishes with a


### PR DESCRIPTION
## Summary
- `rockchip-multimedia-config`'s postinst expects `libv4l-0` to already be present — otherwise the configure step can fail on a fresh minimal image where the V4L2 userspace lib hasn't been pulled in yet
- Adds a separate `pkg_install libv4l-0` between `pkg_update` and the `rockchip-multimedia-*` batch, inside the existing noble/rk3588/vendor gate in `_module_desktops_rockchip_multimedia`
- Mirrors the ordering from armbian/build's [`extensions/mesa-vpu.sh`](https://github.com/armbian/build/blob/main/extensions/mesa-vpu.sh) (which does the same `apt-get install libv4l-0` call before the multimedia batch)

Follow-up to #885.

## Test plan
- [ ] `module_desktops install de=<any> tier=mid mode=build` on an rk3588 / vendor / noble build reports `libv4l-0` in `ACTUALLY_INSTALLED` before the rockchip-multimedia packages
- [ ] Same install on a non-rk3588 / non-noble target stays a no-op (entire block is gated)
- [ ] `module_desktops remove de=<name>` purges `libv4l-0` via the manifest