### PR TITLE
owncloud: fix CI install test + docker_operation_progress pull/error-handling bugs it exposed

### DIFF
--- a/tools/modules/software/module_owncloud.sh
+++ b/tools/modules/software/module_owncloud.sh
@@ -9,7 +9,7 @@ module_options+=(
 	["module_owncloud,group"]="Database"
 	["module_owncloud,port"]="7787"
 	["module_owncloud,arch"]="x86-64 arm64"
-	["module_owncloud,dockerimage"]="owncloud/server:latest"
+	["module_owncloud,dockerimage"]="docker.io/owncloud/server:10.16.1"
 	["module_owncloud,dockername"]="owncloud"
 )
 #


### PR DESCRIPTION
## Summary

The CI `Owncloud install` test has been red because `owncloud/server:latest` no longer exists on Docker Hub — ownCloud stopped publishing the floating `latest` tag after pivoting to Infinite Scale (`owncloud/ocis`). Fixing the image pin surfaced three latent bugs in `docker_operation_progress` that were swallowing failures and masking real errors. This PR fixes all of them.

### Changes

- **`module_owncloud.sh` — pin to `owncloud/server:10.16.1`.**
  `:latest` returned `manifest unknown`. `10.16.1` is the last real `owncloud/server` tag; env-var / port / volume interface (`OWNCLOUD_TRUSTED_DOMAINS`, PUID/PGID, `:8080`, `/config`, `/mnt/data`) unchanged.

- **`docker_operation_progress` — surface real exit status past `dialog_gauge`.**
  Each branch ran the docker command in a subshell piped to `dialog_gauge`; `exit_code=$?` after the pipe only captured `dialog_gauge`'s rc, so any docker failure bubbled up as success. Thread the subshell's true status via a tmp `rc_file`, and echo captured stderr to real stderr (not just `dialog_msgbox`, which is a no-op for `--api` / non-TTY callers).

- **`docker_operation_progress pull` — fix mis-parenthesised jq `select()`.**
  Parser was `select(.status != null) or (.error != null) |` — `or` lived outside `select`, yielding a boolean that the downstream `if .error then …` couldn't index (`Cannot index boolean with string "error"`). Move `or` inside `select()`.

- **`docker_operation_progress pull` — split `repo:tag` into `fromImage` + `tag`.**
  `POST /images/create?fromImage=owncloud/server:10.16.1` returns HTTP 400 on modern dockerd even though `docker pull` from the CLI works. Canonical API form is separate query params. Split on the *last* `:` so `registry:port` prefixes survive.

- **`docker_operation_progress pull` — drop hardcoded `/v1.41/` API prefix.**
  Docker 29.x has `MinAPIVersion 1.44`; the daemon rejects the `v1.41` pin with HTTP 400 before it even parses fromImage/tag. Omit the version and let the daemon pick its own latest (`MinAPIVersion..APIVersion`), which is backward-compatible for `/images/create`.

- **`tests/owncloud.conf` — drop post-install `sleep`.**
  Redundant: `docker_operation_progress run` already blocks on `wait_for_container_ready` before returning.

### Test plan

- [x] `docker pull owncloud/server:10.16.1` works (dockerd 29.1.3)
- [x] CI `Owncloud install (noble/amd64)` and `(noble/arm64)` green
- [x] Local `armbian-config --api module_owncloud install` on noble + dockerd 29.1.3 (MinAPIVersion 1.44) pulls and starts the container
- [x] `module_owncloud status` returns 0 afterwards
- [x] `module_owncloud purge` cleans up container + image