### PR TITLE
ci/unit-tests: cancel in-flight runs on supersede

### DIFF
--- a/.github/workflows/maintenance-unit-tests.yml
+++ b/.github/workflows/maintenance-unit-tests.yml
@@ -14,8 +14,13 @@ env:
   REPOSITORY: "apt.armbian.com"
 
 concurrency:
-  group: pipeline-pr-${{github.event.pull_request.number}}
-  cancel-in-progress: false
+  # One active run per PR (keyed by PR number) or per ref for
+  # non-PR triggers (push to main, schedule, workflow_dispatch) —
+  # falls back to github.ref when pull_request.number is empty.
+  # cancel-in-progress: superseding pushes stop the in-flight run
+  # instead of queueing behind it.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
 


### PR DESCRIPTION
## Summary

`concurrency.cancel-in-progress` was `false`, so a fresh push to a PR (or to `main`) queued behind the current run instead of replacing it — runners stayed pinned on stale SHAs and the new commit could wait hours for a slot.

- Flip to `cancel-in-progress: true` so superseding pushes stop the in-flight run.
- Rework the group key: the previous `pipeline-pr-${{pull_request.number}}` collapsed every non-PR trigger (push-to-main, schedule, workflow_dispatch) into the same empty-numbered group, making unrelated main-branch and nightly runs kill each other. Now the group is `<workflow>-<PR#-or-ref>`, so PR concurrency is per-PR and non-PR concurrency is per-ref.

## Test plan
- [ ] Push a second commit to this branch — the earlier in-flight run cancels immediately instead of queuing
- [ ] A nightly schedule run on `main` is not cancelled by a simultaneous PR push