### PR TITLE
tests: add Bianbu desktop install/remove test

### DIFF
--- a/tests/BIAN01.conf
+++ b/tests/BIAN01.conf
@@ -1,0 +1,10 @@
+ENABLED=true
+RELEASE="noble"
+TESTARCH="riscv64"
+TESTNAME="Bianbu desktop"
+
+testcase() {(
+	set -e
+	./bin/armbian-config --api module_desktops install de=bianbu tier=full
+	./bin/armbian-config --api module_desktops remove  de=bianbu
+)}


### PR DESCRIPTION
## Summary

Add `tests/BIAN01.conf` mirroring the existing `XFCE01.conf` / `GNME01.conf` shape — install Bianbu at the full tier, remove it, both must exit clean.

Scoped to `RELEASE=noble + TESTARCH=riscv64` (the only combination `bianbu.yaml` advertises support for), so on any other board / image the test runner skips it — same convention `GNME01.conf` already uses with `TESTARCH=arm64,amd64`.

## Why now

The Bianbu install path picked up several non-trivial pieces in the last few PRs:

- per-package + host APT pin against `archive.spacemit.com` (#897)
- `--allow-downgrades` on pinned `pkg_install` calls (#899)
- bianbu postinst writing the Armbian wallpaper + the systemd-sleep `AllowSuspend=yes` override (#900)
- install/remove tracking via `/etc/armbian/desktop/<de>.{tier,packages}`
- marker-file-aware DE detection in `module_desktops status` (#897)

A single install→remove smoke test covers all of those at once and would have caught the `libdrm` downgrade refusal that broke the `armbian/os` build last week.

## Test plan

- [ ] Tested locally on a SpacemiT K1 board (musebook) running noble: `./tests/run.sh BIAN01` (or however the runner is invoked) completes successfully.
- [ ] On a non-riscv64 / non-noble target: the test is skipped (TESTARCH/RELEASE filter), no failure.