### PR TITLE
desktops/bianbu: purge gnome-initial-setup after install

### DIFF
--- a/tools/modules/desktops/yaml/bianbu.yaml
+++ b/tools/modules/desktops/yaml/bianbu.yaml
@@ -68,6 +68,13 @@ tiers:
       - libgl1-mesa-dri
       - libglx-mesa0
       - mesa-vulkan-drivers
+    packages_uninstall:
+      # GNOME's first-run wizard (Welcome / account setup) is pulled in
+      # as a dep of Bianbu's GNOME stack. Armbian images already do
+      # their own first-boot user setup via the firstrun service, so
+      # the GNOME wizard is redundant and confuses users with a second
+      # account-creation prompt. Purged after install.
+      - gnome-initial-setup
   mid:
     packages:
       # fuller desktop + optional camera stack


### PR DESCRIPTION
## Summary

Add `gnome-initial-setup` to Bianbu's minimal-tier `packages_uninstall` list, so it gets purged at the end of `module_desktops install de=bianbu`. The list is already wired through the parser ([parse_desktop_yaml.py:296-319](tools/modules/desktops/scripts/parse_desktop_yaml.py#L296-L319)) to a `pkg_remove` (apt autopurge) call ([module_desktops.sh:657-659](tools/modules/desktops/module_desktops.sh#L657-L659)).

## Why

`bianbu-desktop*` pulls `gnome-initial-setup` as a dep. On first GUI boot the GNOME "Welcome" wizard runs, prompting the user to create an account / pick locale / sign in to a Google account. Armbian images already do their own first-boot setup via the firstrun service (account, locale, keyboard, network), so the GNOME wizard is redundant and gives the user a confusing second account-creation prompt.

## Why this knob

`packages_uninstall` (rather than e.g. `packages_remove`) because we *do* want apt to install the dep originally — purging happens after the install completes, with apt's `autopurge` so any orphaned helpers (e.g. `gnome-initial-setup-l10n` if pulled in) are cleaned up too. Runs in build mode (it's part of the install action, not the postinst, which is skipped under CI/container env). Idempotent — for a future release where Bianbu drops the dep, this entry becomes a no-op rather than a regression.

## Verified

```
$ python3 tools/modules/desktops/scripts/parse_desktop_yaml.py tools/modules/desktops/yaml bianbu noble riscv64 --tier minimal | grep UNINSTALL
DESKTOP_PACKAGES_UNINSTALL="gnome-initial-setup"
```

## Test plan

- [ ] Build a Bianbu image, boot on a Musebook, confirm no GNOME first-run wizard appears (the Armbian firstrun runs and completes normally).
- [ ] `dpkg -l | grep gnome-initial-setup` returns no rows post-install.
- [ ] Other DEs (XFCE/GNOME/MATE) install unchanged — `packages_uninstall` is per-DE YAML and unrelated to them.