### PR TITLE
config.system: add Bianbu to the desktop install menu

### DIFF
--- a/tools/json/config.system.json
+++ b/tools/json/config.system.json
@@ -339,6 +339,18 @@
                             "help": "Install Enlightenment (EFL-based) [community-supported, best-effort]."
                         },
                         {
+                            "id": "BIAN01",
+                            "description": "Install Bianbu [CSC]",
+                            "short": "Bianbu [CSC]",
+                            "command": [
+                                "module_desktops install de=bianbu tier=mid"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "! module_desktops installed && module_desktop_supported bianbu",
+                            "help": "Install Bianbu — SpacemiT K1 RISC-V desktop (mid tier: full DE + standard utilities + K1 camera stack). riscv64 on noble/resolute only; uses SpacemiT's pinned archive (priority >1000 to override distro for K1-specific packages). [community-supported, best-effort]."
+                        },
+                        {
                             "id": "XFCE01",
                             "description": "Install XFCE (minimal)",
                             "short": "XFCE",


### PR DESCRIPTION
## Summary

The `bianbu` desktop (SpacemiT K1 RISC-V) has a complete YAML definition at [`tools/modules/desktops/yaml/bianbu.yaml`](tools/modules/desktops/yaml/bianbu.yaml) — riscv64 on noble/resolute, with the pinned SpacemiT archive (`archive.spacemit.com/bianbu/`) at priority >1000 — and installs correctly through `module_desktops install de=bianbu …`. But the DE install menu is populated from hardcoded entries in [`tools/json/config.system.json`](tools/json/config.system.json), and `bianbu` was never added. So on an actual riscv64 image, `armbian-config` has no menu path to Bianbu.

Reported by a user running `armbian-config` on a riscv64 Armbian image: "why don't I see an option to install Bianbu desktop?" — because the menu entry didn't exist.

## Change

Single-item menu entry (`BIAN01`) alongside the other community DEs (`kde-neon`, `budgie`, `deepin`, `enlightenment`), matching their `[CSC]` labelling. Calls `module_desktops install de=bianbu tier=mid` — mid tier pulls the full desktop (`bianbu-desktop`, `bianbu-desktop-en`), the standard utility set (`bianbu-standard`), and the K1 camera stack (`k1x-cam`) — SpacemiT's intended out-of-box experience. Minimal would ship only the bare-bones DE + HW enablement, which isn't really useful on its own.

The `condition` uses `module_desktop_supported bianbu`, which reads the YAML's `architectures: [riscv64]` and `releases: noble, resolute` — so the entry auto-surfaces on riscv64 noble/resolute and auto-hides everywhere else. No extra arch gate needed.

## Test plan

- [ ] On riscv64 + noble or resolute → "Install Bianbu [CSC]" appears under **System → Desktop**
- [ ] On any other arch/release → entry is hidden (arch gate via YAML)
- [ ] Entry runs `module_desktops install de=bianbu tier=mid` successfully (installs SpacemiT archive + keyring + preferences + mid tier packages)