### PR TITLE
desktops: pass --allow-downgrades on pinned package install

### DIFF
--- a/tools/modules/desktops/module_desktops.sh
+++ b/tools/modules/desktops/module_desktops.sh
@@ -581,14 +581,26 @@ function module_desktops() {
 			# a desktop and then flipping default.target to graphical
 			# leaves the next boot pinned to a graphical target with
 			# no working DM, which is a black-screen regression.
-			if ! pkg_install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" ${DESKTOP_PACKAGES}; then
+			#
+			# --allow-downgrades is required for DEs whose per-DE pin
+			# (written by module_desktop_repo above) outranks the distro
+			# at priority >1000 — the whole point of those pins is to
+			# pull packages from a vendor archive even when the distro
+			# ships a *newer* version. Without --allow-downgrades, apt
+			# refuses with "Packages were downgraded and -y was used
+			# without --allow-downgrades" and the install aborts.
+			# Bianbu / SpacemiT K1 hits this with libdrm pulled from
+			# archive.spacemit.com. Flag is a no-op for DEs without a
+			# pin, since apt only picks a downgrade when explicitly
+			# directed to.
+			if ! pkg_install --allow-downgrades -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" ${DESKTOP_PACKAGES}; then
 				echo "Error: ${de} package install failed; aborting before any system state is changed" >&2
 				return 1
 			fi
 
 			# install and register display manager
 			if [[ -n "$DESKTOP_DM" && "$DESKTOP_DM" != "none" ]]; then
-				if ! pkg_install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" "$DESKTOP_DM"; then
+				if ! pkg_install --allow-downgrades -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" "$DESKTOP_DM"; then
 					echo "Error: ${DESKTOP_DM} install failed; aborting before flipping systemd target" >&2
 					return 1
 				fi
@@ -1346,7 +1358,11 @@ _module_desktops_change_tier() {
 		else
 			echo "Upgrading ${de} from ${current} to ${target} (${#to_install[@]} new packages)"
 			ACTUALLY_INSTALLED=()
-			if ! pkg_install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" "${to_install[@]}"; then
+			# --allow-downgrades for the same reason as the initial
+			# install path: the per-DE pin (still in effect during a
+			# tier upgrade) can resolve some packages to an older
+			# vendor-archive version, and apt -y refuses without it.
+			if ! pkg_install --allow-downgrades -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" "${to_install[@]}"; then
 				echo "Error: pkg_install failed during upgrade" >&2
 				return 1
 			fi


### PR DESCRIPTION
## Summary

Image build [run 25250450338](https://github.com/armbian/os/actions/runs/25250450338) hit:

```
The following packages will be DOWNGRADED:
   libdrm-common libdrm2
E: Packages were downgraded and -y was used without --allow-downgrades.
Error: bianbu package install failed; aborting before any system state is changed
```

The downgrade is intentional — Bianbu's `repo.preferences` block (added in #897) pins the Mesa stack against `archive.spacemit.com` at priority 1001, deliberately pulling SpacemiT's older `libdrm2`/`libdrm-common` over the distro's newer ones so the whole Mesa stack stays on a single BSP-aligned version. apt resolves it correctly, it just refuses to act with bare `-y` once the resolution involves downgrades.

## Fix

Add `--allow-downgrades` to the three `pkg_install` call sites that run after the per-DE pin file is in place:

- main `DESKTOP_PACKAGES` install
- display-manager install
- tier-upgrade install (set-tier path; pin is still in place during a cross-tier package add)

The flag is a no-op for DEs whose YAML carries no pin (apt only resolves to a downgrade when explicitly directed to), so it's scoped to the install path that benefits without touching `pkg_install` itself or any other apt user.

## Skipped

- The armbian-plymouth-theme install on the live-system path — specific Armbian-archive package, no pin-driven downgrade scenario.
- The global `_module_desktops_write_apt_pin` path (apt.armbian.com snap-shim swap) — it pins at 1001 too, but acts on packages where the distro version is a snap-transitional stub rather than a real older build, so apt's resolution doesn't classify the swap as a downgrade. That pin has been working as-is for years; not changing it.

## Test plan

- [ ] Re-run the failed `armbian/os` job and confirm the `rootfs-riscv64-noble-bianbu-desktop-mid` chunk now completes through the chrooted `module_desktops install de=bianbu tier=mid mode=build` call.
- [ ] Install of any non-pinned DE (xfce, gnome, mate…) on a clean image: no behavioural change vs main, since `--allow-downgrades` only fires when apt would actually downgrade.
- [ ] Tier upgrade of an installed bianbu (`set-tier de=bianbu tier=full`): completes without the same downgrade-refusal error.