### PR TITLE
desktops: split light/dark wallpapers in gnome + bianbu postinsts

### DIFF
--- a/tools/modules/desktops/postinst/bianbu.sh
+++ b/tools/modules/desktops/postinst/bianbu.sh
@@ -6,9 +6,13 @@ set +e
 # we want to leave those alone. The only piece we override is the
 # wallpaper, so an installed image actually looks like Armbian.
 #
-# picture-uri-dark is set explicitly because Bianbu defaults to dark
-# mode under GNOME 46; without it the override only takes effect in
-# light mode and the user keeps seeing Bianbu's stock background.
+# Both picture-uri (light) and picture-uri-dark (dark) are set
+# explicitly. Bianbu defaults to dark mode under GNOME, and on
+# GNOME 42+ the shell reads picture-uri-dark when the appearance is
+# dark and ignores picture-uri entirely — without picture-uri-dark the
+# Armbian override only takes effect in light mode and the user keeps
+# seeing Bianbu's stock background. Light and dark Armbian variants
+# track GNOME's color-scheme automatically.
 
 keys=/etc/dconf/db/local.d/00-bg
 profile=/etc/dconf/profile/user
@@ -19,7 +23,7 @@ install -Dv /dev/null "$profile"
 cat >> "$keys" <<- EOF
 
 	[org/gnome/desktop/background]
-	picture-uri='file:///usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-3840x2160.jpg'
+	picture-uri='file:///usr/share/backgrounds/armbian/armbian18-Dre0x-Minum-light-3840x2160.jpg'
 	picture-uri-dark='file:///usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-3840x2160.jpg'
 	picture-options='zoom'
 	primary-color='#456789'

--- a/tools/modules/desktops/postinst/gnome.sh
+++ b/tools/modules/desktops/postinst/gnome.sh
@@ -37,7 +37,8 @@ cat >> "$keys" <<- EOF
 	sleep-inactive-ac-timeout='0'
 
 	[org/gnome/desktop/background]
-	picture-uri='file:///usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-3840x2160.jpg'
+	picture-uri='file:///usr/share/backgrounds/armbian/armbian18-Dre0x-Minum-light-3840x2160.jpg'
+	picture-uri-dark='file:///usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-3840x2160.jpg'
 	picture-options='zoom'
 	primary-color='#456789'
 	secondary-color='#FFFFFF'


### PR DESCRIPTION
## Summary

The Armbian wallpaper does not show up on Ubuntu **resolute** (GNOME 47+) GNOME builds, while it does on **noble** (GNOME 46). Cause: GNOME 42+ added `picture-uri-dark` for `org.gnome.desktop.background`. When the session runs in dark appearance (default on resolute, and the default on Bianbu too), the shell reads `picture-uri-dark`, ignores `picture-uri`, and falls back to the schema default if `picture-uri-dark` is unset. The Armbian dconf seeds in [`gnome.sh`](tools/modules/desktops/postinst/gnome.sh) and [`bianbu.sh`](tools/modules/desktops/postinst/bianbu.sh) only set `picture-uri`.

Noble's GNOME 46 happens to fall back to `picture-uri` more leniently, which is why the regression only surfaced once resolute landed.

## Fix

In both gnome.sh and bianbu.sh, set both keys to the matching variants Armbian already ships under `/usr/share/backgrounds/armbian/`:

- `picture-uri` → `armbian18-Dre0x-Minum-light-3840x2160.jpg`
- `picture-uri-dark` → `armbian03-Dre0x-Minum-dark-3840x2160.jpg`

GNOME tracks the user's appearance setting and picks the matching one. The screensaver block doesn't change — `org.gnome.desktop.screensaver` has no `-dark` variant; the dark image stays the right default for the lock screen.

## Test plan

- [ ] Boot a fresh resolute/GNOME image. Default appearance is dark → dark wallpaper renders. Switch to light appearance → light wallpaper renders.
- [ ] Boot a fresh noble/GNOME image. Wallpaper still tracks the appearance setting; no regression.
- [ ] Boot a fresh Bianbu image (K1). Same expected behaviour — dark by default, swap to light works.
- [x] Live test on a running system without rebuilding (per-user, instant):
      ```
      gsettings set org.gnome.desktop.background picture-uri \
          'file:///usr/share/backgrounds/armbian/armbian18-Dre0x-Minum-light-3840x2160.jpg'
      gsettings set org.gnome.desktop.background picture-uri-dark \
          'file:///usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-3840x2160.jpg'
      ```