### PR TITLE
ci/unit-tests: bump job timeouts by +30 minutes

### DIFF
--- a/.github/workflows/maintenance-unit-tests.yml
+++ b/.github/workflows/maintenance-unit-tests.yml
@@ -191,7 +191,7 @@ jobs:
         server: ${{ fromJSON(needs.prepare.outputs.DEPLOYMENT_MATRIX_NATIVE) }}
     name: "${{ matrix.server.name }} (${{ matrix.server.os }}/${{ matrix.server.arch }})"
     runs-on: ${{ matrix.server.runner }}
-    timeout-minutes: 60
+    timeout-minutes: 90
     container:
       image: ${{ matrix.server.docker_image }}
       options: --privileged --security-opt seccomp=unconfined --tmpfs /tmp --tmpfs /run --tmpfs /run/lock
@@ -310,7 +310,7 @@ jobs:
         server: ${{ fromJSON(needs.prepare.outputs.DEPLOYMENT_MATRIX_EMULATED) }}
     name: "${{ matrix.server.name }} (${{ matrix.server.os }}/${{ matrix.server.arch }}-qemu)"
     runs-on: ${{ matrix.server.runner }}
-    timeout-minutes: 180
+    timeout-minutes: 210
     steps:
 
       # Emulated and native jobs share the same self-hosted runner


### PR DESCRIPTION
## Summary

Unit-test jobs have been timing out on the previous caps. Bumping both by +30 min:

- Native matrix: `60 → 90`
- Emulated matrix: `180 → 210`

## Test plan
- [ ] Next nightly run completes without `the job running on runner ... has exceeded the maximum execution time`