### PR TITLE
desktops/bianbu: enable PVR DRI, fix detection, add menu entries

### DIFF
--- a/tools/json/config.system.json
+++ b/tools/json/config.system.json
@@ -340,15 +340,39 @@
                         },
                         {
                             "id": "BIAN01",
-                            "description": "Install Bianbu [CSC]",
+                            "description": "Install Bianbu (minimal) [CSC]",
                             "short": "Bianbu [CSC]",
+                            "command": [
+                                "module_desktops install de=bianbu tier=minimal"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "! module_desktops installed && module_desktop_supported bianbu",
+                            "help": "Install Bianbu — SpacemiT K1 RISC-V desktop (minimal tier: bare DE + K1 hardware enablement: img-gpu-powervr, k1x-vpu-firmware, spacemit-uart-bt, kernel modules, Mesa stack pinned to SpacemiT's archive for PVR DRI). riscv64 on noble/resolute only. [community-supported, best-effort]."
+                        },
+                        {
+                            "id": "BIAN05",
+                            "description": "Install Bianbu (mid) [CSC]",
+                            "short": "Bianbu mid [CSC]",
                             "command": [
                                 "module_desktops install de=bianbu tier=mid"
                             ],
                             "status": "Stable",
                             "author": "@igorpecovnik",
                             "condition": "! module_desktops installed && module_desktop_supported bianbu",
-                            "help": "Install Bianbu — SpacemiT K1 RISC-V desktop (mid tier: full DE + standard utilities + K1 camera stack). riscv64 on noble/resolute only; uses SpacemiT's pinned archive (priority >1000 to override distro for K1-specific packages). [community-supported, best-effort]."
+                            "help": "Install Bianbu (mid tier): minimal + full Bianbu desktop apps + standard utilities + K1 camera stack (k1x-cam). riscv64 on noble/resolute only. [community-supported, best-effort]."
+                        },
+                        {
+                            "id": "BIAN06",
+                            "description": "Install Bianbu (full) [CSC]",
+                            "short": "Bianbu full [CSC]",
+                            "command": [
+                                "module_desktops install de=bianbu tier=full"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "! module_desktops installed && module_desktop_supported bianbu",
+                            "help": "Install Bianbu (full tier): mid + Chinese locale (bianbu-desktop-zh) + development tooling (bianbu-development). riscv64 on noble/resolute only. [community-supported, best-effort]."
                         },
                         {
                             "id": "XFCE01",
@@ -407,6 +431,17 @@
                             "author": "@igorpecovnik",
                             "condition": "module_desktops status de=gnome",
                             "help": "Uninstall the GNOME desktop environment"
+                        },
+                        {
+                            "id": "BIAN02",
+                            "description": "Uninstall Bianbu",
+                            "command": [
+                                "module_desktops remove de=bianbu"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_desktops status de=bianbu",
+                            "help": "Uninstall the Bianbu desktop environment"
                         },
                         {
                             "id": "MATE02",
@@ -519,6 +554,17 @@
                             "help": "Enable automatic desktop login for GNOME"
                         },
                         {
+                            "id": "BIAN03",
+                            "description": "Enable autologin (Bianbu)",
+                            "command": [
+                                "module_desktops auto de=bianbu"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_desktops status de=bianbu && ! module_desktops login de=bianbu",
+                            "help": "Enable automatic desktop login for Bianbu"
+                        },
+                        {
                             "id": "MATE03",
                             "description": "Enable autologin (MATE)",
                             "command": [
@@ -627,6 +673,17 @@
                             "author": "@igorpecovnik",
                             "condition": "module_desktops status de=gnome && module_desktops login de=gnome",
                             "help": "Disable automatic desktop login for GNOME"
+                        },
+                        {
+                            "id": "BIAN04",
+                            "description": "Disable autologin (Bianbu)",
+                            "command": [
+                                "module_desktops manual de=bianbu"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_desktops status de=bianbu && module_desktops login de=bianbu",
+                            "help": "Disable automatic desktop login for Bianbu"
                         },
                         {
                             "id": "MATE04",
@@ -761,6 +818,17 @@
                             "help": "Downgrade GNOME to the minimal tier"
                         },
                         {
+                            "id": "BIAN07",
+                            "description": "Change Bianbu to minimal",
+                            "command": [
+                                "module_desktops set-tier de=bianbu tier=minimal"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_desktops status de=bianbu && ! module_desktops at-tier de=bianbu tier=minimal",
+                            "help": "Downgrade Bianbu to the minimal tier (bare DE + K1 hardware enablement)"
+                        },
+                        {
                             "id": "GNME08",
                             "description": "Change GNOME to mid",
                             "command": [
@@ -772,6 +840,17 @@
                             "help": "Move GNOME to the mid tier"
                         },
                         {
+                            "id": "BIAN08",
+                            "description": "Change Bianbu to mid",
+                            "command": [
+                                "module_desktops set-tier de=bianbu tier=mid"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_desktops status de=bianbu && ! module_desktops at-tier de=bianbu tier=mid",
+                            "help": "Move Bianbu to the mid tier (full DE + standard utilities + K1 camera stack)"
+                        },
+                        {
                             "id": "GNME09",
                             "description": "Change GNOME to full",
                             "command": [
@@ -781,6 +860,17 @@
                             "author": "@igorpecovnik",
                             "condition": "module_desktops status de=gnome && ! module_desktops at-tier de=gnome tier=full",
                             "help": "Upgrade GNOME to the full tier"
+                        },
+                        {
+                            "id": "BIAN09",
+                            "description": "Change Bianbu to full",
+                            "command": [
+                                "module_desktops set-tier de=bianbu tier=full"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_desktops status de=bianbu && ! module_desktops at-tier de=bianbu tier=full",
+                            "help": "Upgrade Bianbu to the full tier (adds zh locale and development tooling)"
                         },
                         {
                             "id": "MATE07",

--- a/tools/modules/desktops/module_desktop_repo.sh
+++ b/tools/modules/desktops/module_desktop_repo.sh
@@ -100,18 +100,38 @@ function module_desktop_repo() {
 						return 1
 					fi
 
+					local origin_host_var pkgs_var origin_host pkgs
 					for (( i=0; i < DESKTOP_REPO_PREFS_COUNT; i++ )); do
 						origin_var="DESKTOP_REPO_PREFS_${i}_ORIGIN"
 						suite_var="DESKTOP_REPO_PREFS_${i}_SUITE"
+						origin_host_var="DESKTOP_REPO_PREFS_${i}_ORIGIN_HOST"
+						pkgs_var="DESKTOP_REPO_PREFS_${i}_PACKAGES"
 						prio_var="DESKTOP_REPO_PREFS_${i}_PRIORITY"
 						origin="${!origin_var}"
 						suite="${!suite_var}"
+						origin_host="${!origin_host_var}"
+						pkgs="${!pkgs_var}"
 						prio="${!prio_var}"
-						if ! printf 'Package: *\nPin: release o=%s, n=%s\nPin-Priority: %s\n\n' \
-							"$origin" "$suite" "$prio" >> "$pref_tmp"; then
-							echo "Error: failed to write preferences for ${de}" >&2
-							rm -f "$pref_tmp"
-							return 1
+						# Empty packages list means "every package": apt's
+						# Package: line wants a glob, never blank.
+						[[ -z "$pkgs" ]] && pkgs="*"
+						# The parser guarantees exactly one pin style is set,
+						# so origin_host non-empty selects the host form,
+						# everything else falls back to release o=,n=.
+						if [[ -n "$origin_host" ]]; then
+							if ! printf 'Package: %s\nPin: origin %s\nPin-Priority: %s\n\n' \
+								"$pkgs" "$origin_host" "$prio" >> "$pref_tmp"; then
+								echo "Error: failed to write preferences for ${de}" >&2
+								rm -f "$pref_tmp"
+								return 1
+							fi
+						else
+							if ! printf 'Package: %s\nPin: release o=%s, n=%s\nPin-Priority: %s\n\n' \
+								"$pkgs" "$origin" "$suite" "$prio" >> "$pref_tmp"; then
+								echo "Error: failed to write preferences for ${de}" >&2
+								rm -f "$pref_tmp"
+								return 1
+							fi
 						fi
 					done
 

--- a/tools/modules/desktops/module_desktops.sh
+++ b/tools/modules/desktops/module_desktops.sh
@@ -425,6 +425,44 @@ function _module_desktops_configure_networking() {
 }
 
 #
+# Detect whether desktop $de is installed. Returns 0 if so, 1 otherwise.
+# Layered to avoid the dpkg-only check misfiring when DEs share
+# packages (e.g. Bianbu's bianbu-desktop-minimal-en depends on
+# gnome-session, so a naive dpkg check would mark gnome as installed
+# on a Bianbu-only system and surface a "Uninstall GNOME" entry that
+# would actually nuke Bianbu's display stack).
+#
+#   1. /etc/armbian/desktop/<de>.tier exists → installed. The marker
+#      is written by `install` and removed by `remove`, so it tracks
+#      exactly what configng put on the system. Authoritative.
+#
+#   2. A different DE has its marker present → not installed. The
+#      other DE's marker is the tiebreaker against the dpkg fallback.
+#
+#   3. No markers anywhere AND dpkg shows DESKTOP_PRIMARY_PKG
+#      installed → legacy installs that pre-date the marker
+#      convention or were done with apt directly. Caller must have
+#      populated DESKTOP_PRIMARY_PKG via module_desktop_yamlparse.
+#
+function _module_desktops_is_installed() {
+	local de="$1"
+	[[ -n "$de" ]] || return 1
+	# Layer 1
+	if [[ -f "/etc/armbian/desktop/${de}.tier" ]]; then
+		return 0
+	fi
+	# Layer 2 — any other DE's marker means dpkg is unsafe
+	local m
+	for m in /etc/armbian/desktop/*.tier; do
+		[[ -f "$m" ]] || continue
+		return 1
+	done
+	# Layer 3 — legacy dpkg fallback
+	[[ -n "${DESKTOP_PRIMARY_PKG:-}" ]] || return 1
+	dpkg -l "$DESKTOP_PRIMARY_PKG" 2>/dev/null | grep -q "^ii"
+}
+
+#
 # Module to install and manage desktop environments (YAML-driven)
 #
 function module_desktops() {
@@ -875,10 +913,7 @@ function module_desktops() {
 				return 1
 			fi
 			module_desktop_yamlparse "$de" || return 1
-			if [[ -n "$DESKTOP_PRIMARY_PKG" ]] && dpkg -l "$DESKTOP_PRIMARY_PKG" 2>/dev/null | grep -q "^ii"; then
-				return 0
-			fi
-			return 1
+			_module_desktops_is_installed "$de"
 		;;
 
 		"${commands[5]}")
@@ -1107,7 +1142,7 @@ function module_desktops() {
 				return 1
 			fi
 			module_desktop_yamlparse "$de" || return 1
-			if [[ -n "$DESKTOP_PRIMARY_PKG" ]] && dpkg -l "$DESKTOP_PRIMARY_PKG" 2>/dev/null | grep -q "^ii"; then
+			if _module_desktops_is_installed "$de"; then
 				if [[ -f "/etc/armbian/desktop/${de}.tier" ]]; then
 					cat "/etc/armbian/desktop/${de}.tier"
 				else
@@ -1131,8 +1166,7 @@ function module_desktops() {
 				return 1
 			fi
 			module_desktop_yamlparse "$de" || return 1
-			[[ -n "$DESKTOP_PRIMARY_PKG" ]] || return 1
-			dpkg -l "$DESKTOP_PRIMARY_PKG" 2>/dev/null | grep -q "^ii" || return 1
+			_module_desktops_is_installed "$de" || return 1
 			local current="minimal"
 			[[ -f "/etc/armbian/desktop/${de}.tier" ]] && current=$(< "/etc/armbian/desktop/${de}.tier")
 			[[ "$current" == "$tier" ]]

--- a/tools/modules/desktops/postinst/bianbu.sh
+++ b/tools/modules/desktops/postinst/bianbu.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set +e
+# Bianbu is a GNOME variant (gdm3 / GNOME Shell). Branding is much
+# narrower than the stock GNOME postinst — Bianbu ships its own
+# opinionated favorites, theme, and panel config from SpacemiT, and
+# we want to leave those alone. The only piece we override is the
+# wallpaper, so an installed image actually looks like Armbian.
+#
+# picture-uri-dark is set explicitly because Bianbu defaults to dark
+# mode under GNOME 46; without it the override only takes effect in
+# light mode and the user keeps seeing Bianbu's stock background.
+
+keys=/etc/dconf/db/local.d/00-bg
+profile=/etc/dconf/profile/user
+
+install -Dv /dev/null "$keys"
+install -Dv /dev/null "$profile"
+
+cat >> "$keys" <<- EOF
+
+	[org/gnome/desktop/background]
+	picture-uri='file:///usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-3840x2160.jpg'
+	picture-uri-dark='file:///usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-3840x2160.jpg'
+	picture-options='zoom'
+	primary-color='#456789'
+	secondary-color='#FFFFFF'
+
+	[org/gnome/desktop/screensaver]
+	picture-uri='file:///usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-3840x2160.jpg'
+	picture-options='zoom'
+	primary-color='#456789'
+	secondary-color='#FFFFFF'
+EOF
+
+echo "user-db:user
+system-db:local" >> "$profile"
+
+dconf update
+
+if [ -d /usr/share/glib-2.0/schemas ]; then
+	glib-compile-schemas /usr/share/glib-2.0/schemas
+fi

--- a/tools/modules/desktops/scripts/parse_desktop_yaml.py
+++ b/tools/modules/desktops/scripts/parse_desktop_yaml.py
@@ -51,8 +51,10 @@ Output (bash eval-friendly):
   DESKTOP_REPO_SUITE_<n>="..."  (for n in 0..N-1)
   DESKTOP_REPO_COMPONENTS="..." (optional, space-separated; defaults to "main")
   DESKTOP_REPO_PREFS_COUNT="N" (optional; 0 when no APT pins)
-  DESKTOP_REPO_PREFS_<n>_ORIGIN="..."   (for n in 0..N-1)
-  DESKTOP_REPO_PREFS_<n>_SUITE="..."
+  DESKTOP_REPO_PREFS_<n>_ORIGIN="..."        (for n in 0..N-1; empty when origin_host pin)
+  DESKTOP_REPO_PREFS_<n>_SUITE="..."         (empty when origin_host pin)
+  DESKTOP_REPO_PREFS_<n>_ORIGIN_HOST="..."   (empty when release/origin+suite pin)
+  DESKTOP_REPO_PREFS_<n>_PACKAGES="..."      (space-separated; empty means "*")
   DESKTOP_REPO_PREFS_<n>_PRIORITY="1200"
 """
 
@@ -386,36 +388,88 @@ def parse_desktop(yaml_dir, de_name, release, arch, tier):
         print(f'DESKTOP_REPO_COMPONENTS="{shell_escape(" ".join(components))}"')
 
         # Optional APT pin preferences written to /etc/apt/preferences.d/<de>.
-        # Each entry must be a mapping with origin + suite + priority. The
-        # triple (o=<origin>, n=<suite>) is the match criterion; priority
-        # is a positive integer (apt treats >1000 as "allow downgrades").
+        # Each entry must be a mapping with priority and exactly one of:
+        #   - origin + suite       → renders `Pin: release o=<origin>, n=<suite>`
+        #   - origin_host          → renders `Pin: origin <host>` (matches archive
+        #                            hostname; useful when the Suite field is
+        #                            unstable or the upstream archive carries
+        #                            its own non-standard Suite values)
+        # The optional `packages` list narrows the stanza to specific package
+        # names (apt globs allowed, e.g. "libdrm*"); when omitted, the stanza
+        # applies to every package (`Package: *`). Priority is a positive
+        # integer (apt treats >1000 as "allow downgrades").
+        _PKG_RE = re.compile(r"^[A-Za-z0-9._:+*-]+$")
+        _HOST_RE = re.compile(r"^[A-Za-z0-9._-]+$")
         prefs = _as_list(repo.get("preferences"))
         valid_prefs = []
         for p in prefs:
             p = _as_dict(p)
             origin = str(p.get("origin", "")).strip()
             suite = str(p.get("suite", "")).strip()
+            origin_host = str(p.get("origin_host", "")).strip()
+            raw_packages = p.get("packages")
             priority = p.get("priority")
+
             # isinstance(True, int) is True because bool subclasses int, so
             # reject bools explicitly — `priority: true` would otherwise
             # render `Pin-Priority: True` which apt refuses.
-            if (
-                not origin
-                or not suite
-                or isinstance(priority, bool)
-                or not isinstance(priority, int)
-                or priority <= 0
-            ):
+            priority_ok = (
+                not isinstance(priority, bool)
+                and isinstance(priority, int)
+                and priority > 0
+            )
+            uses_release_pin = bool(origin and suite)
+            uses_host_pin = bool(origin_host) and _HOST_RE.match(origin_host) is not None
+            # Exactly one of the two pin styles must be present. Mixing them
+            # would produce two Pin: lines, which apt rejects.
+            pin_style_ok = uses_release_pin ^ uses_host_pin
+
+            if not priority_ok or not pin_style_ok:
                 print(
                     f"Warning: ignoring malformed repo.preferences entry for {de_name}: {p!r}",
                     file=sys.stderr,
                 )
                 continue
-            valid_prefs.append((origin, suite, priority))
+
+            packages = []
+            if raw_packages is not None:
+                for pkg in _as_list(raw_packages):
+                    pkg = str(pkg).strip()
+                    if pkg and _PKG_RE.match(pkg):
+                        packages.append(pkg)
+                    else:
+                        print(
+                            f"Warning: ignoring invalid package name {pkg!r} in repo.preferences for {de_name}",
+                            file=sys.stderr,
+                        )
+                # `packages:` was provided but every entry failed validation
+                # (or the list was empty to begin with). Falling through to
+                # the renderer would emit `Package: *`, silently widening
+                # the pin to every package — opposite of the user's intent
+                # of narrowing scope. Drop the whole entry with a warning so
+                # the misconfiguration surfaces.
+                if not packages:
+                    print(
+                        f"Warning: ignoring repo.preferences entry for {de_name}: packages={raw_packages!r} produced no valid names",
+                        file=sys.stderr,
+                    )
+                    continue
+
+            valid_prefs.append(
+                (
+                    origin if uses_release_pin else "",
+                    suite if uses_release_pin else "",
+                    origin_host if uses_host_pin else "",
+                    " ".join(packages),
+                    priority,
+                )
+            )
         print(f'DESKTOP_REPO_PREFS_COUNT="{len(valid_prefs)}"')
-        for i, (origin, suite, priority) in enumerate(valid_prefs):
+        for i, (origin, suite, origin_host, packages, priority) in enumerate(valid_prefs):
             print(f'DESKTOP_REPO_PREFS_{i}_ORIGIN="{shell_escape(origin)}"')
             print(f'DESKTOP_REPO_PREFS_{i}_SUITE="{shell_escape(suite)}"')
+            print(f'DESKTOP_REPO_PREFS_{i}_ORIGIN_HOST="{shell_escape(origin_host)}"')
+            print(f'DESKTOP_REPO_PREFS_{i}_PACKAGES="{shell_escape(packages)}"')
             print(f'DESKTOP_REPO_PREFS_{i}_PRIORITY="{priority}"')
 
 

--- a/tools/modules/desktops/yaml/bianbu.yaml
+++ b/tools/modules/desktops/yaml/bianbu.yaml
@@ -12,19 +12,43 @@ repo:
   components: [main, universe, restricted, multiverse]
   key_url: "https://archive.spacemit.com/bianbu/bianbu-archive-keyring.gpg"
   keyring: "/usr/share/keyrings/bianbu-archive-keyring.gpg"
-  # APT pin preferences — SpacemiT's ported archive must outrank the
-  # distro archive for the K1 RISC-V platform bits. Priority >1000
-  # also allows downgrades from the distro to SpacemiT's version.
+  # APT pin preferences — Bianbu's archive ships a Mesa fork (24.01bbx)
+  # with the PVR DRI backend that GNOME Shell needs on the SpacemiT K1.
+  # The upstream Mesa in the distro archive lacks that backend, so the
+  # whole Mesa/EGL/DRM stack must be resolved from archive.spacemit.com.
+  #
+  # We pin by archive hostname rather than by Suite/Origin: Bianbu's
+  # Release files set `Suite:` to the full snapshot path
+  # (e.g. `noble/snapshots/v2.3`), which changes every snapshot bump,
+  # and the snapshot version is encoded per release in this file's
+  # `releases:` block — pinning by host stays correct across version
+  # bumps. Priority >1000 lets apt downgrade if the distro archive
+  # ever ships a newer Mesa.
   preferences:
-    - origin: Spacemit
-      suite: mantic-spacemit
-      priority: 1200
-    - origin: Spacemit
-      suite: mantic-porting
-      priority: 1100
-    - origin: Spacemit
-      suite: mantic-customization
-      priority: 1100
+    # Glob-based to cover both runtime libs and their -dev variants. Mesa's
+    # internal packaging uses strict =-version dependencies between the
+    # runtime and the -dev side, so pinning only the runtime makes any
+    # request for a -dev package (transitively, e.g. via bianbu-development
+    # in the full tier) unsatisfiable. Pinning the full glob keeps every
+    # Mesa-stack version coherent.
+    #
+    # Bianbu doesn't ship every name these globs match (e.g. libxatracker*,
+    # libegl1-amdgpu-mesa-drivers); those entries are inert — apt only
+    # applies the pin when the package actually exists in the pinned
+    # archive, otherwise it resolves at default priority.
+    - packages:
+        - "libgl1*"      # libgl1, libgl1-mesa-dri, libgl1-mesa-dev, libgl1-amber-dri
+        - "libegl*"      # libegl1, libegl-mesa0, libegl-dev, libegl1-mesa-dev
+        - "libglx*"      # libglx0, libglx-mesa0, libglx-dev
+        - "libgbm*"      # libgbm1, libgbm-dev
+        - "libglvnd*"    # libglvnd0, libglvnd-dev, libglvnd-core-dev
+        - "libgles*"     # libgles1, libgles2, libgles-dev, libgles2-mesa-dev
+        - "libosmesa*"   # libosmesa6, libosmesa6-dev
+        - "libglapi*"    # libglapi-mesa
+        - "libdrm*"      # libdrm2, libdrm-{amdgpu1,common,nouveau2,radeon1,dev}
+        - "mesa-*"       # mesa-{vulkan,vdpau}-drivers, mesa-common-dev
+      origin_host: archive.spacemit.com
+      priority: 1001
 
 tiers:
   minimal:
@@ -35,6 +59,15 @@ tiers:
       - k1x-vpu-firmware
       - spacemit-uart-bt
       - spacemit-modules-usrload
+      # Mesa/EGL from Bianbu (24.01bbx) — contains the PVR DRI backend
+      # that GNOME Shell needs (libEGL → Mesa DRI → img-gpu-powervr).
+      # The upstream Mesa in Armbian does not ship this backend.
+      - libegl-mesa0
+      - libglapi-mesa
+      - libgbm1
+      - libgl1-mesa-dri
+      - libglx-mesa0
+      - mesa-vulkan-drivers
   mid:
     packages:
       # fuller desktop + optional camera stack


### PR DESCRIPTION
## Summary

Make the Bianbu desktop on the SpacemiT K1 actually work end-to-end. Four logical commits:

1. **Schema extension** — `repo.preferences` learns per-package + host-based pinning.
2. **Bianbu Mesa pinning** — pull Mesa from Bianbu's archive so GNOME Shell can render via PVR DRI.
3. **Bianbu wallpaper** — minimal dconf postinst so installed images look like Armbian.
4. **DE-detection fix + Bianbu menu entries** — Desktops submenu was showing GNOME options on a Bianbu install; fix the dpkg detector, populate Bianbu's own management entries, and round out the install slots so Bianbu shows minimal/mid/full like every other DE.

## Why each piece exists

### 1. Schema: per-package + host-based pinning

`repo.preferences` previously only spoke release-form pins (`Pin: release o=<origin>, n=<suite>`), which require the upstream Release file's `Suite:` field to be stable. Bianbu sets `Suite:` to the full snapshot path (`noble/snapshots/v2.3`), so a release-form pin would go stale on every snapshot bump. Earlier iterations on this branch chased that target through `mantic-*` → `noble` → `noble/snapshots/v2.3` and ran into exactly that problem.

Two new optional fields per entry:

| Field | Purpose |
|---|---|
| `packages:` | List of package names or apt globs (`libdrm*`). Joined into the `Package:` line. Omitted → applies to `*`. Provided-but-all-invalid → entry dropped with a warning (no silent widening to `*`). |
| `origin_host:` | Renders `Pin: origin <host>`. Mutually exclusive with `origin:` + `suite:`. |

Existing release-form pins (any other DE YAML, currently none) render unchanged.

### 2. Bianbu Mesa pinning

`img-gpu-powervr` only ships PVR user-space libs. GNOME Shell reaches the GPU via:

```
libEGL → Mesa DRI → img-gpu-powervr
```

The middle hop needs a Mesa build that carries the PVR DRI backend. The upstream Mesa in the distro archive does not — Bianbu's `24.01bbx` fork does. Without it, the EGL/DRI hand-off fails and the desktop won't come up.

Two changes to bianbu.yaml:

- **Add explicit Mesa runtime libs to the minimal tier** so the desktop meta-package's deps don't have to pull them in by accident.
- **Add a per-package APT pin against `archive.spacemit.com`** using the new schema. Glob patterns cover the runtime libs *and their `-dev` counterparts* — the explicit-name attempts that came earlier on this branch broke `libgbm-dev` against the distro `libgbm1` because the runtime was pinned but `-dev` was not. Mesa's strict `=`-version inter-deps need both sides to come from the same archive.

```yaml
preferences:
  - packages:
      - "libgl1*"
      - "libegl*"
      - "libglx*"
      - "libgbm*"
      - "libglvnd*"
      - "libgles*"
      - "libosmesa*"
      - "libglapi*"
      - "libdrm*"
      - "mesa-*"
    origin_host: archive.spacemit.com
    priority: 1001
```

Verified against `archive.spacemit.com/bianbu/dists/noble/snapshots/v2.3/main/binary-riscv64/Packages.gz` that Bianbu ships matching `-dev` variants of every glob.

**Out of scope:** the YAML's `resolute` release block is stale — the archive has no `resolute*/snapshots/v3.0/` at all (only `resolute-customization` and `resolute-porting` at `v4.0betaN`). That's a separate fix; this PR pins only the noble side.

### 3. Bianbu wallpaper

The branding step looks for `postinst/<de>.sh` and runs it. There was no `bianbu.sh`, so installs went out wearing Bianbu's stock background. New `postinst/bianbu.sh` writes the dconf override for the GNOME background and screensaver — minimal scope on purpose: Bianbu ships its own opinionated favorites/theme/panel from SpacemiT and we leave those alone.

`picture-uri-dark` is set explicitly because Bianbu defaults to dark mode under GNOME 46.

### 4. DE-detection fix + Bianbu menu entries

`module_desktops status de=<X>` is the gate every Desktops submenu entry runs in its `condition` field. The old check was a plain `dpkg -l "$DESKTOP_PRIMARY_PKG" | grep ^ii`, which misfires whenever two desktops share a primary-tier package — exactly the case here, since Bianbu's `bianbu-desktop-minimal-en` pulls `gnome-session` as a dependency. The Desktops menu would offer "Uninstall GNOME" and "Change GNOME to full" while the installed DE was actually Bianbu, and clicking them would tear down packages Bianbu owns.

Three coupled changes (the fix alone leaves the user with an empty submenu and a single mid-tier install entry):

- **`_module_desktops_is_installed`** routes through three layers:
  1. `/etc/armbian/desktop/<de>.tier` exists → installed (authoritative; written by `install`, removed by `remove`).
  2. A different DE has its marker present → not installed (tiebreaker against dpkg when desktops share packages).
  3. No markers anywhere AND `DESKTOP_PRIMARY_PKG` is dpkg-installed → legacy fallback for installs done before the marker convention or via apt directly.
- **Six new management entries** in `config.system.json` (`BIAN02` Uninstall, `BIAN03/04` autologin on/off, `BIAN07/08/09` change-tier minimal/mid/full) following the GNOME pattern.
- **Install-slot cleanup**: `BIAN01` was the only Bianbu install entry and was misnamed — labelled "Install Bianbu" with `tier=mid`, where every other DE's slot 01 is `minimal`. Repointed `BIAN01` to `tier=minimal` and added `BIAN05` (mid) and `BIAN06` (full) so a clean-install user sees the full minimal/mid/full choice on the install menu instead of a single ambiguous entry.

## Test plan

- [x] Build a Bianbu image with the `mid` tier and boot on a SpacemiT K1 board.
- [x] Confirm GNOME Shell starts (no fallback to llvmpipe / no black screen).
- [x] Confirm `apt-cache policy libgl1-mesa-dri` shows priority 1001 against `archive.spacemit.com`.
- [x] Confirm `apt-cache policy libgbm-dev` matches `libgbm1` versions (no `-dev` ↔ runtime split).
- [x] On a clean install, `armbian-config` → System → Desktops shows three Bianbu install entries (minimal / mid / full).
- [x] After install, `armbian-config` → System → Desktops shows Bianbu management entries (Uninstall, autologin, tier change) and no GNOME entries.
- [x] After install, the Armbian wallpaper appears (verify with `dconf dump /org/gnome/desktop/background/`).
- [ ] Schema regression: any existing release-form pin in another DE YAML renders identically to before this PR.

## History

This branch went through several dead-ends (chasing `Suite:` strings, partial-pin dep collisions). Earlier exploratory commits have been squashed into the four logical changes above; the messy iteration is preserved in the PR's force-push history if anyone wants the trail.