### PR TITLE
desktops/bianbu: re-enable systemd suspend on K1

### DIFF
--- a/tools/modules/desktops/postinst/bianbu.sh
+++ b/tools/modules/desktops/postinst/bianbu.sh
@@ -40,3 +40,23 @@ dconf update
 if [ -d /usr/share/glib-2.0/schemas ]; then
 	glib-compile-schemas /usr/share/glib-2.0/schemas
 fi
+
+# Re-enable systemd suspend. SpacemiT ships a sleep.conf with
+# AllowSuspend=no on the K1 so `systemctl suspend` fails with
+# "Sleep verb 'suspend' is disabled by config". Suspend does work
+# on shipped K1 boards (verified on musebook), so drop a drop-in
+# that re-enables it. Path is sleep.conf.d/ so an upgrade of the
+# Bianbu-shipped config doesn't clobber the override.
+install -d /etc/systemd/sleep.conf.d
+cat > /etc/systemd/sleep.conf.d/99-armbian-allow-suspend.conf <<- 'EOF'
+	# Managed by armbian-config (module_desktops, bianbu postinst).
+	# Re-enables suspend on Bianbu/K1 — SpacemiT's stock sleep.conf
+	# disables it. Remove this file to fall back to the SpacemiT
+	# default.
+	[Sleep]
+	AllowSuspend=yes
+EOF
+# Pick up the new value without forcing a daemon-reload that would
+# disturb running units in the chrooted build environment; logind
+# re-reads sleep.conf on each `systemctl suspend` invocation, so the
+# override is live on first boot regardless.


### PR DESCRIPTION
## Summary

Drop a `/etc/systemd/sleep.conf.d/99-armbian-allow-suspend.conf` from the Bianbu postinst that sets `AllowSuspend=yes`, overriding SpacemiT's stock `AllowSuspend=no` and making the suspend button in GNOME (and `systemctl suspend`, lid-close, etc.) actually work.

## Why

A freshly installed Bianbu desktop exposes a Suspend entry in the GNOME power menu, but clicking it silently no-ops with:

```
Call to Suspend failed: Sleep verb 'suspend' is disabled by config
```

The cause is in `/etc/systemd/sleep.conf` shipped by Bianbu — it carries `AllowSuspend=no`. The kernel and BSP do support suspend; SpacemiT just gates it off, presumably for edge-case resume reliability. Verified on a Musebook K1 board: with `AllowSuspend=yes` the system suspends and resumes cleanly via the GNOME menu.

## How

The override goes into `/etc/systemd/sleep.conf.d/` rather than rewriting the SpacemiT-shipped `sleep.conf`:

- A `bianbu-*` package upgrade replacing `sleep.conf` won't clobber the override.
- A user who hits resume problems on some other K1 board / firmware combo can simply `rm /etc/systemd/sleep.conf.d/99-armbian-allow-suspend.conf` to fall back to SpacemiT's default.

No `systemctl daemon-reload` is fired — logind re-reads `sleep.conf` on every suspend call, so the new value is live on first boot, and skipping the reload avoids disturbing running units in the chroot environment where this postinst also runs at build time.

## Test plan

- [x] On a Musebook K1 running Bianbu desktop: with this drop-in present, the GNOME Suspend menu entry, `systemctl suspend`, and lid-close all suspend the system; resume completes cleanly.
- [ ] Re-test on a different K1 board (Banana Pi F3 / MuseBook / OrangePi RV2) to confirm resume works there too. If it doesn't, the user removes one file — no permanent state change beyond the single drop-in.
- [ ] On a clean install of any non-bianbu DE: drop-in is not deployed (this lives in `postinst/bianbu.sh` only).