### PR TITLE
owncloud: fix CI install test + docker_operation_progress pull/error-handling bugs it exposed

### DIFF
--- a/tests/owncloud.conf
+++ b/tests/owncloud.conf
@@ -7,6 +7,7 @@ testcase() {(
 	set -e
 	./bin/armbian-config --api module_owncloud purge
 	./bin/armbian-config --api module_owncloud install
+	sleep 10
 	./bin/armbian-config --api module_owncloud status
 	./bin/armbian-config --api module_owncloud purge
 )}

--- a/tests/owncloud.conf
+++ b/tests/owncloud.conf
@@ -7,7 +7,6 @@ testcase() {(
 	set -e
 	./bin/armbian-config --api module_owncloud purge
 	./bin/armbian-config --api module_owncloud install
-	sleep 10
 	./bin/armbian-config --api module_owncloud status
 	./bin/armbian-config --api module_owncloud purge
 )}

--- a/tools/modules/functions/module_docker_utils.sh
+++ b/tools/modules/functions/module_docker_utils.sh
@@ -216,6 +216,26 @@ docker_operation_progress() {
 			local raw_response_file=$(mktemp)
 			local http_code_file=$(mktemp)
 
+			# Split `repo:tag` into separate `fromImage` + `tag` query
+			# params. Modern dockerd returns HTTP 400 when fromImage
+			# carries the tag inline — `docker pull owncloud/server:
+			# 10.16.1` works from the CLI but the same request shaped
+			# as `POST /images/create?fromImage=owncloud/server:
+			# 10.16.1` is rejected. The canonical API form passes
+			# image and tag as separate query params. Split on the
+			# LAST `:` so a registry:port prefix
+			# (registry.example.com:5000/repo:tag) stays in fromImage
+			# and only the tag goes to `tag=`. Default missing tag
+			# to `latest` to match docker CLI behavior.
+			local pull_image pull_tag
+			if [[ "$target" == *:* ]]; then
+				pull_image="${target%:*}"
+				pull_tag="${target##*:}"
+			else
+				pull_image="$target"
+				pull_tag="latest"
+			fi
+
 			(
 				echo "XXX"
 				echo "0"
@@ -224,7 +244,7 @@ docker_operation_progress() {
 
 				unbuffer curl --silent --show-error \
 					--unix-socket "$socket_path" \
-					-X POST "http://localhost/$api_version/images/create?fromImage=$target" \
+					-X POST "http://localhost/$api_version/images/create?fromImage=${pull_image}&tag=${pull_tag}" \
 					-w "%{http_code}" \
 					-o "$raw_response_file" \
 					2> "$error_file" \

--- a/tools/modules/functions/module_docker_utils.sh
+++ b/tools/modules/functions/module_docker_utils.sh
@@ -253,9 +253,20 @@ docker_operation_progress() {
 					exit 0
 				fi
 
-				# Parse and display progress from captured response
+				# Parse and display progress from captured response.
+				# NB the parens: `or` must be INSIDE select(), not
+				# outside. `select(X) or Y` is a boolean expression
+				# (select filters the stream, then `or` returns a
+				# bool) which the downstream `| if .error then ...`
+				# cannot index, producing
+				#   jq: error ... Cannot index boolean with string "error"
+				# for every JSON line in the Docker API pull stream.
+				# The original select((X) or (Y)) was mis-parenthesised
+				# and only ever worked when jq happened to emit
+				# nothing (e.g. pulls that returned zero progress
+				# lines).
 				if ! jq -r --unbuffered '
-						select(.status != null) or (.error != null) |
+						select((.status != null) or (.error != null)) |
 						if .error then
 							"ERROR\n" + .error + "\n"
 						elif .progressDetail.current and .progressDetail.total then

--- a/tools/modules/functions/module_docker_utils.sh
+++ b/tools/modules/functions/module_docker_utils.sh
@@ -131,7 +131,12 @@ docker_parse_commands() {
 docker_operation_progress() {
 	local operation="$1"
 	local target="$2"
-	local api_version="v1.41"
+	# No /v1.XX/ prefix on the Docker API URL below: the daemon
+	# serves versions between MinAPIVersion and APIVersion, and any
+	# hardcoded value ages out of that window. Docker 29.x already
+	# has MinAPIVersion 1.44, so a pin at v1.41 returns HTTP 400
+	# outright. Omitting the prefix makes the daemon pick its own
+	# latest, which is backward-compatible for the endpoints we use.
 	local socket_path="/var/run/docker.sock"
 
 	# Ensure Docker is available
@@ -244,7 +249,7 @@ docker_operation_progress() {
 
 				unbuffer curl --silent --show-error \
 					--unix-socket "$socket_path" \
-					-X POST "http://localhost/$api_version/images/create?fromImage=${pull_image}&tag=${pull_tag}" \
+					-X POST "http://localhost/images/create?fromImage=${pull_image}&tag=${pull_tag}" \
 					-w "%{http_code}" \
 					-o "$raw_response_file" \
 					2> "$error_file" \

--- a/tools/modules/functions/module_docker_utils.sh
+++ b/tools/modules/functions/module_docker_utils.sh
@@ -167,12 +167,40 @@ docker_operation_progress() {
 
 	local exit_code
 	local error_file=$(mktemp)
+	# rc_file threads the true exit status of the subshell past the
+	# `... | dialog_gauge ...` pipe. Without it, `exit_code=$?` only
+	# captures dialog_gauge's rc (almost always 0), so every docker
+	# run/rm/rmi/pull failure bubbled up as success — the caller
+	# (e.g. module_owncloud install) then reported success for a
+	# container that never started, and the test suite's downstream
+	# `status` step was the first to notice. Each branch writes 0
+	# on success / 1 on failure to rc_file; the post-pipe check
+	# reads it and surfaces the real result.
+	local rc_file=$(mktemp)
+	echo 0 > "$rc_file"
 	local title="Docker $operation"
+
+	# surface_failure <friendly-title>
+	# Unified failure handler: emits the captured stderr to the
+	# *real* stderr (so --api / CI consumers see the docker error)
+	# AND shows a TUI msgbox (for interactive sessions). Without the
+	# echo-to-stderr, dialog_msgbox alone hides the error from any
+	# non-TTY caller, since msgbox writes to the dialog tool's FD
+	# and --api mode has no one to read it.
+	surface_failure() {
+		local heading="$1"
+		local body="$2"
+		local error_output=""
+		[[ -s "$error_file" ]] && error_output=$(<"$error_file")
+		echo "${heading}: ${target}" >&2
+		[[ -n "$error_output" ]] && printf '%s\n' "$error_output" >&2
+		dialog_msgbox "$heading" "${body}: $target\n\n${error_output}" 14 60
+	}
 
 	case "$operation" in
 		pull)
 			# Ensure Docker is installed
-			docker_ensure_docker || return 1
+			docker_ensure_docker || { rm -f "$error_file" "$rc_file"; return 1; }
 
 			# Check if image already exists
 			local existing_image
@@ -180,6 +208,7 @@ docker_operation_progress() {
 
 			if [[ -n "$existing_image" ]]; then
 				# Image already exists, skip pull
+				rm -f "$error_file" "$rc_file"
 				return 0
 			fi
 
@@ -208,7 +237,9 @@ docker_operation_progress() {
 					echo "0"
 					echo "Error: HTTP $http_code"
 					echo "XXX"
-					exit 1
+					echo "HTTP $http_code from Docker API" >> "$error_file"
+					echo 1 > "$rc_file"
+					exit 0
 				fi
 
 				# Check if response file has content
@@ -217,7 +248,9 @@ docker_operation_progress() {
 					echo "0"
 					echo "Error: Empty response from Docker API"
 					echo "XXX"
-					exit 1
+					echo "empty response from Docker API" >> "$error_file"
+					echo 1 > "$rc_file"
+					exit 0
 				fi
 
 				# Parse and display progress from captured response
@@ -240,7 +273,9 @@ docker_operation_progress() {
 					echo "0"
 					echo "Error: Failed to parse Docker API response"
 					echo "XXX"
-					exit 1
+					echo "failed to parse Docker API response" >> "$error_file"
+					echo 1 > "$rc_file"
+					exit 0
 				fi
 
 				echo "XXX"
@@ -249,15 +284,14 @@ docker_operation_progress() {
 				echo "XXX"
 			) | dialog_gauge "$title" "Pulling: $target" 8 80
 
-			exit_code=$?
-
 			rm -f "$raw_response_file" "$http_code_file"
+
+			exit_code=$(<"$rc_file")
 
 			# Verify and show result
 			if [[ $exit_code -ne 0 ]]; then
-				local error_output=""
-				[[ -s "$error_file" ]] && error_output=$(<"$error_file")
-				dialog_msgbox "Pull Failed" "Failed to pull: $target\n\nExit code: $exit_code\n\n${error_output}" 14 60
+				surface_failure "Pull Failed" "Failed to pull"
+				rm -f "$error_file" "$rc_file"
 				return 1
 			fi
 			# Note: We trust the Docker API response. If HTTP 200 with no errors,
@@ -269,6 +303,7 @@ docker_operation_progress() {
 			# Remove container - check if exists first
 			if ! docker container ls -a --format '{{.Names}}' | grep -q "^${target}$"; then
 				# Container doesn't exist, silently succeed
+				rm -f "$error_file" "$rc_file"
 				return 0
 			fi
 
@@ -289,15 +324,15 @@ docker_operation_progress() {
 					echo "0"
 					echo "Failed to remove container"
 					echo "XXX"
+					echo 1 > "$rc_file"
 				fi
 			) | dialog_gauge "$title" "Removing: $target" 6 80
 
-			exit_code=$?
+			exit_code=$(<"$rc_file")
 
 			if [[ $exit_code -ne 0 ]]; then
-				local error_output=""
-				[[ -s "$error_file" ]] && error_output=$(<"$error_file")
-				dialog_msgbox "Error" "Failed to remove container: $target\n\n${error_output}" 10 60
+				surface_failure "Docker rm Failed" "Failed to remove container"
+				rm -f "$error_file" "$rc_file"
 				return 1
 			fi
 			;;
@@ -306,6 +341,7 @@ docker_operation_progress() {
 			# Remove image - check if exists first
 			if ! docker image ls --format '{{.Repository}}:{{.Tag}}' | grep -q "^${target}$"; then
 				# Image doesn't exist, silently succeed
+				rm -f "$error_file" "$rc_file"
 				return 0
 			fi
 
@@ -326,15 +362,15 @@ docker_operation_progress() {
 					echo "0"
 					echo "Failed to remove image"
 					echo "XXX"
+					echo 1 > "$rc_file"
 				fi
 			) | dialog_gauge "$title" "Removing: $target" 6 80
 
-			exit_code=$?
+			exit_code=$(<"$rc_file")
 
 			if [[ $exit_code -ne 0 ]]; then
-				local error_output=""
-				[[ -s "$error_file" ]] && error_output=$(<"$error_file")
-				dialog_msgbox "Error" "Failed to remove image: $target\n\n${error_output}" 10 60
+				surface_failure "Docker rmi Failed" "Failed to remove image"
+				rm -f "$error_file" "$rc_file"
 				return 1
 			fi
 			;;
@@ -355,7 +391,11 @@ docker_operation_progress() {
 					echo "Container started. Waiting for ready..."
 					echo "XXX"
 
-					# Wait for container to be ready
+					# Wait for container to be ready. Timeout is a soft
+					# warning (progress bar shows 75% + message) — not a
+					# failure. docker run succeeded, container is up;
+					# some images take a while to become "ready" by
+					# their own definition.
 					if wait_for_container_ready "$target" 2>/dev/null; then
 						echo "XXX"
 						echo "100"
@@ -372,22 +412,22 @@ docker_operation_progress() {
 					echo "0"
 					echo "Failed to start container"
 					echo "XXX"
+					echo 1 > "$rc_file"
 				fi
 			) | dialog_gauge "$title" "Starting: $target" 8 80
 
-			exit_code=$?
+			exit_code=$(<"$rc_file")
 
 			if [[ $exit_code -ne 0 ]]; then
-				local error_output=""
-				[[ -s "$error_file" ]] && error_output=$(<"$error_file")
-				dialog_msgbox "Error" "Failed to start container: $target\n\n${error_output}" 10 60
+				surface_failure "Docker run Failed" "Failed to start container"
+				rm -f "$error_file" "$rc_file"
 				return 1
 			fi
 			;;
 	esac
 
-	# Clean up error file
-	rm -f "$error_file"
+	# Clean up
+	rm -f "$error_file" "$rc_file"
 
 	return 0
 }

--- a/tools/modules/software/module_owncloud.sh
+++ b/tools/modules/software/module_owncloud.sh
@@ -9,7 +9,7 @@ module_options+=(
 	["module_owncloud,group"]="Database"
 	["module_owncloud,port"]="7787"
 	["module_owncloud,arch"]="x86-64 arm64"
-	["module_owncloud,dockerimage"]="owncloud/server:latest"
+	["module_owncloud,dockerimage"]="docker.io/owncloud/server:10.16.1"
 	["module_owncloud,dockername"]="owncloud"
 )
 #

--- a/tools/modules/software/module_owncloud.sh
+++ b/tools/modules/software/module_owncloud.sh
@@ -9,7 +9,7 @@ module_options+=(
 	["module_owncloud,group"]="Database"
 	["module_owncloud,port"]="7787"
 	["module_owncloud,arch"]="x86-64 arm64"
-	["module_owncloud,dockerimage"]="docker.io/owncloud/server:10.16.1"
+	["module_owncloud,dockerimage"]="owncloud/server:10.16.1"
 	["module_owncloud,dockername"]="owncloud"
 )
 #


### PR DESCRIPTION
## Summary

The CI `Owncloud install` test has been red because `owncloud/server:latest` no longer exists on Docker Hub — ownCloud stopped publishing the floating `latest` tag after pivoting to Infinite Scale (`owncloud/ocis`). Fixing the image pin surfaced three latent bugs in `docker_operation_progress` that were swallowing failures and masking real errors. This PR fixes all of them.

### Changes

- **`module_owncloud.sh` — pin to `owncloud/server:10.16.1`.**
  `:latest` returned `manifest unknown`. `10.16.1` is the last real `owncloud/server` tag; env-var / port / volume interface (`OWNCLOUD_TRUSTED_DOMAINS`, PUID/PGID, `:8080`, `/config`, `/mnt/data`) unchanged.

- **`docker_operation_progress` — surface real exit status past `dialog_gauge`.**
  Each branch ran the docker command in a subshell piped to `dialog_gauge`; `exit_code=$?` after the pipe only captured `dialog_gauge`'s rc, so any docker failure bubbled up as success. Thread the subshell's true status via a tmp `rc_file`, and echo captured stderr to real stderr (not just `dialog_msgbox`, which is a no-op for `--api` / non-TTY callers).

- **`docker_operation_progress pull` — fix mis-parenthesised jq `select()`.**
  Parser was `select(.status != null) or (.error != null) |` — `or` lived outside `select`, yielding a boolean that the downstream `if .error then …` couldn't index (`Cannot index boolean with string "error"`). Move `or` inside `select()`.

- **`docker_operation_progress pull` — split `repo:tag` into `fromImage` + `tag`.**
  `POST /images/create?fromImage=owncloud/server:10.16.1` returns HTTP 400 on modern dockerd even though `docker pull` from the CLI works. Canonical API form is separate query params. Split on the *last* `:` so `registry:port` prefixes survive.

- **`docker_operation_progress pull` — drop hardcoded `/v1.41/` API prefix.**
  Docker 29.x has `MinAPIVersion 1.44`; the daemon rejects the `v1.41` pin with HTTP 400 before it even parses fromImage/tag. Omit the version and let the daemon pick its own latest (`MinAPIVersion..APIVersion`), which is backward-compatible for `/images/create`.

- **`tests/owncloud.conf` — drop post-install `sleep`.**
  Redundant: `docker_operation_progress run` already blocks on `wait_for_container_ready` before returning.

### Test plan

- [x] `docker pull owncloud/server:10.16.1` works (dockerd 29.1.3)
- [x] CI `Owncloud install (noble/amd64)` and `(noble/arm64)` green
- [x] Local `armbian-config --api module_owncloud install` on noble + dockerd 29.1.3 (MinAPIVersion 1.44) pulls and starts the container
- [x] `module_owncloud status` returns 0 afterwards
- [x] `module_owncloud purge` cleans up container + image