### PR TITLE
ci/maintenance-unit-tests: list docker state on the runner

### DIFF
--- a/.github/workflows/maintenance-unit-tests.yml
+++ b/.github/workflows/maintenance-unit-tests.yml
@@ -242,11 +242,28 @@ jobs:
           docker system df || true
           echo "::endgroup::"
 
-          # Once we know the pattern (e.g. images matching
-          # ghcr.io/armbian/repository-update:* and stopped containers
-          # whose Names begin with the test ids we generate) the
-          # removal commands go here. Same step location as in
-          # gradle-emulated.
+          echo "::group::Cleanup: orphaned 'Created' containers (image ref is bare hash)"
+          # Pattern: stopped-but-never-started containers whose Image
+          # column is a 12-char hex ID (no repo:tag). These are
+          # leftovers from prior runs whose image was already removed
+          # but whose container record is stuck in 'Created'. Tagged
+          # images are deliberately skipped — a 'Created' container
+          # with a tagged image (e.g. mysql:lts) may belong to the
+          # host operator and is mid-'docker create'.
+          #
+          # xargs -r no-ops on empty input; '|| true' so a transient
+          # docker hiccup doesn't fail the job.
+          docker ps -a --filter 'status=created' --format '{{.ID}} {{.Image}}' \
+            | awk '$2 ~ /^[0-9a-f]{12}$/ { print $1 }' \
+            | xargs -r docker rm \
+            || true
+          echo "::endgroup::"
+
+          # Future cleanups (test-image purge after tests finish,
+          # dangling-volume prune) belong in the 'stop' job — they're
+          # whole-workflow operations, not per-slot, and would
+          # otherwise race sibling matrix slots that still need the
+          # images.
 
       - name: "Initialize systemd"
         run: |
@@ -395,12 +412,28 @@ jobs:
           docker system df || true
           echo "::endgroup::"
 
-          # Once we know the pattern (e.g. images matching
-          # ghcr.io/armbian/repository-update:* and stopped containers
-          # whose Names begin with the test ids we generate) the
-          # removal commands go here, before the runner picks up the
-          # next job. Keep the listing too — it's cheap and helps
-          # debug "why did the cleanup not delete X" cases.
+          echo "::group::Cleanup: orphaned 'Created' containers (image ref is bare hash)"
+          # Pattern: stopped-but-never-started containers whose Image
+          # column is a 12-char hex ID (no repo:tag). These are
+          # leftovers from prior runs whose image was already removed
+          # but whose container record is stuck in 'Created'. Tagged
+          # images are deliberately skipped — a 'Created' container
+          # with a tagged image (e.g. mysql:lts) may belong to the
+          # host operator and is mid-'docker create'.
+          #
+          # xargs -r no-ops on empty input; '|| true' so a transient
+          # docker hiccup doesn't fail the job.
+          docker ps -a --filter 'status=created' --format '{{.ID}} {{.Image}}' \
+            | awk '$2 ~ /^[0-9a-f]{12}$/ { print $1 }' \
+            | xargs -r docker rm \
+            || true
+          echo "::endgroup::"
+
+          # Future cleanups (test-image purge after tests finish,
+          # dangling-volume prune) belong in the 'stop' job — they're
+          # whole-workflow operations, not per-slot, and would
+          # otherwise race sibling matrix slots that still need the
+          # images.
 
       # Emulated and native jobs share the same self-hosted runner
       # and the same _work/<repo>/<repo>/ path. A previous native

--- a/.github/workflows/maintenance-unit-tests.yml
+++ b/.github/workflows/maintenance-unit-tests.yml
@@ -318,6 +318,46 @@ jobs:
     timeout-minutes: 210
     steps:
 
+      # Diagnostic only for now — list docker state on the runner so
+      # we can see which containers / images survive across runs and
+      # pick a precise removal pattern before adding any cleanup.
+      # gradle-emulated is the right place: its steps run on the
+      # self-hosted host (no job-level `container:`) and can talk to
+      # the host docker daemon. gradle-native's steps run inside a
+      # container and only see that container's filesystem, so a
+      # listing there would be empty.
+      #
+      # Output is grouped under `::group::` so each section is
+      # collapsed-by-default in the GHA log UI; expand the section
+      # whose pattern you want to inspect. `|| true` on every command
+      # so a missing socket / docker daemon outage doesn't fail the
+      # job — this step is observational, not load-bearing.
+      - name: "Show docker state on the runner"
+        shell: bash
+        run: |
+          echo "::group::Running containers (docker ps)"
+          docker ps --format 'table {{.ID}}\t{{.Image}}\t{{.Status}}\t{{.Names}}\t{{.RunningFor}}' || true
+          echo "::endgroup::"
+
+          echo "::group::All containers, incl. stopped (docker ps -a)"
+          docker ps -a --format 'table {{.ID}}\t{{.Image}}\t{{.Status}}\t{{.Names}}\t{{.RunningFor}}' || true
+          echo "::endgroup::"
+
+          echo "::group::Images (docker images)"
+          docker images --format 'table {{.Repository}}:{{.Tag}}\t{{.ID}}\t{{.CreatedSince}}\t{{.Size}}' || true
+          echo "::endgroup::"
+
+          echo "::group::Disk usage (docker system df)"
+          docker system df || true
+          echo "::endgroup::"
+
+          # Once we know the pattern (e.g. images matching
+          # ghcr.io/armbian/repository-update:* and stopped containers
+          # whose Names begin with the test ids we generate) the
+          # removal commands go here, before the runner picks up the
+          # next job. Keep the listing too — it's cheap and helps
+          # debug "why did the cleanup not delete X" cases.
+
       # Emulated and native jobs share the same self-hosted runner
       # and the same _work/<repo>/<repo>/ path. A previous native
       # job (which uses job-level `container:`) runs as root inside

--- a/.github/workflows/maintenance-unit-tests.yml
+++ b/.github/workflows/maintenance-unit-tests.yml
@@ -199,10 +199,54 @@ jobs:
     timeout-minutes: 90
     container:
       image: ${{ matrix.server.docker_image }}
-      options: --privileged --security-opt seccomp=unconfined --tmpfs /tmp --tmpfs /run --tmpfs /run/lock
+      # Host docker socket + CLI bind-mounted so the in-container
+      # diagnostic step below can list the runner host's docker
+      # state. Without this, an in-container `docker ps` has no
+      # daemon to talk to. Trade-off: container is already
+      # `--privileged`, and adding the socket effectively grants
+      # host-root (a malicious test could `docker run -v /:/host`).
+      # Acceptable because the test code is ours; revisit if test
+      # images ever start running untrusted code.
+      options: --privileged --security-opt seccomp=unconfined --tmpfs /tmp --tmpfs /run --tmpfs /run/lock -v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker:ro
       env:
         DBUS_SESSION_BUS_ADDRESS: unix:path=/run/bus/bus.sock
     steps:
+
+      # Same diagnostic step as gradle-emulated. Native runs inside
+      # the per-arch test container, but the container.options above
+      # bind-mount the host docker socket and CLI so this step can
+      # still see the runner host's images / containers. Useful on
+      # the arm64 self-hosted runner — emulated jobs only run on
+      # the amd64 host, so without this step the arm64 runner's
+      # docker leftovers were never observed.
+      #
+      # `|| true` on every command — observational, must not fail
+      # the job. Output grouped under `::group::` for collapsed
+      # log rendering.
+      - name: "Show docker state on the runner"
+        shell: bash
+        run: |
+          echo "::group::Running containers (docker ps)"
+          docker ps --format 'table {{.ID}}\t{{.Image}}\t{{.Status}}\t{{.Names}}\t{{.RunningFor}}' || true
+          echo "::endgroup::"
+
+          echo "::group::All containers, incl. stopped (docker ps -a)"
+          docker ps -a --format 'table {{.ID}}\t{{.Image}}\t{{.Status}}\t{{.Names}}\t{{.RunningFor}}' || true
+          echo "::endgroup::"
+
+          echo "::group::Images (docker images)"
+          docker images --format 'table {{.Repository}}:{{.Tag}}\t{{.ID}}\t{{.CreatedSince}}\t{{.Size}}' || true
+          echo "::endgroup::"
+
+          echo "::group::Disk usage (docker system df)"
+          docker system df || true
+          echo "::endgroup::"
+
+          # Once we know the pattern (e.g. images matching
+          # ghcr.io/armbian/repository-update:* and stopped containers
+          # whose Names begin with the test ids we generate) the
+          # removal commands go here. Same step location as in
+          # gradle-emulated.
 
       - name: "Initialize systemd"
         run: |

--- a/tests/postgres.conf
+++ b/tests/postgres.conf
@@ -5,7 +5,7 @@ TESTNAME="PostgreSQL install"
 
 testcase() {(
 	set -e
-	./bin/armbian-config --api module_postgres remove
+	./bin/armbian-config --api module_postgres purge
 	./bin/armbian-config --api module_postgres install
 	./bin/armbian-config --api module_postgres status
 	./bin/armbian-config --api module_postgres purge


### PR DESCRIPTION
## Summary

Add a diagnostic-only step at the head of both `gradle-native` and `gradle-emulated` that prints the runner's current docker state — running and stopped containers, all images with size and age, and `docker system df` for the reclaimable / unreclaimable totals.

Symmetric coverage is the point: the amd64 self-hosted runner serves both gradle-native (amd64 tests) and gradle-emulated (armhf / riscv64 via qemu), so it's visible from either matrix. The **arm64** self-hosted runner serves only gradle-native — emulated jobs never fan out to it — so without a listing step in native too, the arm64 runner's docker leftovers stay invisible.

## Why now

The workflow's per-job containers and images aren't being torn down between runs on the self-hosted pool, so the runners accumulate stale `ghcr.io/armbian/repository-update:*` tags (and likely `alpine:3` from the pre-clean step at [maintenance-unit-tests.yml:332-336](.github/workflows/maintenance-unit-tests.yml#L332-L336)) over time. Before adding any cleanup commands we want to actually see what's leftover so the removal pattern targets only our images and not whatever else lives on the shared runner.

## Where the listing runs

| Job | Step location | Sees what |
|---|---|---|
| `gradle-emulated` | first step (before `Pre-clean root-owned leftovers`) | amd64 host docker (steps run host-side, no `container:` block) |
| `gradle-native` | first step (before `Initialize systemd`) | host docker via bind-mounted socket; covers both arm64 host (where only native runs) and amd64 host (extra view) |

## Native needed plumbing

`gradle-native` runs each step **inside** the per-arch test container, so the in-container docker CLI has nothing to talk to by default — `docker ps` would either error with "no such command" or "Cannot connect to the Docker daemon". To make the listing meaningful, two host paths are bind-mounted into the native container:

```yaml
options: --privileged
         --security-opt seccomp=unconfined
         --tmpfs /tmp --tmpfs /run --tmpfs /run/lock
         -v /var/run/docker.sock:/var/run/docker.sock
         -v /usr/bin/docker:/usr/bin/docker:ro
```

The CLI bind-mount works because the host runner OS and the test image are both Linux/glibc-compatible (Armbian's `repository-update:<release>-<arch>` images are Debian-derived); a static-CLI fallback would be cleaner but isn't needed today.

### Trade-off

Native test containers were already `--privileged`. Adding the docker socket on top means a malicious test could `docker run -v /:/host` and step out onto the host filesystem with root. That's a real boundary change vs today's "no host docker visibility at all" posture.

The mitigation is that this workflow only runs *our* test code — the `tests/*.conf` files in this repo plus `armbian-config` itself — so the trust boundary is already at "trust contributors who can land code in this repo via PR". A comment in `container.options` flags the assumption so a future move to running untrusted test code would have to step through the warning before the socket exposure.

If that trade-off isn't acceptable, alternatives:

- **Install docker CLI inside the test image** (one-off per image build) and skip the bind-mount of `/usr/bin/docker`, but the socket is still required for any cross-container view. Same boundary issue.
- **Add a separate single-host diagnostic job** that runs once per workflow on each runner host. Loses the per-(release × arch) fan-out — fine if you don't actually need per-slot listings, but you said "matrix" so I went with fan-out.
- **Keep the listing in `gradle-emulated` only**, which is the v1 commit on this branch. arm64 host stays uncovered.

## Output shape

Each bucket is wrapped in `::group::` / `::endgroup::` so the log UI collapses them by default — expand only the section relevant to a given investigation:

```
::group::Running containers (docker ps)
CONTAINER ID   IMAGE   STATUS   NAMES   RUNNING FOR
…
::endgroup::
::group::All containers, incl. stopped (docker ps -a)
…
::endgroup::
::group::Images (docker images)
REPOSITORY:TAG                                        IMAGE ID       CREATED SINCE   SIZE
…
::endgroup::
::group::Disk usage (docker system df)
…
::endgroup::
```

Every docker call ends in `|| true` — the step is observational and must not fail the job if the daemon hiccups or the bind-mounted CLI can't exec for some reason.

## Next step (separate commit)

Once a couple of runs have shown the leftover pattern, targeted removal slots in below the listing in the same step. A placeholder comment marks the intent in both jobs so the next reader knows where the cleanup lands. Probable shape:

```bash
# Remove our stale images, leave the runner's other state alone
docker images --format '{{.Repository}}:{{.Tag}} {{.ID}}' \
  | awk '$1 ~ /^ghcr\.io\/armbian\/repository-update:/ {print $2}' \
  | xargs -r docker rmi
```

Deliberately not in this PR — pattern needs to be confirmed first across both runner hosts.

## Commits

- `e14ab47c` — diagnostic step in `gradle-emulated` (amd64 host coverage)
- `ba5a340b` — same step in `gradle-native` + socket/CLI bind-mounts (arm64 host coverage + extra amd64 view)

## Test plan

- [x] Trigger the workflow (`workflow_dispatch` on this branch); on each native and emulated slot, expand the four log groups and confirm there's no false-positive "operation not permitted" / socket-access error.
- [x] On the arm64 self-hosted runner specifically, confirm the listing step actually produces output (the bind-mount path was new there).
- [ ] After the workflow finishes, run it a second time and look at the deltas in the listings — the images that grew (or rather, the ones that didn't shrink) are the candidates for the removal pattern.
- [ ] Compare the listings from a native amd64 slot and an emulated armhf slot — they should show identical host docker state since they share the runner host.