### PR TITLE
software: auto-configure SWAG reverse proxy for all modules with stock proxy-confs

### DIFF
--- a/tools/json/config.software.json
+++ b/tools/json/config.software.json
@@ -2106,6 +2106,45 @@
                             "author": "@armbian",
                             "condition": "module_dozzle status",
                             "help": "Dozzle purge"
+                        },
+                        {
+                            "id": "BSZ001",
+                            "description": "Beszel lightweight server monitoring hub",
+                            "short": "Beszel",
+                            "module": "module_beszel",
+                            "about": "This operation will install Beszel",
+                            "command": [
+                                "module_beszel install"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "! module_beszel status",
+                            "container_type": "docker",
+                            "help": "Beszel is a lightweight monitoring hub for SBC servers and Docker containers. https://beszel.dev"
+                        },
+                        {
+                            "id": "BSZ002",
+                            "description": "Beszel remove",
+                            "about": "This operation will remove Beszel",
+                            "command": [
+                                "module_beszel remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_beszel status",
+                            "help": "Beszel remove"
+                        },
+                        {
+                            "id": "BSZ003",
+                            "description": "Beszel purge",
+                            "about": "This operation will purge Beszel",
+                            "command": [
+                                "module_beszel purge"
+                            ],
+                            "status": "Stable",
+                            "author": "@armbian",
+                            "condition": "module_beszel status",
+                            "help": "Beszel purge"
                         }
                     ],
                     "help": "Real-time monitoring, collecting metrics, up-time status"

--- a/tools/modules/functions/module_docker_utils.sh
+++ b/tools/modules/functions/module_docker_utils.sh
@@ -142,6 +142,11 @@ docker_operation_progress() {
 	# Ensure Docker is available
 	docker_ensure_docker
 
+	# Ensure unbuffer is available (for real-time pull progress)
+	if ! command -v unbuffer >/dev/null 2>&1; then
+		pkg_install expect
+	fi
+
 	# Argument validation
 	if [[ -z "$operation" || -z "$target" ]]; then
 		dialog_msgbox "Usage Error" "Usage: docker_operation_progress <pull|rm|rmi> <target>\n\n  pull <image>   - Pull Docker image\n  rm <container> - Remove container\n  rmi <image>    - Remove image" 12 60
@@ -466,4 +471,119 @@ docker_operation_progress() {
 	rm -f "$error_file" "$rc_file"
 
 	return 0
+}
+
+#
+# Configure SWAG reverse proxy for a service
+# Usage: docker_configure_swag_proxy <servicename> [port] [protocol] [upstream_host]
+#
+# Parameters:
+#   servicename    - Name of the service (e.g., "transmission", "sonarr")
+#   port           - Optional: Override the default port in the proxy config
+#   protocol       - Optional: Override the protocol (http/https) in the proxy config
+#   upstream_host  - Optional: Override 'set $upstream_app …' in the proxy
+#                    config. Stock LSIO samples assume the service is on the
+#                    'lsio' bridge and resolve by container name; modules
+#                    that run with '--network=host' can't be addressed that
+#                    way, so we point at the host's IP (or any IP the SWAG
+#                    container can route to) here. Pass $LOCALIPADD or similar.
+#
+# Returns: 0 on success, 1 if proxy config not found or enabling failed
+#
+docker_configure_swag_proxy() {
+	local servicename="$1"
+	local port="$2"
+	local protocol="$3"
+	local upstream_host="$4"
+
+	# Check if SWAG container exists
+	if ! docker container ls -a --format "{{.Names}}" | grep -q "^swag$"; then
+		return 2
+	fi
+
+	# Check if SWAG has proxy config for this service (sample or actual)
+	local proxy_sample="/config/nginx/proxy-confs/${servicename}.subfolder.conf.sample"
+	local proxy_actual="/config/nginx/proxy-confs/${servicename}.subfolder.conf"
+
+	if docker exec swag test -f "$proxy_sample" 2>/dev/null; then
+		# Copy sample to actual config if it doesn't exist
+		if ! docker exec swag test -f "$proxy_actual" 2>/dev/null; then
+			docker exec swag cp "$proxy_sample" "$proxy_actual" 2>/dev/null
+		fi
+
+		# If port is specified, update it in the config
+		if [[ -n "$port" ]]; then
+			docker exec swag sed -i "s/set \\\$upstream_port [0-9]*/set \\\$upstream_port ${port}/g" "$proxy_actual" 2>/dev/null
+		fi
+
+		# If protocol is specified, update it in the config
+		if [[ -n "$protocol" ]]; then
+			docker exec swag sed -i "s/set \\\$upstream_proto [a-z]*/set \\\$upstream_proto ${protocol}/g" "$proxy_actual" 2>/dev/null
+		fi
+
+		# If upstream_host is specified, replace the LSIO bridge name
+		# in 'set $upstream_app …'. Required for --network=host
+		# services since the docker DNS can't resolve the container
+		# name from inside SWAG's lsio namespace.
+		if [[ -n "$upstream_host" ]]; then
+			docker exec swag sed -i "s|set \\\$upstream_app [^;]*|set \\\$upstream_app ${upstream_host}|g" "$proxy_actual" 2>/dev/null
+		fi
+
+		# Enable the proxy configuration
+		if docker exec swag touch "/config/nginx/proxy-confs/${servicename}.subfolder.conf.enabled" 2>/dev/null; then
+			# Reload nginx to apply
+			docker exec swag nginx -s reload >/dev/null 2>&1
+			return 0
+		fi
+		return 1
+	fi
+
+	return 1
+}
+
+#
+# Seed a custom SWAG subfolder proxy-conf sample inside the SWAG container.
+# Usage: docker_seed_swag_proxy_conf <servicename> <<'NGINX'
+#            location ^~ /<servicename> { … }
+#        NGINX
+#
+# Used for services that linuxserver/reverse-proxy-confs:master does NOT
+# ship a stock sample for (e.g. netbox, immich). Reads the conf body from
+# stdin and writes it to:
+#   /config/nginx/proxy-confs/<servicename>.subfolder.conf.sample
+# inside the SWAG container, where docker_configure_swag_proxy() picks
+# it up on its next call.
+#
+# Behaviour:
+#   - If the SWAG container isn't installed, returns 2 (no-op).
+#   - If a `.sample` is already present (whether stock LSIO or seeded by
+#     a prior call), returns 0 without overwriting — defer to upstream
+#     when it eventually ships one, and keep an admin's hand-edited
+#     sample intact across re-installs.
+#   - Otherwise writes the body and returns 0 on success, 1 on docker
+#     exec failure.
+#
+# Returns: 0 on success / no-op skip, 1 on failure, 2 if no SWAG.
+#
+docker_seed_swag_proxy_conf() {
+	local servicename="$1"
+
+	if ! docker container ls -a --format "{{.Names}}" | grep -q "^swag$"; then
+		return 2
+	fi
+
+	local proxy_sample="/config/nginx/proxy-confs/${servicename}.subfolder.conf.sample"
+
+	# Already there — let it be (LSIO upstream may have started shipping
+	# one between releases; the admin may have hand-edited it).
+	if docker exec swag test -f "$proxy_sample" 2>/dev/null; then
+		return 0
+	fi
+
+	# `docker exec -i ... sh -c "cat > FILE"` is the portable way to
+	# stream stdin into a file inside the container.
+	if docker exec -i swag sh -c "cat > '${proxy_sample}'" 2>/dev/null; then
+		return 0
+	fi
+	return 1
 }

--- a/tools/modules/functions/module_docker_utils.sh
+++ b/tools/modules/functions/module_docker_utils.sh
@@ -531,6 +531,12 @@ docker_configure_swag_proxy() {
 
 		# Enable the proxy configuration
 		if docker exec swag touch "/config/nginx/proxy-confs/${servicename}.subfolder.conf.enabled" 2>/dev/null; then
+			# Apply HTTP basic auth if the operator has run
+			# 'module_swag password' (which creates .htpasswd). We
+			# do this BEFORE the nginx reload so both changes land
+			# in a single SIGHUP and active connections aren't
+			# interrupted twice.
+			docker_swag_enable_basic_auth "$servicename"
 			# Reload nginx to apply
 			docker exec swag nginx -s reload >/dev/null 2>&1
 			return 0
@@ -539,6 +545,71 @@ docker_configure_swag_proxy() {
 	fi
 
 	return 1
+}
+
+#
+# Enable HTTP basic auth on a service's subfolder.conf.
+# Usage: docker_swag_enable_basic_auth <servicename>
+#
+# No-ops unless /config/nginx/.htpasswd exists inside SWAG (i.e. the
+# operator has already set a password via 'module_swag password').
+# Idempotent — safe to call repeatedly. Two cases:
+#   - LSIO stock confs ship `auth_basic` and `auth_basic_user_file`
+#     commented out. We uncomment them via sed.
+#   - Our docker_seed_swag_proxy_conf-seeded confs may not have those
+#     lines at all. We inject them just inside the location block.
+# We deliberately ONLY touch the htpasswd-flavoured auth_basic lines —
+# LSIO's templates also ship commented `include` lines for ldap /
+# authelia / authentik integrations which the operator may want to
+# enable separately.
+#
+# Caller is responsible for the nginx reload — this function only
+# edits the file. (Skipping the reload here lets configure_swag_proxy
+# batch its own touch+enable+reload into a single SIGHUP.)
+#
+# Returns: 0 always (best effort). 2 if SWAG not installed.
+#
+docker_swag_enable_basic_auth() {
+	local servicename="$1"
+
+	if ! docker container ls -a --format "{{.Names}}" | grep -q "^swag$"; then
+		return 2
+	fi
+
+	# No password set yet — leave the conf alone so the user can run
+	# 'module_swag password' later and have it apply retroactively.
+	if ! docker exec swag test -f /config/nginx/.htpasswd 2>/dev/null; then
+		return 0
+	fi
+
+	local conf="/config/nginx/proxy-confs/${servicename}.subfolder.conf"
+	if ! docker exec swag test -f "$conf" 2>/dev/null; then
+		return 0
+	fi
+
+	# Already active? Nothing to do.
+	if docker exec swag grep -qE '^[[:space:]]*auth_basic_user_file[[:space:]]+/config/nginx/\.htpasswd' "$conf" 2>/dev/null; then
+		return 0
+	fi
+
+	# Are the LSIO stock commented lines present? Uncomment them.
+	if docker exec swag grep -qE '^[[:space:]]*#auth_basic_user_file[[:space:]]+/config/nginx/\.htpasswd' "$conf" 2>/dev/null; then
+		docker exec swag sed -i \
+			-e 's|^\([[:space:]]*\)#\(auth_basic[[:space:]]\)|\1\2|' \
+			-e 's|^\([[:space:]]*\)#\(auth_basic_user_file[[:space:]]\)|\1\2|' \
+			"$conf" 2>/dev/null
+		return 0
+	fi
+
+	# Custom-seeded conf with no auth lines at all — inject them just
+	# inside the first `location ^~ /<service>` block.
+	docker exec swag sed -i \
+		"/^[[:space:]]*location[[:space:]]\\^~[[:space:]]\\/${servicename}/a\\
+\\tauth_basic \"Restricted\";\\
+\\tauth_basic_user_file /config/nginx/.htpasswd;" \
+		"$conf" 2>/dev/null
+
+	return 0
 }
 
 #

--- a/tools/modules/functions/module_env_init.sh
+++ b/tools/modules/functions/module_env_init.sh
@@ -141,6 +141,13 @@ function set_runtime_variables() {
 	LOCALIPADD=$(ip -4 addr show dev $DEFAULT_ADAPTER | awk '/inet/ {print $2}' | cut -d'/' -f1)
 	LOCALSUBNET=$(echo ${LOCALIPADD} | cut -d"." -f1-3).0/24
 
+	# Check if SWAG is installed and use its domain URL for display
+	# This replaces LOCALIPADD with the actual domain in menu URLs
+	SWAG_URL=""
+	if [[ -f "${SOFTWARE_FOLDER}/swag/config/SWAG_URL" ]]; then
+		SWAG_URL=$(cat "${SOFTWARE_FOLDER}/swag/config/SWAG_URL")
+	fi
+
 	# create local lan and docker lan whitelist for transmission
 	TRANSMISSION_WHITELIST=$(echo ${LOCALIPADD} | cut -d"." -f1-3)".*"
 	local docker_subnet=$(docker network inspect lsio 2> /dev/null | grep Subnet | xargs | cut -d" " -f2 | cut -d"/" -f1 | cut -d"." -f1-2)

--- a/tools/modules/runtime/config.runtime.sh
+++ b/tools/modules/runtime/config.runtime.sh
@@ -16,6 +16,41 @@ locale_setting="$LANG"
 installed_software="$(see_current_apt)"
 held_packages=$(apt-mark showhold)
 
+# Use SWAG domain URL if available, otherwise fall back to local IP
+# This makes all menu URLs show the actual domain instead of IP when SWAG is installed
+DISPLAY_URL="${SWAG_URL:-$LOCALIPADD}"
+
+# Helper function to determine service URL format.
+#   - SWAG container missing OR proxy-conf for this service not
+#     enabled → http://$LOCALIPADD:<port>. The non-proxied backend
+#     listens on the host's LAN IP, NOT on the public SWAG domain
+#     (which only serves SWAG itself on 443) — DISPLAY_URL would be
+#     the wrong host here when SWAG_URL is set.
+#   - Proxy-conf enabled → https://$DISPLAY_URL/<service>. DISPLAY_URL
+#     resolves to SWAG_URL whenever it's set, which is exactly the
+#     public domain we want for the SWAG-fronted path.
+get_service_url() {
+	local service_name="$1"
+	local service_port="$2"
+
+	# Check if SWAG is running
+	if ! docker container ls -a --format "{{.Names}}" 2>/dev/null | grep -q "^swag$"; then
+		echo "http://$LOCALIPADD:$service_port"
+		return
+	fi
+
+	# Check if SWAG proxy is enabled for this service
+	local proxy_enabled_file="/config/nginx/proxy-confs/${service_name}.subfolder.conf.enabled"
+	if ! docker exec swag test -f "$proxy_enabled_file" 2>/dev/null; then
+		echo "http://$LOCALIPADD:$service_port"
+		return
+	fi
+
+	# SWAG proxy is enabled - return subfolder URL
+	echo "https://$DISPLAY_URL/$service_name"
+}
+
+
 module_options+=(
 	["update_json_data,author"]="@Tearran"
 	["update_json_data,ref_link"]=""
@@ -103,7 +138,7 @@ update_sub_submenu_data "System" "Storage" "NFS04" "$NFS_CLIENTS_NUMBER"
 
 # Database
 update_sub_submenu_data "Software" "Database" "DAT002" "Server: $LOCALIPADD"
-update_sub_submenu_data "Software" "Database" "MYA002" "http://$LOCALIPADD:${module_options["module_phpmyadmin,port"]}"
+update_sub_submenu_data "Software" "Database" "MYA002" "$(get_service_url "phpmyadmin" "${module_options["module_phpmyadmin,port"]}")"
 
 # Finance
 update_sub_submenu_data "Software" "Finance" "ABU002" "http://$LOCALIPADD:${module_options["module_actualbudget,port"]}"
@@ -111,25 +146,31 @@ update_sub_submenu_data "Software" "Finance" "WAL002" "http://$LOCALIPADD:${modu
 
 # Media
 update_sub_submenu_data "Software" "Media" "OMV002" "http://$LOCALIPADD:${module_options["module_omv,port"]}"
-update_sub_submenu_data "Software" "Media" "MED002" "http://$LOCALIPADD:${module_options["module_plexmediaserver,port"]}"
-update_sub_submenu_data "Software" "Media" "EMB002" "http://$LOCALIPADD:${module_options["module_embyserver,port"]}"
-update_sub_submenu_data "Software" "Media" "FIL002" "http://$LOCALIPADD:${module_options["module_filebrowser,port"]}"
+update_sub_submenu_data "Software" "Media" "MED002" "$(get_service_url "plex" "${module_options["module_plexmediaserver,port"]}")"
+update_sub_submenu_data "Software" "Media" "EMB002" "$(get_service_url "emby" "${module_options["module_embyserver,port"]}")"
+update_sub_submenu_data "Software" "Media" "FIL002" "$(get_service_url "filebrowser" "${module_options["module_filebrowser,port"]}")"
 update_sub_submenu_data "Software" "Media" "STR002" "http://$LOCALIPADD:${module_options["module_stirling,port"]}"
-update_sub_submenu_data "Software" "Media" "STC002" "http://$LOCALIPADD:${module_options["module_syncthing,port"]%% *}" # removing second port from url
+update_sub_submenu_data "Software" "Media" "STC002" "$(get_service_url "syncthing" "${module_options["module_syncthing,port"]%% *}")" # removing second port from url
 update_sub_submenu_data "Software" "Media" "NCT002" "https://$LOCALIPADD:${module_options["module_nextcloud,port"]}"
 update_sub_submenu_data "Software" "Media" "OWC002" "http://$LOCALIPADD:${module_options["module_owncloud,port"]}"
-update_sub_submenu_data "Software" "Media" "JMS002" "http://$LOCALIPADD:${module_options["module_jellyfin,port"]}"
-update_sub_submenu_data "Software" "Media" "IMM002" "http://$LOCALIPADD:${module_options["module_immich,port"]}"
+update_sub_submenu_data "Software" "Media" "JMS002" "$(get_service_url "jellyfin" "${module_options["module_jellyfin,port"]}")"
+	update_sub_submenu_data "Software" "Media" "IMM002" "$(get_service_url "immich" "${module_options["module_immich,port"]}")"
 update_sub_submenu_data "Software" "Media" "NAV002" "http://$LOCALIPADD:${module_options["module_navidrome,port"]}"
 
 # Containers
-update_sub_submenu_data "Software" "Containers" "POR002" "http://$LOCALIPADD:${module_options["module_portainer,port"]%% *}" # removing second port from url
+# Portainer uses HTTPS on port 9443 (not the edge agent port 9000)
+if docker container ls -a --format "{{.Names}}" 2>/dev/null | grep -q "^swag$" && \
+	docker exec swag test -f "/config/nginx/proxy-confs/portainer.subfolder.conf.enabled" 2>/dev/null; then
+	update_sub_submenu_data "Software" "Containers" "POR002" "https://$DISPLAY_URL/portainer"
+else
+	update_sub_submenu_data "Software" "Containers" "POR002" "https://$LOCALIPADD:9443"
+fi
 
 # Backup
-update_sub_submenu_data "Software" "Backup" "DPL002" "http://$LOCALIPADD:${module_options["module_duplicati,port"]%% *}" # removing second port from url
+update_sub_submenu_data "Software" "Backup" "DPL002" "$(get_service_url "duplicati" "${module_options["module_duplicati,port"]%% *}")" # removing second port from url
 
 # Printing
-update_sub_submenu_data "Software" "Printing" "OCT002" "http://$LOCALIPADD:${module_options["module_octoprint,port"]}"
+update_sub_submenu_data "Software" "Printing" "OCT002" "$(get_service_url "octoprint" "${module_options["module_octoprint,port"]}")"
 
 # DevTools
 [[ -f /etc/rsyncd.conf ]] && update_sub_submenu_data "Software" "DevTools" "DEV011" "$(grep -oP '(?<=^\[).*(?=\])' /etc/rsyncd.conf | xargs)"
@@ -137,38 +178,41 @@ update_sub_submenu_data "Software" "Printing" "OCT002" "http://$LOCALIPADD:${mod
 # Home automation
 update_sub_submenu_data "Software" "HomeAutomation" "HAB002" "http://$LOCALIPADD:${module_options["module_openhab,port"]}"
 update_sub_submenu_data "Software" "HomeAutomation" "HAS002" "http://$LOCALIPADD:${module_options["module_haos,port"]}"
-update_sub_submenu_data "Software" "HomeAutomation" "DOM002" "http://$LOCALIPADD:${module_options["module_domoticz,port"]}"
+update_sub_submenu_data "Software" "HomeAutomation" "DOM002" "$(get_service_url "domoticz" "${module_options["module_domoticz,port"]}")"
 update_sub_submenu_data "Software" "HomeAutomation" "EVCC02" "http://$LOCALIPADD:${module_options["module_evcc,port"]}"
 
 # DNS
-update_sub_submenu_data "Software" "DNS" "PIH003" "http://$LOCALIPADD:${module_options["module_pi_hole,port"]%% *}/admin" # removing second port from url
+update_sub_submenu_data "Software" "DNS" "PIH003" "$(get_service_url "pihole" "${module_options["module_pi_hole,port"]%% *}")/admin" # removing second port from url
 update_sub_submenu_data "Software" "DNS" "ADG002" "http://$LOCALIPADD:${module_options["module_adguardhome,port"]%% *}" # removing second port from url
 
 # Monitoring
-update_sub_submenu_data "Software" "Monitoring" "UPK002" "http://$LOCALIPADD:${module_options["module_uptimekuma,port"]}"
-update_sub_submenu_data "Software" "Monitoring" "NTD002" "http://$LOCALIPADD:${module_options["module_netdata,port"]}"
-update_sub_submenu_data "Software" "Monitoring" "GRA002" "http://$LOCALIPADD:${module_options["module_grafana,port"]}"
-update_sub_submenu_data "Software" "Monitoring" "NAX002" "http://$LOCALIPADD:${module_options["module_netalertx,port"]}"
-update_sub_submenu_data "Software" "Monitoring" "PRO002" "http://$LOCALIPADD:${module_options["module_prometheus,port"]}"
+update_sub_submenu_data "Software" "Monitoring" "UPK002" "$(get_service_url "uptime-kuma" "${module_options["module_uptimekuma,port"]}")"
+update_sub_submenu_data "Software" "Monitoring" "NTD002" "$(get_service_url "netdata" "${module_options["module_netdata,port"]}")"
+update_sub_submenu_data "Software" "Monitoring" "GRA002" "$(get_service_url "grafana" "${module_options["module_grafana,port"]}")"
+update_sub_submenu_data "Software" "Monitoring" "NAX002" "$(get_service_url "netalertx" "${module_options["module_netalertx,port"]}")"
+update_sub_submenu_data "Software" "Monitoring" "PRO002" "$(get_service_url "prometheus" "${module_options["module_prometheus,port"]}")"
+update_sub_submenu_data "Software" "Monitoring" "DOZ002" "$(get_service_url "dozzle" "${module_options["module_dozzle,port"]}")"
+update_sub_submenu_data "Software" "Monitoring" "BSZ002" "$(get_service_url "beszel" "${module_options["module_beszel,port"]}")"
 
 # Management
 update_sub_submenu_data "Software" "Management" "CPT002" "https://$LOCALIPADD:${module_options["module_cockpit,port"]}"
-update_sub_submenu_data "Software" "Management" "HPG002" "http://$LOCALIPADD:${module_options["module_homepage,port"]}"
-update_sub_submenu_data "Software" "Management" "NBOX02" "http://$LOCALIPADD:${module_options["module_netbox,port"]}"
+update_sub_submenu_data "Software" "Management" "HPG002" "$(get_service_url "homepage" "${module_options["module_homepage,port"]}")"
+	update_sub_submenu_data "Software" "Management" "NBOX02" "$(get_service_url "netbox" "${module_options["module_netbox,port"]}")"
 
 # Downloaders
-update_sub_submenu_data "Software" "Downloaders" "DOW002" "http://$LOCALIPADD:${module_options["module_qbittorrent,port"]%% *}" # removing second port from url
-update_sub_submenu_data "Software" "Downloaders" "DEL002" "http://$LOCALIPADD:${module_options["module_deluge,port"]%% *}" # removing second port from url
-update_sub_submenu_data "Software" "Downloaders" "TRA002" "http://$LOCALIPADD:${module_options["module_transmission,port"]%% *}" # removing second port from url
-update_sub_submenu_data "Software" "Downloaders" "SABN02" "http://$LOCALIPADD:${module_options["module_sabnzbd,port"]}"
-update_sub_submenu_data "Software" "Downloaders" "MDS002" "http://$LOCALIPADD:${module_options["module_medusa,port"]}"
-update_sub_submenu_data "Software" "Downloaders" "SON002" "http://$LOCALIPADD:${module_options["module_sonarr,port"]}"
-update_sub_submenu_data "Software" "Downloaders" "RAD002" "http://$LOCALIPADD:${module_options["module_radarr,port"]}"
-update_sub_submenu_data "Software" "Downloaders" "BAZ002" "http://$LOCALIPADD:${module_options["module_bazarr,port"]}"
-update_sub_submenu_data "Software" "Downloaders" "LID002" "http://$LOCALIPADD:${module_options["module_lidarr,port"]}"
-update_sub_submenu_data "Software" "Downloaders" "RDR002" "http://$LOCALIPADD:${module_options["module_readarr,port"]}"
-update_sub_submenu_data "Software" "Downloaders" "DOW026" "http://$LOCALIPADD:${module_options["module_prowlarr,port"]}"
+update_sub_submenu_data "Software" "Downloaders" "DOW002" "$(get_service_url "qbittorrent" "${module_options["module_qbittorrent,port"]%% *}")" # removing second port from url
+update_sub_submenu_data "Software" "Downloaders" "DEL002" "$(get_service_url "deluge" "${module_options["module_deluge,port"]%% *}")" # removing second port from url
+update_sub_submenu_data "Software" "Downloaders" "TRA002" "$(get_service_url ${module_options["module_transmission,servicename"]} ${module_options["module_transmission,port"]})" # removing second port from url
+update_sub_submenu_data "Software" "Downloaders" "SABN02" "$(get_service_url "sabnzbd" "${module_options["module_sabnzbd,port"]}")"
+update_sub_submenu_data "Software" "Downloaders" "MDS002" "$(get_service_url "medusa" "${module_options["module_medusa,port"]}")"
+update_sub_submenu_data "Software" "Downloaders" "SON002" "$(get_service_url "sonarr" "${module_options["module_sonarr,port"]}")"
+update_sub_submenu_data "Software" "Downloaders" "RAD002" "$(get_service_url "radarr" "${module_options["module_radarr,port"]}")"
+update_sub_submenu_data "Software" "Downloaders" "BAZ002" "$(get_service_url "bazarr" "${module_options["module_bazarr,port"]}")"
+update_sub_submenu_data "Software" "Downloaders" "LID002" "$(get_service_url "lidarr" "${module_options["module_lidarr,port"]}")"
+update_sub_submenu_data "Software" "Downloaders" "RDR002" "$(get_service_url "readarr" "${module_options["module_readarr,port"]}")"
+update_sub_submenu_data "Software" "Downloaders" "DOW026" "$(get_service_url "prowlarr" "${module_options["module_prowlarr,port"]}")"
 update_sub_submenu_data "Software" "Downloaders" "JEL002" "http://$LOCALIPADD:${module_options["module_jellyseerr,port"]}"
 
 # web
-update_sub_submenu_data "Software" "WebHosting" "GHOST2" "http://$LOCALIPADD:${module_options["module_ghost,port"]}/ghost"
+update_sub_submenu_data "Software" "WebHosting" "GHOST2" "$(get_service_url "ghost" "${module_options["module_ghost,port"]}")/ghost"
+update_sub_submenu_data "Software" "WebHosting" "SWAG01" "https://$DISPLAY_URL"

--- a/tools/modules/runtime/config.runtime.sh
+++ b/tools/modules/runtime/config.runtime.sh
@@ -156,6 +156,7 @@ update_sub_submenu_data "Software" "Media" "OWC002" "http://$LOCALIPADD:${module
 update_sub_submenu_data "Software" "Media" "JMS002" "$(get_service_url "jellyfin" "${module_options["module_jellyfin,port"]}")"
 	update_sub_submenu_data "Software" "Media" "IMM002" "$(get_service_url "immich" "${module_options["module_immich,port"]}")"
 update_sub_submenu_data "Software" "Media" "NAV002" "http://$LOCALIPADD:${module_options["module_navidrome,port"]}"
+update_sub_submenu_data "Software" "Media" "HPS002" "http://$LOCALIPADD:${module_options["module_hastebin,port"]}"
 
 # Containers
 # Portainer uses HTTPS on port 9443 (not the edge agent port 9000)

--- a/tools/modules/runtime/config.runtime.sh
+++ b/tools/modules/runtime/config.runtime.sh
@@ -156,7 +156,7 @@ update_sub_submenu_data "Software" "Media" "OWC002" "http://$LOCALIPADD:${module
 update_sub_submenu_data "Software" "Media" "JMS002" "$(get_service_url "jellyfin" "${module_options["module_jellyfin,port"]}")"
 	update_sub_submenu_data "Software" "Media" "IMM002" "$(get_service_url "immich" "${module_options["module_immich,port"]}")"
 update_sub_submenu_data "Software" "Media" "NAV002" "http://$LOCALIPADD:${module_options["module_navidrome,port"]}"
-update_sub_submenu_data "Software" "Media" "HPS002" "http://$LOCALIPADD:${module_options["module_hastebin,port"]}"
+update_sub_submenu_data "Software" "Media" "HPS002" "$(get_service_url "hastebin" "${module_options["module_hastebin,port"]}")"
 
 # Containers
 # Portainer uses HTTPS on port 9443 (not the edge agent port 9000)

--- a/tools/modules/runtime/config.runtime.sh
+++ b/tools/modules/runtime/config.runtime.sh
@@ -149,7 +149,7 @@ update_sub_submenu_data "Software" "Media" "OMV002" "http://$LOCALIPADD:${module
 update_sub_submenu_data "Software" "Media" "MED002" "$(get_service_url "plex" "${module_options["module_plexmediaserver,port"]}")"
 update_sub_submenu_data "Software" "Media" "EMB002" "$(get_service_url "emby" "${module_options["module_embyserver,port"]}")"
 update_sub_submenu_data "Software" "Media" "FIL002" "$(get_service_url "filebrowser" "${module_options["module_filebrowser,port"]}")"
-update_sub_submenu_data "Software" "Media" "STR002" "http://$LOCALIPADD:${module_options["module_stirling,port"]}"
+update_sub_submenu_data "Software" "Media" "STR002" "$(get_service_url "stirling-pdf" "${module_options["module_stirling,port"]}")"
 update_sub_submenu_data "Software" "Media" "STC002" "$(get_service_url "syncthing" "${module_options["module_syncthing,port"]%% *}")" # removing second port from url
 update_sub_submenu_data "Software" "Media" "NCT002" "https://$LOCALIPADD:${module_options["module_nextcloud,port"]}"
 update_sub_submenu_data "Software" "Media" "OWC002" "http://$LOCALIPADD:${module_options["module_owncloud,port"]}"

--- a/tools/modules/software/module_bazarr.sh
+++ b/tools/modules/software/module_bazarr.sh
@@ -9,7 +9,7 @@ module_options+=(
 	["module_bazarr,group"]="Downloaders"
 	["module_bazarr,port"]="6767"
 	["module_bazarr,arch"]="x86-64 arm64"
-	["module_bazarr,dockerimage"]="lscr.io/linuxserver/bazarr:latest"
+	["module_bazarr,dockerimage"]="linuxserver/bazarr:latest"
 	["module_bazarr,dockername"]="bazarr"
 )
 #
@@ -47,6 +47,8 @@ function module_bazarr () {
 				-v "${base_dir}/tv:/tv" \
 				--restart=always \
 				"$dockerimage"
+			# Auto-configure SWAG reverse proxy if available
+			docker_configure_swag_proxy "$dockername" "6767"
 		;;
 		"${commands[1]}") # remove
 			# Remove container and image (functions handle existence checks)

--- a/tools/modules/software/module_beszel.sh
+++ b/tools/modules/software/module_beszel.sh
@@ -88,12 +88,12 @@ function module_beszel () {
 
 				proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
-				## PocketBase realtime uses SSE — extend read timeout
-				## so the long-poll connection isn't reaped. LSIO's
-				## proxy.conf already sets the WebSocket Upgrade /
-				## Connection / HTTP-1.1 headers; redeclaring them here
-				## triggers nginx 'duplicate directive' errors.
-				proxy_read_timeout 86400;
+				## LSIO's proxy.conf (included above) already sets
+				## proxy_read_timeout, the WebSocket Upgrade /
+				## Connection headers, and proxy_http_version 1.1 —
+				## redeclaring any of them here triggers nginx
+				## 'duplicate directive' emerg errors and the reload
+				## silently keeps the previous (broken) config.
 
 				## sub_filter operates on uncompressed bytes only;
 				## strip Accept-Encoding so the upstream returns plain

--- a/tools/modules/software/module_beszel.sh
+++ b/tools/modules/software/module_beszel.sh
@@ -1,0 +1,99 @@
+module_options+=(
+	["module_beszel,author"]="@armbian"
+	["module_beszel,maintainer"]="@igorpecovnik"
+	["module_beszel,feature"]="module_beszel"
+	["module_beszel,example"]="install remove purge status help"
+	["module_beszel,desc"]="Install Beszel container (lightweight server monitoring hub)"
+	["module_beszel,status"]="Active"
+	["module_beszel,doc_link"]="https://beszel.dev/guide/what-is-beszel"
+	["module_beszel,group"]="Monitoring"
+	["module_beszel,port"]="8090"
+	["module_beszel,arch"]="x86-64 arm64"
+	["module_beszel,dockerimage"]="henrygd/beszel:latest"
+	["module_beszel,dockername"]="beszel"
+)
+#
+# Module Beszel
+#
+function module_beszel () {
+	local title="Beszel"
+	local dockerimage="${module_options["module_beszel,dockerimage"]}"
+	local dockername="${module_options["module_beszel,dockername"]}"
+	local port="${module_options["module_beszel,port"]}"
+
+	local commands
+	IFS=' ' read -r -a commands <<< "${module_options["module_beszel,example"]}"
+
+	local base_dir="${SOFTWARE_FOLDER}/$dockername"
+
+	case "$1" in
+		"${commands[0]}") # install
+			# Pull image
+			docker_operation_progress pull "$dockerimage"
+
+			# Create base directory
+			docker_manage_base_dir create "$base_dir" || return 1
+
+			# Run container — Beszel hub on port 8090 (its default).
+			# --net=lsio so SWAG can resolve the container by name on
+			# the LSIO bridge (LSIO ships a stock proxy-conf that
+			# expects $upstream_app=beszel).
+			docker_operation_progress run "$dockername" \
+				-d \
+				--name="$dockername" \
+				--net=lsio \
+				-e TZ="$(cat /etc/timezone)" \
+				-p "${port}:8090" \
+				-v "${base_dir}:/beszel_data" \
+				--restart=always \
+				"$dockerimage"
+
+			# Auto-configure SWAG reverse proxy if available.
+			# linuxserver/reverse-proxy-confs:master ships a stock
+			# beszel.subfolder.conf.sample, but it assumes Beszel
+			# itself is configured to serve at /beszel/ — Beszel
+			# (PocketBase under the hood) doesn't actually support a
+			# base path, so /beszel/ reaches upstream as /beszel/ and
+			# Beszel returns nothing. Inject a rewrite into the live
+			# conf so the upstream sees /.
+			docker_configure_swag_proxy "$dockername" "8090"
+			if docker container ls -a --format "{{.Names}}" 2>/dev/null | grep -q "^swag$" \
+				&& docker exec swag test -f /config/nginx/proxy-confs/beszel.subfolder.conf 2>/dev/null \
+				&& ! docker exec swag grep -q "rewrite \^/beszel/" /config/nginx/proxy-confs/beszel.subfolder.conf 2>/dev/null; then
+				# Idempotent: only inject if the rewrite isn't there
+				# already. Place after the last `set $upstream_proto`
+				# line so the set vars are still defined when proxy_pass
+				# evaluates the upstream URL.
+				docker exec swag sed -i '/set \$upstream_proto/a\\trewrite ^/beszel/(.*)$ /$1 break;' \
+					/config/nginx/proxy-confs/beszel.subfolder.conf 2>/dev/null || true
+				docker exec swag nginx -s reload >/dev/null 2>&1 || true
+			fi
+			# Note: Beszel's own settings (Application URL) need to
+			# be set to https://<swag-host>/beszel/ in the admin UI
+			# after first login so emailed alerts and share links
+			# line up; there's no bake-it-at-install env var for that.
+		;;
+		"${commands[1]}") # remove
+			docker_operation_progress rm "$dockername"
+			docker_operation_progress rmi "$dockerimage"
+		;;
+		"${commands[2]}") # purge
+			# Remove container and image first
+			if ! ${module_options["module_beszel,feature"]} ${commands[1]}; then
+				return 1
+			fi
+			# Only remove data directory if container/image removal succeeded
+			docker_manage_base_dir remove "$base_dir"
+		;;
+		"${commands[3]}") # status
+			docker_is_installed "$dockername" "$dockerimage"
+		;;
+		"${commands[4]}") # help
+			show_module_help "module_beszel" "$title" \
+				"Web Interface: http://localhost:${port}\nDocker Image: $dockerimage\n\nLightweight monitoring hub. Install agents on monitored hosts via the web UI."
+		;;
+		*)
+			${module_options["module_beszel,feature"]} ${commands[4]}
+		;;
+	esac
+}

--- a/tools/modules/software/module_beszel.sh
+++ b/tools/modules/software/module_beszel.sh
@@ -48,26 +48,69 @@ function module_beszel () {
 				--restart=always \
 				"$dockerimage"
 
-			# Auto-configure SWAG reverse proxy if available.
-			# linuxserver/reverse-proxy-confs:master ships a stock
-			# beszel.subfolder.conf.sample, but it assumes Beszel
-			# itself is configured to serve at /beszel/ — Beszel
-			# (PocketBase under the hood) doesn't actually support a
-			# base path, so /beszel/ reaches upstream as /beszel/ and
-			# Beszel returns nothing. Inject a rewrite into the live
-			# conf so the upstream sees /.
-			docker_configure_swag_proxy "$dockername" "8090"
-			if docker container ls -a --format "{{.Names}}" 2>/dev/null | grep -q "^swag$" \
-				&& docker exec swag test -f /config/nginx/proxy-confs/beszel.subfolder.conf 2>/dev/null \
-				&& ! docker exec swag grep -q "rewrite \^/beszel/" /config/nginx/proxy-confs/beszel.subfolder.conf 2>/dev/null; then
-				# Idempotent: only inject if the rewrite isn't there
-				# already. Place after the last `set $upstream_proto`
-				# line so the set vars are still defined when proxy_pass
-				# evaluates the upstream URL.
-				docker exec swag sed -i '/set \$upstream_proto/a\\trewrite ^/beszel/(.*)$ /$1 break;' \
-					/config/nginx/proxy-confs/beszel.subfolder.conf 2>/dev/null || true
-				docker exec swag nginx -s reload >/dev/null 2>&1 || true
+			# Auto-configure SWAG reverse proxy if available — best
+			# effort. linuxserver/reverse-proxy-confs:master ships a
+			# stock beszel.subfolder.conf.sample, but it assumes Beszel
+			# is configured to serve at /beszel/. Beszel (PocketBase +
+			# SvelteKit frontend) has no base-path support: the served
+			# HTML emits absolute asset paths like /static/… and
+			# /_app/…, so the browser asks SWAG for those at the root
+			# and the page renders blank. We replace LSIO's stock
+			# sample with one that strips /beszel/ at the upstream and
+			# sub_filters the served HTML/CSS/JS so absolute asset
+			# URLs are rewritten back to /beszel/-prefixed paths.
+			# Subdomain proxying is the unbroken path; subfolder is
+			# best-effort (runtime-built URLs in JS modules may still
+			# 404). set/rewrite ordering matters — set vars must
+			# precede `rewrite … break;`.
+			if docker container ls -a --format "{{.Names}}" 2>/dev/null | grep -q "^swag$"; then
+				docker exec swag rm -f \
+					/config/nginx/proxy-confs/beszel.subfolder.conf \
+					/config/nginx/proxy-confs/beszel.subfolder.conf.sample \
+					/config/nginx/proxy-confs/beszel.subfolder.conf.enabled \
+					2>/dev/null || true
 			fi
+			docker_seed_swag_proxy_conf "$dockername" <<- 'NGINX'
+				## Custom Armbian seed — beszel subfolder proxy.
+				## Best-effort: Beszel/PocketBase is not subpath-aware.
+				## Subdomain proxying is the recommended path.
+				location = /beszel { return 301 /beszel/; }
+
+				location ^~ /beszel/ {
+				include /config/nginx/proxy.conf;
+				include /config/nginx/resolver.conf;
+
+				set $upstream_app beszel;
+				set $upstream_port 8090;
+				set $upstream_proto http;
+
+				rewrite ^/beszel/(.*)$ /$1 break;
+
+				proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+				## PocketBase realtime uses SSE — extend read timeout
+				## so the long-poll connection isn't reaped. LSIO's
+				## proxy.conf already sets the WebSocket Upgrade /
+				## Connection / HTTP-1.1 headers; redeclaring them here
+				## triggers nginx 'duplicate directive' errors.
+				proxy_read_timeout 86400;
+
+				## sub_filter operates on uncompressed bytes only;
+				## strip Accept-Encoding so the upstream returns plain
+				## text we can rewrite.
+				proxy_set_header Accept-Encoding "";
+
+				sub_filter_once off;
+				sub_filter_types text/html text/css application/javascript;
+				sub_filter 'href="/'    'href="/beszel/';
+				sub_filter "href='/"    "href='/beszel/";
+				sub_filter 'src="/'     'src="/beszel/';
+				sub_filter "src='/"     "src='/beszel/";
+				sub_filter 'action="/'  'action="/beszel/';
+				sub_filter 'url(/'      'url(/beszel/';
+				}
+			NGINX
+			docker_configure_swag_proxy "$dockername" "8090"
 			# Note: Beszel's own settings (Application URL) need to
 			# be set to https://<swag-host>/beszel/ in the admin UI
 			# after first login so emailed alerts and share links

--- a/tools/modules/software/module_beszel.sh
+++ b/tools/modules/software/module_beszel.sh
@@ -62,6 +62,21 @@ function module_beszel () {
 				--restart=always \
 				"$dockerimage"
 
+			# Reset the active conf so we always start from LSIO's
+			# stock sample. Required when upgrading from a prior
+			# version of this module that shipped a custom
+			# sub_filter-based seed — without this, the stale conf
+			# would double-prefix asset URLs (/beszel/beszel/...).
+			# docker_configure_swag_proxy only copies .sample to
+			# active when active is absent, so we have to drop it
+			# explicitly.
+			if docker container ls -a --format "{{.Names}}" 2>/dev/null | grep -q "^swag$"; then
+				docker exec swag rm -f \
+					/config/nginx/proxy-confs/beszel.subfolder.conf \
+					/config/nginx/proxy-confs/beszel.subfolder.conf.enabled \
+					2>/dev/null || true
+			fi
+
 			# LSIO ships a stock beszel.subfolder.conf.sample that
 			# works as-is once APP_URL is set on the container.
 			docker_configure_swag_proxy "$dockername" "8090"

--- a/tools/modules/software/module_beszel.sh
+++ b/tools/modules/software/module_beszel.sh
@@ -34,6 +34,19 @@ function module_beszel () {
 			# Create base directory
 			docker_manage_base_dir create "$base_dir" || return 1
 
+			# When SWAG is on this host, tell Beszel its public URL via
+			# APP_URL. Beszel parses the URL and derives BASE_PATH
+			# (the path component) and HUB_URL (the full URL),
+			# injecting both into the served index.html — without
+			# this, the frontend JS builds API calls against / and
+			# they 404 through the proxy. Subpath deployment is
+			# officially supported (https://beszel.dev/guide/reverse-proxy);
+			# with APP_URL set, LSIO's stock subfolder.conf works as-is.
+			local -a beszel_extra_env=()
+			if [[ -n "${SWAG_URL:-}" ]]; then
+				beszel_extra_env+=(-e "APP_URL=https://${SWAG_URL}/beszel")
+			fi
+
 			# Run container — Beszel hub on port 8090 (its default).
 			# --net=lsio so SWAG can resolve the container by name on
 			# the LSIO bridge (LSIO ships a stock proxy-conf that
@@ -43,80 +56,20 @@ function module_beszel () {
 				--name="$dockername" \
 				--net=lsio \
 				-e TZ="$(cat /etc/timezone)" \
+				"${beszel_extra_env[@]}" \
 				-p "${port}:8090" \
 				-v "${base_dir}:/beszel_data" \
 				--restart=always \
 				"$dockerimage"
 
-			# Auto-configure SWAG reverse proxy if available — best
-			# effort. linuxserver/reverse-proxy-confs:master ships a
-			# stock beszel.subfolder.conf.sample, but it assumes Beszel
-			# is configured to serve at /beszel/. Beszel (PocketBase +
-			# SvelteKit frontend) has no base-path support: the served
-			# HTML emits absolute asset paths like /static/… and
-			# /_app/…, so the browser asks SWAG for those at the root
-			# and the page renders blank. We replace LSIO's stock
-			# sample with one that strips /beszel/ at the upstream and
-			# sub_filters the served HTML/CSS/JS so absolute asset
-			# URLs are rewritten back to /beszel/-prefixed paths.
-			# Subdomain proxying is the unbroken path; subfolder is
-			# best-effort (runtime-built URLs in JS modules may still
-			# 404). set/rewrite ordering matters — set vars must
-			# precede `rewrite … break;`.
-			if docker container ls -a --format "{{.Names}}" 2>/dev/null | grep -q "^swag$"; then
-				docker exec swag rm -f \
-					/config/nginx/proxy-confs/beszel.subfolder.conf \
-					/config/nginx/proxy-confs/beszel.subfolder.conf.sample \
-					/config/nginx/proxy-confs/beszel.subfolder.conf.enabled \
-					2>/dev/null || true
-			fi
-			docker_seed_swag_proxy_conf "$dockername" <<- 'NGINX'
-				## Custom Armbian seed — beszel subfolder proxy.
-				## Best-effort: Beszel/PocketBase is not subpath-aware.
-				## Subdomain proxying is the recommended path.
-				location = /beszel { return 301 /beszel/; }
-
-				location ^~ /beszel/ {
-				include /config/nginx/proxy.conf;
-				include /config/nginx/resolver.conf;
-
-				set $upstream_app beszel;
-				set $upstream_port 8090;
-				set $upstream_proto http;
-
-				rewrite ^/beszel/(.*)$ /$1 break;
-
-				proxy_pass $upstream_proto://$upstream_app:$upstream_port;
-
-				## LSIO's proxy.conf (included above) already sets
-				## proxy_read_timeout, the WebSocket Upgrade /
-				## Connection headers, and proxy_http_version 1.1 —
-				## redeclaring any of them here triggers nginx
-				## 'duplicate directive' emerg errors and the reload
-				## silently keeps the previous (broken) config.
-
-				## sub_filter operates on uncompressed bytes only;
-				## strip Accept-Encoding so the upstream returns plain
-				## text we can rewrite.
-				proxy_set_header Accept-Encoding "";
-
-				sub_filter_once off;
-				## text/html is always processed by default; listing it
-				## here triggers a 'duplicate MIME type' nginx warn.
-				sub_filter_types text/css application/javascript;
-				sub_filter 'href="/'    'href="/beszel/';
-				sub_filter "href='/"    "href='/beszel/";
-				sub_filter 'src="/'     'src="/beszel/';
-				sub_filter "src='/"     "src='/beszel/";
-				sub_filter 'action="/'  'action="/beszel/';
-				sub_filter 'url(/'      'url(/beszel/';
-				}
-			NGINX
+			# LSIO ships a stock beszel.subfolder.conf.sample that
+			# works as-is once APP_URL is set on the container.
 			docker_configure_swag_proxy "$dockername" "8090"
-			# Note: Beszel's own settings (Application URL) need to
-			# be set to https://<swag-host>/beszel/ in the admin UI
-			# after first login so emailed alerts and share links
-			# line up; there's no bake-it-at-install env var for that.
+			# Note: Shoutrrr alert links use PocketBase's own
+			# Application URL (Settings → Application URL in the
+			# admin UI), which is independent of APP_URL. Set it to
+			# https://<swag-host>/beszel after first login so emailed
+			# alerts and share links line up.
 		;;
 		"${commands[1]}") # remove
 			docker_operation_progress rm "$dockername"

--- a/tools/modules/software/module_beszel.sh
+++ b/tools/modules/software/module_beszel.sh
@@ -101,7 +101,9 @@ function module_beszel () {
 				proxy_set_header Accept-Encoding "";
 
 				sub_filter_once off;
-				sub_filter_types text/html text/css application/javascript;
+				## text/html is always processed by default; listing it
+				## here triggers a 'duplicate MIME type' nginx warn.
+				sub_filter_types text/css application/javascript;
 				sub_filter 'href="/'    'href="/beszel/';
 				sub_filter "href='/"    "href='/beszel/";
 				sub_filter 'src="/'     'src="/beszel/';

--- a/tools/modules/software/module_code-server.sh
+++ b/tools/modules/software/module_code-server.sh
@@ -9,7 +9,7 @@ module_options+=(
 	["module_code-server,group"]="Development"
 	["module_code-server,port"]="8443"
 	["module_code-server,arch"]="x86-64 arm64"
-	["module_code-server,dockerimage"]="lscr.io/linuxserver/code-server:latest"
+	["module_code-server,dockerimage"]="linuxserver/code-server:latest"
 	["module_code-server,dockername"]="code-server"
 )
 #

--- a/tools/modules/software/module_deluge.sh
+++ b/tools/modules/software/module_deluge.sh
@@ -9,7 +9,7 @@ module_options+=(
 	["module_deluge,group"]="Downloaders"
 	["module_deluge,port"]="8112"
 	["module_deluge,arch"]="x86-64 arm64"
-	["module_deluge,dockerimage"]="lscr.io/linuxserver/deluge:latest"
+	["module_deluge,dockerimage"]="linuxserver/deluge:latest"
 	["module_deluge,dockername"]="deluge"
 )
 #
@@ -50,6 +50,8 @@ function module_deluge () {
 				-v "${base_dir}/downloads:/downloads" \
 				--restart=always \
 				"$dockerimage"
+			# Auto-configure SWAG reverse proxy if available
+			docker_configure_swag_proxy "$dockername" "8112"
 		;;
 		"${commands[1]}") # remove
 			# Remove container and image (functions handle existence checks)

--- a/tools/modules/software/module_domoticz.sh
+++ b/tools/modules/software/module_domoticz.sh
@@ -57,6 +57,8 @@ function module_domoticz () {
 				-v "${base_dir}:/opt/domoticz/userdata" \
 				--restart=always \
 				"$dockerimage"
+			# Auto-configure SWAG reverse proxy if available
+			docker_configure_swag_proxy "$dockername" "8080"
 		;;
 		"${commands[1]}") # remove
 			docker_operation_progress rm "$dockername"

--- a/tools/modules/software/module_dozzle.sh
+++ b/tools/modules/software/module_dozzle.sh
@@ -35,15 +35,30 @@ function module_dozzle () {
 			# Pull image (handles Docker installation and already-installed check)
 			docker_operation_progress pull "$dockerimage"
 
+			# When SWAG is on this host, tell Dozzle its base path
+			# via DOZZLE_BASE so the frontend emits asset URLs under
+			# /dozzle/. LSIO's stock proxy-conf header documents this
+			# requirement; without it the rendered HTML asks for
+			# /assets/… at the root, SWAG returns the default page,
+			# and the dozzle URL appears blank with no error in the
+			# nginx log (every request is a 200).
+			local -a dozzle_extra_env=()
+			if docker container ls -a --format "{{.Names}}" 2>/dev/null | grep -q "^swag$"; then
+				dozzle_extra_env+=(-e "DOZZLE_BASE=/dozzle")
+			fi
+
 			# Run Dozzle container with Docker socket mount
 			docker_operation_progress run "$dockername" \
 				-d \
 				--name "$dockername" \
 				--net lsio \
 				-v /var/run/docker.sock:/var/run/docker.sock \
+				"${dozzle_extra_env[@]}" \
 				-p "${port}:8080" \
 				--restart unless-stopped \
 				"$dockerimage"
+			# Auto-configure SWAG reverse proxy if available
+			docker_configure_swag_proxy "$dockername" "8080"
 
 			# Wait for container to be ready
 			wait_for_container_ready "$dockername" 30 3 "running"

--- a/tools/modules/software/module_duplicati.sh
+++ b/tools/modules/software/module_duplicati.sh
@@ -9,7 +9,7 @@ module_options+=(
 	["module_duplicati,group"]="Backup"
 	["module_duplicati,port"]="8200"
 	["module_duplicati,arch"]="x86-64 arm64"
-	["module_duplicati,dockerimage"]="lscr.io/linuxserver/duplicati:latest"
+	["module_duplicati,dockerimage"]="linuxserver/duplicati:latest"
 	["module_duplicati,dockername"]="duplicati"
 )
 #
@@ -78,6 +78,8 @@ function module_duplicati () {
 				-v "${base_dir}/backups:/backups" \
 				-v /:/source:ro \
 				"$dockerimage"
+			# Auto-configure SWAG reverse proxy if available
+			docker_configure_swag_proxy "$dockername" "8200"
 		;;
 		"${commands[1]}") # remove
 			docker_operation_progress rm "$dockername"

--- a/tools/modules/software/module_embyserver.sh
+++ b/tools/modules/software/module_embyserver.sh
@@ -9,7 +9,7 @@ module_options+=(
 	["module_embyserver,group"]="Media"
 	["module_embyserver,port"]="8091"
 	["module_embyserver,arch"]="x86-64 arm64"
-	["module_embyserver,dockerimage"]="lscr.io/linuxserver/emby:latest"
+	["module_embyserver,dockerimage"]="linuxserver/emby:latest"
 	["module_embyserver,dockername"]="emby"
 )
 #
@@ -51,6 +51,8 @@ function module_embyserver () {
 				-v "${base_dir}/tvshows:/tvshows" \
 				--restart=always \
 				"$dockerimage"
+			# Auto-configure SWAG reverse proxy if available
+			docker_configure_swag_proxy "$dockername" "8096"
 		;;
 		"${commands[1]}") # remove
 			docker_operation_progress rm "$dockername"

--- a/tools/modules/software/module_filebrowser.sh
+++ b/tools/modules/software/module_filebrowser.sh
@@ -39,6 +39,17 @@ function module_filebrowser () {
 			mkdir -p "${base_dir}/database"
 			chown -R "${DOCKER_USERUID}:${DOCKER_GROUPUID}" "${base_dir}/database"
 
+			# When SWAG is on this host, tell filebrowser its base URL
+			# via --baseurl. LSIO's stock subfolder.conf forwards
+			# /filebrowser/ as-is to the upstream — without this flag,
+			# filebrowser serves at / and its frontend JS calls /api/…
+			# which 404s through the proxy, leaving the page stuck on
+			# the loading spinner.
+			local -a filebrowser_extra_args=()
+			if docker container ls -a --format "{{.Names}}" 2>/dev/null | grep -q "^swag$"; then
+				filebrowser_extra_args+=(--baseurl /filebrowser)
+			fi
+
 			docker_operation_progress run "$dockername" \
 				-d \
 				--net=lsio \
@@ -53,7 +64,8 @@ function module_filebrowser () {
 				-p "${port}:80" \
 				--restart=always \
 				"$dockerimage" \
-				--database /database/filebrowser.db
+				--database /database/filebrowser.db \
+				"${filebrowser_extra_args[@]}"
 
 			# Auto-configure SWAG reverse proxy if available
 			docker_configure_swag_proxy "$dockername" "80"

--- a/tools/modules/software/module_filebrowser.sh
+++ b/tools/modules/software/module_filebrowser.sh
@@ -55,6 +55,9 @@ function module_filebrowser () {
 				"$dockerimage" \
 				--database /database/filebrowser.db
 
+			# Auto-configure SWAG reverse proxy if available
+			docker_configure_swag_proxy "$dockername" "80"
+
 			# Wait for container to initialize and extract password from logs
 			sleep 3
 			local admin_password

--- a/tools/modules/software/module_ghost.sh
+++ b/tools/modules/software/module_ghost.sh
@@ -65,6 +65,8 @@ function module_ghost () {
 				-e url="http://$LOCALIPADD:${port}" \
 				-v "$base_dir:/var/lib/ghost/content" \
 				"$dockerimage"
+			# Auto-configure SWAG reverse proxy if available
+			docker_configure_swag_proxy "$dockername" "2368"
 		;;
 		"${commands[1]}") # remove
 			docker_operation_progress rm "$dockername"

--- a/tools/modules/software/module_grafana.sh
+++ b/tools/modules/software/module_grafana.sh
@@ -34,6 +34,29 @@ function module_grafana () {
 			# Create base directory
 			docker_manage_base_dir create "$base_dir" || return 1
 
+			# When SWAG is on this host, set GF_SERVER_ROOT_URL /
+			# GF_SERVER_DOMAIN so Grafana emits absolute URLs under
+			# /grafana/ (login redirects, public assets, dashboard
+			# share links, etc.). Without these, the rendered HTML
+			# carries /public/… paths that 404 once SWAG strips them
+			# at /grafana.
+			#
+			# Do NOT set GF_SERVER_SERVE_FROM_SUB_PATH=true here. The
+			# LSIO proxy-conf rewrites '^/grafana/(.*)$ /$1 break',
+			# so Grafana receives the bare path. With sub-path mode
+			# enabled Grafana would 302 every '/' back to '/grafana/',
+			# which the proxy strips again — ERR_TOO_MANY_REDIRECTS.
+			# GF_SERVER_DOMAIN is the hostname only (no scheme); the
+			# scheme/path live in GF_SERVER_ROOT_URL.
+			local -a grafana_extra_env=()
+			if docker container ls -a --format "{{.Names}}" 2>/dev/null | grep -q "^swag$" \
+				&& [[ -n "${SWAG_URL:-}" ]]; then
+				grafana_extra_env+=(
+					-e "GF_SERVER_ROOT_URL=https://${SWAG_URL}/grafana/"
+					-e "GF_SERVER_DOMAIN=${SWAG_URL}"
+				)
+			fi
+
 			docker_operation_progress run "$dockername" \
 				-d \
 				--name="$dockername" \
@@ -41,10 +64,21 @@ function module_grafana () {
 				--net=lsio \
 				--user 0 \
 				-e TZ="$(cat /etc/timezone)" \
+				"${grafana_extra_env[@]}" \
 				-p "${port}:3000" \
 				-v "${base_dir}:/var/lib/grafana" \
 				--restart=always \
 				"$dockerimage"
+			# Auto-configure SWAG reverse proxy if available
+			docker_configure_swag_proxy "$dockername" "3000"
+
+			# Restart so Grafana picks up the GF_SERVER_* env on a
+			# clean process (matches the netbox/octoprint pattern —
+			# no-op if the container isn't running, e.g. SWAG-less
+			# install where no env vars were added).
+			if docker container ls --format '{{.Names}}' 2>/dev/null | grep -q "^${dockername}$"; then
+				docker restart "$dockername" >/dev/null 2>&1 || true
+			fi
 		;;
 		"${commands[1]}") # remove
 			# Remove container and image (functions handle existence checks)

--- a/tools/modules/software/module_hastebin.sh
+++ b/tools/modules/software/module_hastebin.sh
@@ -52,6 +52,58 @@ function module_hastebin () {
 				-v "${base_dir}:/app:rw" \
 				--restart=always \
 				"$dockerimage"
+
+			# Auto-configure SWAG reverse proxy if available — best
+			# effort. Hastebin (haste-server fork) has no native
+			# subpath support: its application.js calls /documents,
+			# /raw/ and /about.md as absolute paths, and the inline
+			# JS extracts the document key via
+			# window.location.pathname.substring(1) — which under
+			# /hastebin/<key> reads "hastebin/<key>" and breaks paste
+			# viewing. We rewrite the absolute API paths in the JS
+			# bundle so paste *creation* works, but viewing existing
+			# pastes via /hastebin/<key> is broken without source
+			# patches. Subdomain proxying is the recommended path.
+			docker_seed_swag_proxy_conf "$dockername" <<- 'NGINX'
+				## Custom Armbian seed — hastebin subfolder proxy.
+				## Best-effort: hastebin is not subpath-aware. Paste
+				## creation is functional; viewing /<key> is broken.
+				## Subdomain proxying is the recommended path.
+				location = /hastebin { return 301 /hastebin/; }
+
+				location ^~ /hastebin/ {
+				include /config/nginx/proxy.conf;
+				include /config/nginx/resolver.conf;
+
+				set $upstream_app hastebin;
+				set $upstream_port 7777;
+				set $upstream_proto http;
+
+				rewrite ^/hastebin/(.*)$ /$1 break;
+
+				proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+				## sub_filter operates on uncompressed bytes only;
+				## strip Accept-Encoding so the upstream returns
+				## plain text we can rewrite.
+				proxy_set_header Accept-Encoding "";
+
+				sub_filter_once off;
+				## text/html is always processed by default; listing it
+				## here triggers a 'duplicate MIME type' nginx warn.
+				sub_filter_types application/javascript text/css;
+				## Rewrite the absolute API paths the haste-server JS
+				## bundle uses, so they hit the proxy at /hastebin/…
+				## (which then strips back to / for the upstream).
+				sub_filter "'/documents'"  "'/hastebin/documents'";
+				sub_filter '"/documents"'  '"/hastebin/documents"';
+				sub_filter "'/raw/'"       "'/hastebin/raw/'";
+				sub_filter '"/raw/"'       '"/hastebin/raw/"';
+				sub_filter "'/about.md'"   "'/hastebin/about.md'";
+				sub_filter '"/about.md"'   '"/hastebin/about.md"';
+				}
+			NGINX
+			docker_configure_swag_proxy "$dockername" "7777"
 		;;
 		"${commands[1]}") # remove
 			docker_operation_progress rm "$dockername"

--- a/tools/modules/software/module_homepage.sh
+++ b/tools/modules/software/module_homepage.sh
@@ -11,6 +11,7 @@ module_options+=(
 	["module_homepage,arch"]=""
 	["module_homepage,dockerimage"]="ghcr.io/gethomepage/homepage:latest"
 	["module_homepage,dockername"]="homepage"
+	["module_homepage,servicename"]="homepage"
 )
 #
 # Module Homepage
@@ -40,12 +41,17 @@ function module_homepage () {
 				--name="$dockername" \
 				-e PUID="${DOCKER_USERUID}" \
 				-e PGID="${DOCKER_GROUPUID}" \
+				-e TZ="$(cat /etc/timezone)" \
 				-e HOMEPAGE_ALLOWED_HOSTS="${LOCALIPADD}:${port},homepage.local:${port},localhost:${port}" \
+				-e HOMEPAGE_VAR_LOCALIPADD="${LOCALIPADD}" \
+				-e HOMEPAGE_VAR_SWAG_URL="${SWAG_URL:-}" \
 				-p "${port}:3000" \
 				-v "${base_dir}/config:/app/config" \
 				-v /var/run/docker.sock:/var/run/docker.sock:ro \
 				--restart=always \
 				"$dockerimage"
+			# Auto-configure SWAG reverse proxy if available
+			docker_configure_swag_proxy "homepage" "3000"
 		;;
 		"${commands[1]}") # remove
 			# Remove container and image (functions handle existence checks)

--- a/tools/modules/software/module_immich.sh
+++ b/tools/modules/software/module_immich.sh
@@ -11,6 +11,7 @@ module_options+=(
 	["module_immich,arch"]="x86-64 arm64"
 	["module_immich,dockerimage"]="ghcr.io/imagegenius/immich:latest"
 	["module_immich,dockername"]="immich"
+	["module_immich,servicename"]="immich"
 )
 #
 # Module immich
@@ -144,6 +145,9 @@ function module_immich () {
 				done
 				echo "XXX"; echo "100"; echo "Timed out waiting for Immich"; echo "XXX"
 			) | dialog_gauge "$title" "Starting Immich..." 8 60
+
+			# Auto-configure SWAG reverse proxy if available
+			docker_configure_swag_proxy "immich" "8080"
 
 			# Verify Immich is responding
 			if ! curl -sf http://localhost:${port}/ > /dev/null; then

--- a/tools/modules/software/module_jellyfin.sh
+++ b/tools/modules/software/module_jellyfin.sh
@@ -9,7 +9,7 @@ module_options+=(
 	["module_jellyfin,group"]="Media"
 	["module_jellyfin,port"]="8096"
 	["module_jellyfin,arch"]="x86-64 arm64"
-	["module_jellyfin,dockerimage"]="lscr.io/linuxserver/jellyfin:latest"
+	["module_jellyfin,dockerimage"]="linuxserver/jellyfin:latest"
 	["module_jellyfin,dockername"]="jellyfin"
 )
 #
@@ -83,6 +83,8 @@ function module_jellyfin () {
 				-v "${base_dir}/movies:/data/movies" \
 				--restart=always \
 				"$dockerimage"
+			# Auto-configure SWAG reverse proxy if available
+			docker_configure_swag_proxy "$dockername" "8096"
 		;;
 		"${commands[1]}") # remove
 			# Remove container and image (functions handle existence checks)

--- a/tools/modules/software/module_jellyfin.sh
+++ b/tools/modules/software/module_jellyfin.sh
@@ -53,9 +53,17 @@ function module_jellyfin () {
 			[ -e "/dev/$dev" ] && hwacc+=" --device /dev/$dev"
 		done
 	elif [[ "${LINUXFAMILY}" == "bcm2711" ]]; then
-		hwacc="--device=/dev/video10:/dev/video10 --device=/dev/video11:/dev/video11 --device=/dev/video12:/dev/video12"
+		# Only pass devices that actually exist; bare-metal Pi
+		# exposes them, but VMs and containers without VC4 may not.
+		for dev in video10 video11 video12; do
+			[[ -e "/dev/$dev" ]] && hwacc+=" --device=/dev/$dev:/dev/$dev"
+		done
 	elif [[ "${LINUXFAMILY}" == "x86" ]]; then
-		hwacc="--device=/dev/dri:/dev/dri"
+		# /dev/dri is the Intel/AMD render node — present on
+		# bare-metal x86 with an iGPU, missing on most VPS / headless
+		# setups. Skip silently when absent rather than failing the
+		# whole install on `error gathering device information`.
+		[[ -e /dev/dri ]] && hwacc="--device=/dev/dri:/dev/dri"
 	fi
 
 	case "$1" in

--- a/tools/modules/software/module_lidarr.sh
+++ b/tools/modules/software/module_lidarr.sh
@@ -9,7 +9,7 @@ module_options+=(
 	["module_lidarr,group"]="Downloaders"
 	["module_lidarr,port"]="8686"
 	["module_lidarr,arch"]="x86-64 arm64"
-	["module_lidarr,dockerimage"]="lscr.io/linuxserver/lidarr:latest"
+	["module_lidarr,dockerimage"]="linuxserver/lidarr:latest"
 	["module_lidarr,dockername"]="lidarr"
 )
 #
@@ -47,6 +47,8 @@ function module_lidarr () {
 				-v "${base_dir}/downloads:/downloads" \
 				--restart=always \
 				"$dockerimage"
+			# Auto-configure SWAG reverse proxy if available
+			docker_configure_swag_proxy "$dockername" "8686"
 		;;
 		"${commands[1]}") # remove
 			# Remove container and image (functions handle existence checks)

--- a/tools/modules/software/module_mariadb.sh
+++ b/tools/modules/software/module_mariadb.sh
@@ -9,7 +9,7 @@ module_options+=(
 	["module_mariadb,group"]="Database"
 	["module_mariadb,port"]="3307"
 	["module_mariadb,arch"]="x86-64 arm64"
-	["module_mariadb,dockerimage"]="lscr.io/linuxserver/mariadb:latest"
+	["module_mariadb,dockerimage"]="linuxserver/mariadb:latest"
 	["module_mariadb,dockername"]="mariadb"
 )
 #

--- a/tools/modules/software/module_medusa.sh
+++ b/tools/modules/software/module_medusa.sh
@@ -9,7 +9,7 @@ module_options+=(
 	["module_medusa,group"]="Downloaders"
 	["module_medusa,port"]="8081"
 	["module_medusa,arch"]="x86-64 arm64"
-	["module_medusa,dockerimage"]="lscr.io/linuxserver/medusa:latest"
+	["module_medusa,dockerimage"]="linuxserver/medusa:latest"
 	["module_medusa,dockername"]="medusa"
 )
 #
@@ -51,6 +51,8 @@ function module_medusa () {
 				-v "${base_dir}/downloads/tv:/tv" \
 				--restart=always \
 				"$dockerimage"
+			# Auto-configure SWAG reverse proxy if available
+			docker_configure_swag_proxy "$dockername" "8081"
 		;;
 		"${commands[1]}") # remove
 			docker_operation_progress rm "$dockername"

--- a/tools/modules/software/module_netalertx.sh
+++ b/tools/modules/software/module_netalertx.sh
@@ -39,6 +39,26 @@ function module_netalertx () {
 			# Create subdirectories
 			mkdir -p "${base_dir}/config" "${base_dir}/db"
 
+			# ARP flux sysctls for accurate scans on multi-NIC hosts.
+			# NetAlertX itself warns when these aren't set; without
+			# them the kernel answers ARP requests on any interface
+			# regardless of which NIC the address belongs to, which
+			# pollutes the device list. NetAlertX runs with
+			# --network=host so the sysctls have to live on the host
+			# namespace; drop a sysctl.d snippet and reload.
+			# https://docs.netalertx.com/docker-troubleshooting/arp-flux-sysctls/
+			local sysctl_file="/etc/sysctl.d/99-armbian-netalertx-arp.conf"
+			if [[ ! -f "$sysctl_file" ]]; then
+				cat > "$sysctl_file" <<- 'EOF'
+					# Managed by armbian-config (module_netalertx install).
+					# Reduce ARP flux for NetAlertX's host-network scanner.
+					# https://docs.netalertx.com/docker-troubleshooting/arp-flux-sysctls/
+					net.ipv4.conf.all.arp_ignore=1
+					net.ipv4.conf.all.arp_announce=2
+				EOF
+				sysctl --system > /dev/null 2>&1 || true
+			fi
+
 			# Check if we should use tmpfs for /app/api (requires sufficient RAM)
 			local mount_params=""
 			if [[ "${NETALERTX_NO_TMPFS}" != "1" ]]; then
@@ -50,6 +70,19 @@ function module_netalertx () {
 				else
 					echo "Warning: Insufficient RAM for tmpfs mount. /app/api will use disk storage."
 				fi
+			fi
+
+			# When SWAG is on this host, pass SUB_PATH=netalertx (no-op
+			# on the current 26.5.4 image — its nginx template
+			# ignores the variable — but forward-compatible for when
+			# upstream wires it through; we keep the conf below
+			# regardless).
+			# --network=host (raw sockets for ARP scanning) means SWAG
+			# can't reach this container by name on the lsio bridge,
+			# so the proxy below targets the host's IP directly.
+			local -a netalertx_extra_env=()
+			if docker container ls -a --format "{{.Names}}" 2>/dev/null | grep -q "^swag$"; then
+				netalertx_extra_env+=(-e "SUB_PATH=netalertx")
 			fi
 
 			# Run container with special security options
@@ -73,11 +106,75 @@ function module_netalertx () {
 				-e PGID=300 \
 				-e TZ="$(cat /etc/timezone)" \
 				-e PORT="${port}" \
+				"${netalertx_extra_env[@]}" \
 				-v "${base_dir}/config:/data/config:rw" \
 				-v "${base_dir}/db:/data/db:rw" \
 				$mount_params \
 				--restart unless-stopped \
 				"$dockerimage"
+
+			# Auto-configure SWAG reverse proxy if available — best
+			# effort. linuxserver/reverse-proxy-confs:master doesn't
+			# ship a netalertx sample, so we seed our own.
+			#
+			# NetAlertX 26.5.4 has no real subpath support: the
+			# rendered HTML/CSS/JS uses absolute /static/, /server/,
+			# /img/ paths, and the page also makes runtime fetch()
+			# calls against absolute URLs. We rewrite the literal
+			# strings in the response body via sub_filter so the
+			# initial page + static assets load under /netalertx/,
+			# and then a catch-all fallback inside the proxy block
+			# handles the upstream side.
+			#
+			# Caveat — this only fixes URLs that exist as literal
+			# strings in the served bytes. Anything assembled in JS
+			# at runtime (template literals, string concatenation in
+			# XHR/fetch, EventSource(...)) will still target / and
+			# 404 against SWAG. Until NetAlertX ships actual SUB_PATH
+			# behaviour, the UI will look loaded but most data won't
+			# populate. Direct port (LOCALIPADD:${port}) or a SWAG
+			# subdomain are the unbroken paths. SUB_PATH=netalertx
+			# is left set so this just starts working when upstream
+			# fixes it.
+			#
+			# Heredoc is unquoted (NGINX, not 'NGINX') so $LOCALIPADD
+			# and ${port} expand at install time; nginx variables and
+			# regex anchors are escaped with \$ to pass through.
+			docker_seed_swag_proxy_conf "netalertx" <<- NGINX
+				## Custom Armbian seed — netalertx subfolder proxy.
+				## Best-effort: NetAlertX 26.5.4 isn't subpath-aware,
+				## so we sub_filter literal absolute paths in the
+				## delivered HTML/CSS/JS. Runtime-built URLs are out
+				## of scope and will still 404.
+				location = /netalertx { return 301 /netalertx/; }
+
+				location ^~ /netalertx/ {
+				include /config/nginx/proxy.conf;
+
+				set \$upstream_app ${LOCALIPADD};
+				set \$upstream_port ${port};
+				set \$upstream_proto http;
+
+				rewrite ^/netalertx/(.*)\$ /\$1 break;
+
+				proxy_pass \$upstream_proto://\$upstream_app:\$upstream_port;
+
+				## sub_filter needs the upstream to send uncompressed
+				## bytes; NetAlertX honours Accept-Encoding so we
+				## stomp on it here.
+				proxy_set_header Accept-Encoding "";
+
+				sub_filter_once off;
+				sub_filter_types text/html text/css application/javascript;
+				sub_filter 'href="/'    'href="/netalertx/';
+				sub_filter "href='/"    "href='/netalertx/";
+				sub_filter 'src="/'     'src="/netalertx/';
+				sub_filter "src='/"     "src='/netalertx/";
+				sub_filter 'action="/'  'action="/netalertx/';
+				sub_filter 'url(/'      'url(/netalertx/';
+				}
+			NGINX
+			docker_configure_swag_proxy "netalertx" "${port}"
 		;;
 		"${commands[1]}") # remove
 			docker_operation_progress rm "$dockername"
@@ -90,6 +187,12 @@ function module_netalertx () {
 			fi
 			# Only remove data directory if container/image removal succeeded
 			docker_manage_base_dir remove "$base_dir"
+			# Drop the ARP-flux sysctl snippet seeded at install. The
+			# settings only mattered while NetAlertX was scanning;
+			# leaving them behind would surprise an admin who later
+			# investigates 'why is my host's ARP behaviour different'.
+			rm -f /etc/sysctl.d/99-armbian-netalertx-arp.conf
+			sysctl --system > /dev/null 2>&1 || true
 		;;
 		"${commands[3]}") # status
 			docker_is_installed "$dockername" "$dockerimage"

--- a/tools/modules/software/module_netbox.sh
+++ b/tools/modules/software/module_netbox.sh
@@ -11,6 +11,7 @@ module_options+=(
 	["module_netbox,arch"]="x86-64 arm64"
 	["module_netbox,dockerimage"]="netboxcommunity/netbox:latest"
 	["module_netbox,dockername"]="netbox"
+	["module_netbox,servicename"]="netbox"
 )
 
 #
@@ -31,7 +32,8 @@ function module_netbox () {
 	local DATABASE_PASSWORD="netbox"
 	local DATABASE_NAME="netbox"
 	local DATABASE_HOST="postgres-netbox"
-	local DATABASE_IMAGE="postgres:17-alpine"
+	local DATABASE_IMAGE="postgres"
+	local DATABASE_TAG="17-alpine"
 	local DATABASE_PORT="5432"
 
 	local commands
@@ -59,17 +61,44 @@ function module_netbox () {
 				module_redis install
 			fi
 			if ! docker container ls -a --format '{{.Names}}' | grep -q "^$DATABASE_HOST$"; then
-				module_postgres install $DATABASE_USER $DATABASE_PASSWORD $DATABASE_NAME $DATABASE_IMAGE $DATABASE_HOST
+				# module_postgres install <user> <password> <db> <image-repo> <image-tag> <container-name>
+				# (six positional args; image and tag must be passed separately, the
+				# previous five-arg form fused them and produced
+				# "postgres:17-alpine:postgres-netbox" — Docker 404 on pull.)
+				module_postgres install "$DATABASE_USER" "$DATABASE_PASSWORD" "$DATABASE_NAME" "$DATABASE_IMAGE" "$DATABASE_TAG" "$DATABASE_HOST"
 			fi
 
 			# Generate a random secret key (50+ chars)
 			NETBOX_SECRET_KEY=$(tr -dc 'A-Za-z0-9!@#$%^&*()-_=+' </dev/urandom | head -c 64)
+
+			# When SWAG is on this host, NetBox needs to know it lives
+			# at /netbox/ — otherwise Django renders absolute paths
+			# (form action="/login/?next=/netbox", static URIs like
+			# /static/…) that 404 once SWAG strips them at /netbox.
+			# Same applies to CSRF: Django rejects POSTs whose Origin
+			# header isn't in CSRF_TRUSTED_ORIGINS, so the SWAG host
+			# has to be listed there.
+			#
+			# Both settings are real Python in configuration.py, not
+			# env vars — netboxcommunity/netbox reads /etc/netbox/
+			# config/configuration.py, not BASE_PATH/CSRF_TRUSTED_*
+			# from the container env.
+			local netbox_base_path=""
+			local netbox_csrf_origins=""
+			if docker container ls -a --format "{{.Names}}" 2>/dev/null | grep -q "^swag$"; then
+				netbox_base_path="BASE_PATH = 'netbox/'"
+				if [[ -n "${SWAG_URL:-}" ]]; then
+					netbox_csrf_origins="CSRF_TRUSTED_ORIGINS = ['https://${SWAG_URL}']"
+				fi
+			fi
 
 			# Create configuration directory and file
 			mkdir -p "$base_dir/config"
 			if [[ ! -f "$base_dir/config/configuration.py" ]]; then
 				cat > "$base_dir/config/configuration.py" <<- EOT
 				ALLOWED_HOSTS = ['*']
+				${netbox_base_path}
+				${netbox_csrf_origins}
 				DATABASE = {
 					'NAME': '$DATABASE_NAME',
 					'USER': '$DATABASE_USER',
@@ -101,7 +130,10 @@ function module_netbox () {
 			# Pull image
 			docker_operation_progress pull "$dockerimage"
 
-			# Run container
+			# Run container. The BASE_PATH / CSRF_TRUSTED_ORIGINS
+			# settings that make NetBox SWAG-aware are baked into
+			# configuration.py above (env vars are not consumed by
+			# upstream NetBox).
 			if ! docker_operation_progress run "$dockername" \
 				-d \
 				--name="$dockername" \
@@ -142,6 +174,34 @@ function module_netbox () {
 					fi
 				done
 			fi
+
+			# Auto-configure SWAG reverse proxy if available.
+			# linuxserver/reverse-proxy-confs:master doesn't ship a
+			# netbox sample, so seed our own first.  No-op on hosts
+			# without SWAG, and skipped if a sample is already in
+			# place (LSIO upstream / hand-edited admin override).
+			# `<<-` strips ALL leading tabs (not spaces) from each line
+			# of the heredoc body before it reaches stdin, so the body
+			# below uses tabs to indent in source (editorconfig keeps
+			# the file tab-only) while emitting unindented nginx — the
+			# server doesn't care about whitespace inside a `location`
+			# block.
+			docker_seed_swag_proxy_conf "netbox" <<- 'NGINX'
+				## Custom Armbian seed — netbox subfolder proxy.
+				## upstream NetBox runs with BASE_PATH=netbox so the
+				## upstream URI is /netbox, not /. No path rewriting.
+				location ^~ /netbox {
+				include /config/nginx/proxy.conf;
+				include /config/nginx/resolver.conf;
+
+				set $upstream_app netbox;
+				set $upstream_port 8080;
+				set $upstream_proto http;
+
+				proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+				}
+			NGINX
+			docker_configure_swag_proxy "netbox" "8080"
 
 			# Delete default API Token
 			docker exec -i "$dockername" /opt/netbox/netbox/manage.py shell -c "from users.models import Token;Token.objects.filter(key='0123456789abcdef0123456789abcdef01234567').delete();"

--- a/tools/modules/software/module_netdata.sh
+++ b/tools/modules/software/module_netdata.sh
@@ -56,6 +56,12 @@ function module_netdata () {
 				--cap-add SYS_ADMIN \
 				--security-opt apparmor=unconfined \
 				"$dockerimage"
+			# Auto-configure SWAG reverse proxy if available.
+			# --network=host: LSIO's stock netdata.subfolder.conf
+			# resolves the upstream by container name on the lsio
+			# bridge, which misses host-network containers and 502s.
+			# Point the upstream at the host's IP instead.
+			docker_configure_swag_proxy "$dockername" "19999" "" "${LOCALIPADD}"
 		;;
 		"${commands[1]}") # remove
 			# Remove container and image (functions handle existence checks)

--- a/tools/modules/software/module_nextcloud.sh
+++ b/tools/modules/software/module_nextcloud.sh
@@ -9,7 +9,7 @@ module_options+=(
 	["module_nextcloud,group"]="Downloaders"
 	["module_nextcloud,port"]="1443"
 	["module_nextcloud,arch"]="x86-64 arm64"
-	["module_nextcloud,dockerimage"]="lscr.io/linuxserver/nextcloud:latest"
+	["module_nextcloud,dockerimage"]="linuxserver/nextcloud:latest"
 	["module_nextcloud,dockername"]="nextcloud"
 )
 #
@@ -50,6 +50,8 @@ function module_nextcloud () {
 				-v "${base_dir}/data:/data" \
 				--restart=always \
 				"$dockerimage"
+			# Auto-configure SWAG reverse proxy if available
+			docker_configure_swag_proxy "$dockername" "443" "https"
 		;;
 		"${commands[1]}") # remove
 			docker_operation_progress rm "$dockername"

--- a/tools/modules/software/module_octoprint.sh
+++ b/tools/modules/software/module_octoprint.sh
@@ -43,9 +43,13 @@ function module_octoprint () {
 			fi
 
 			# Run container
+			# --net=lsio so SWAG (on the same bridge) can reach
+			# upstream by container name; otherwise the proxy-conf's
+			# `proxy_pass http://octoprint:80` would fail to resolve.
 			docker_operation_progress run "$dockername" \
 				-d \
 				--name="$dockername" \
+				--net=lsio \
 				-v "${base_dir}:/octoprint/octoprint" \
 				$device_params \
 				-e TZ="$(cat /etc/timezone)" \
@@ -53,6 +57,47 @@ function module_octoprint () {
 				-p "${port}:80" \
 				--restart=always \
 				"$dockerimage"
+
+			# Auto-configure SWAG reverse proxy if available.
+			# linuxserver/reverse-proxy-confs:master doesn't ship an
+			# octoprint sample, so seed our own first. The conf
+			# rewrites /octoprint/* to /* on the upstream side and
+			# sets X-Script-Name so OctoPrint emits URLs with the
+			# /octoprint prefix.
+			docker_seed_swag_proxy_conf "octoprint" <<- 'NGINX'
+				## Custom Armbian seed — octoprint subfolder proxy.
+				## set/rewrite ordering matters: `rewrite … break;`
+				## ends the rewrite-module phase, and `set` lives in
+				## that same phase. Any `set` *after* the break is
+				## silently skipped at request time, leaving
+				## $upstream_* empty and proxy_pass rendering "://:".
+				## Always declare set vars first.
+				location ^~ /octoprint {
+				include /config/nginx/proxy.conf;
+				include /config/nginx/resolver.conf;
+
+				set $upstream_app octoprint;
+				set $upstream_port 80;
+				set $upstream_proto http;
+
+				rewrite ^/octoprint/?(.*)$ /$1 break;
+
+				proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+				proxy_set_header X-Script-Name /octoprint;
+				proxy_set_header X-Scheme $scheme;
+				}
+			NGINX
+			# Restart octoprint after the SWAG conf is in place. On a
+			# first install the container started under the old proxy
+			# state (or none) and gets stuck on "Loading OctoPrint's
+			# UI"; a restart picks up the X-Script-Name path and the
+			# UI loads correctly. No-op if the container isn't running
+			# (e.g. SWAG-less host where the seed/configure steps both
+			# returned non-zero).
+			if docker container ls --format '{{.Names}}' 2>/dev/null | grep -q "^${dockername}$"; then
+				docker restart "$dockername" >/dev/null 2>&1 || true
+			fi
 		;;
 		"${commands[1]}") # remove
 			docker_operation_progress rm "$dockername"

--- a/tools/modules/software/module_phpmyadmin.sh
+++ b/tools/modules/software/module_phpmyadmin.sh
@@ -9,7 +9,7 @@ module_options+=(
 	["module_phpmyadmin,group"]="Database"
 	["module_phpmyadmin,port"]="8071"
 	["module_phpmyadmin,arch"]="x86-64 arm64"
-	["module_phpmyadmin,dockerimage"]="lscr.io/linuxserver/phpmyadmin:latest"
+	["module_phpmyadmin,dockerimage"]="linuxserver/phpmyadmin:latest"
 	["module_phpmyadmin,dockername"]="phpmyadmin"
 )
 #
@@ -47,6 +47,8 @@ function module_phpmyadmin () {
 				-v "${base_dir}/config:/config" \
 				--restart=always \
 				"$dockerimage"
+			# Auto-configure SWAG reverse proxy if available
+			docker_configure_swag_proxy "$dockername" "80"
 		;;
 		"${commands[1]}") # remove
 			docker_operation_progress rm "$dockername"

--- a/tools/modules/software/module_pi-hole.sh
+++ b/tools/modules/software/module_pi-hole.sh
@@ -70,6 +70,8 @@ function module_pi_hole () {
 				-e FTLCONF_LOCAL_IPV4="${LOCALIPADD}" \
 				-e FTLCONF_dns_upstreams="unbound#5335" \
 				"$dockerimage"
+			# Auto-configure SWAG reverse proxy if available
+			docker_configure_swag_proxy "$dockername" "80"
 
 			# Add container IP to DNS configuration after container is running
 			if srv_active systemd-resolved; then

--- a/tools/modules/software/module_portainer.sh
+++ b/tools/modules/software/module_portainer.sh
@@ -7,10 +7,11 @@ module_options+=(
 	["module_portainer,status"]="Active"
 	["module_portainer,doc_link"]="https://docs.portainer.io/"
 	["module_portainer,group"]="Containers"
-	["module_portainer,port"]="9000"
+	["module_portainer,port"]="9443"
 	["module_portainer,arch"]="x86-64 arm64"
 	["module_portainer,dockerimage"]="portainer/portainer-ce:latest"
 	["module_portainer,dockername"]="portainer"
+	["module_portainer,servicename"]="portainer"
 )
 #
 # Module Portainer
@@ -39,6 +40,7 @@ function module_portainer () {
 
 			docker_operation_progress run "$dockername" \
 				-d \
+				--net=lsio \
 				--name="$dockername" \
 				--restart=always \
 				-p 9000:9000 \
@@ -47,6 +49,8 @@ function module_portainer () {
 				-v /run/docker.sock:/var/run/docker.sock \
 				-v "${base_dir}/data:/data" \
 				"$dockerimage"
+			# Auto-configure SWAG reverse proxy if available
+			docker_configure_swag_proxy "portainer" "9443" "https"
 		;;
 		"${commands[1]}") # remove
 			# Remove container and image (functions handle existence checks)

--- a/tools/modules/software/module_prometheus.sh
+++ b/tools/modules/software/module_prometheus.sh
@@ -48,7 +48,34 @@ function module_prometheus () {
 					> "$base_dir/prometheus.yml"
 			fi
 
-			# Run container
+			# Args after the image name REPLACE the prom/prometheus
+			# default CMD wholesale (config.file, storage.tsdb.path,
+			# console libraries / templates). To add anything we have
+			# to redeclare those defaults, otherwise Prometheus starts
+			# without --config.file, doesn't pick up the mounted
+			# prometheus.yml, and SWAG returns 502.
+			local -a prometheus_args=(
+				"--config.file=/etc/prometheus/prometheus.yml"
+				"--storage.tsdb.path=/prometheus"
+				"--web.console.libraries=/usr/share/prometheus/console_libraries"
+				"--web.console.templates=/usr/share/prometheus/consoles"
+			)
+			# When SWAG is on this host, tell Prometheus its external
+			# URL so the rendered HTML, redirects, and API responses
+			# use the /prometheus subpath. SWAG below rewrites
+			# /prometheus/(.*) → /$1 at the proxy, so internally
+			# Prometheus stays at route-prefix=/ — that keeps direct
+			# port access working too.
+			if docker container ls -a --format "{{.Names}}" 2>/dev/null | grep -q "^swag$" \
+				&& [[ -n "${SWAG_URL:-}" ]]; then
+				prometheus_args+=(
+					"--web.external-url=https://${SWAG_URL}/prometheus/"
+					"--web.route-prefix=/"
+				)
+			fi
+
+			# Run container — prometheus_args go after the image name,
+			# they're CMD overrides for the entrypoint.
 			docker_operation_progress run "$dockername" \
 				-d \
 				--name="$dockername" \
@@ -56,7 +83,30 @@ function module_prometheus () {
 				-p "${port}:9090" \
 				-v "${base_dir}:/etc/prometheus" \
 				--restart=always \
-				"$dockerimage"
+				"$dockerimage" \
+				"${prometheus_args[@]}"
+
+			# Auto-configure SWAG reverse proxy if available.
+			# linuxserver/reverse-proxy-confs:master doesn't ship a
+			# prometheus sample, so seed our own. set/rewrite ordering
+			# matters: any `set` after `rewrite … break;` is silently
+			# skipped at request time and proxy_pass renders "://:".
+			docker_seed_swag_proxy_conf "prometheus" <<- 'NGINX'
+				## Custom Armbian seed — prometheus subfolder proxy.
+				location ^~ /prometheus {
+				include /config/nginx/proxy.conf;
+				include /config/nginx/resolver.conf;
+
+				set $upstream_app prometheus;
+				set $upstream_port 9090;
+				set $upstream_proto http;
+
+				rewrite ^/prometheus/?(.*)$ /$1 break;
+
+				proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+				}
+			NGINX
+			docker_configure_swag_proxy "prometheus" "9090"
 		;;
 		"${commands[1]}") # remove
 			docker_operation_progress rm "$dockername"

--- a/tools/modules/software/module_prowlarr.sh
+++ b/tools/modules/software/module_prowlarr.sh
@@ -9,7 +9,7 @@ module_options+=(
 	["module_prowlarr,group"]="Database"
 	["module_prowlarr,port"]="9696"
 	["module_prowlarr,arch"]="x86-64 arm64"
-	["module_prowlarr,dockerimage"]="lscr.io/linuxserver/prowlarr:latest"
+	["module_prowlarr,dockerimage"]="linuxserver/prowlarr:latest"
 	["module_prowlarr,dockername"]="prowlarr"
 )
 #
@@ -46,6 +46,8 @@ function module_prowlarr () {
 				-v "${base_dir}/config:/config" \
 				--restart=always \
 				"$dockerimage"
+			# Auto-configure SWAG reverse proxy if available
+			docker_configure_swag_proxy "$dockername" "9696"
 		;;
 		"${commands[1]}") # remove
 			docker_operation_progress rm "$dockername"

--- a/tools/modules/software/module_qbittorrent.sh
+++ b/tools/modules/software/module_qbittorrent.sh
@@ -9,7 +9,7 @@ module_options+=(
 	["module_qbittorrent,group"]="Downloaders"
 	["module_qbittorrent,port"]="8090"
 	["module_qbittorrent,arch"]="x86-64 arm64"
-	["module_qbittorrent,dockerimage"]="lscr.io/linuxserver/qbittorrent:latest"
+	["module_qbittorrent,dockerimage"]="linuxserver/qbittorrent:latest"
 	["module_qbittorrent,dockername"]="qbittorrent"
 )
 #
@@ -50,6 +50,8 @@ function module_qbittorrent () {
 				-v "${base_dir}/downloads:/downloads" \
 				--restart=always \
 				"$dockerimage"
+			# Auto-configure SWAG reverse proxy if available
+			docker_configure_swag_proxy "$dockername" "8090"
 
 			# Get temporary password from logs
 			local temp_password

--- a/tools/modules/software/module_radarr.sh
+++ b/tools/modules/software/module_radarr.sh
@@ -9,7 +9,7 @@ module_options+=(
 	["module_radarr,group"]="Downloaders"
 	["module_radarr,port"]="7878"
 	["module_radarr,arch"]="x86-64 arm64"
-	["module_radarr,dockerimage"]="lscr.io/linuxserver/radarr:latest"
+	["module_radarr,dockerimage"]="linuxserver/radarr:latest"
 	["module_radarr,dockername"]="radarr"
 )
 #
@@ -47,6 +47,8 @@ function module_radarr () {
 				-v "${base_dir}/downloads:/downloads" \
 				--restart=always \
 				"$dockerimage"
+			# Auto-configure SWAG reverse proxy if available
+			docker_configure_swag_proxy "$dockername" "7878"
 		;;
 		"${commands[1]}") # remove
 			# Remove container and image (functions handle existence checks)

--- a/tools/modules/software/module_sabnzbd.sh
+++ b/tools/modules/software/module_sabnzbd.sh
@@ -9,7 +9,7 @@ module_options+=(
 	["module_sabnzbd,group"]="Downloaders"
 	["module_sabnzbd,port"]="8380"
 	["module_sabnzbd,arch"]="x86-64 arm64"
-	["module_sabnzbd,dockerimage"]="lscr.io/linuxserver/sabnzbd:latest"
+	["module_sabnzbd,dockerimage"]="linuxserver/sabnzbd:latest"
 	["module_sabnzbd,dockername"]="sabnzbd"
 )
 #
@@ -47,6 +47,8 @@ function module_sabnzbd () {
 				-v "${base_dir}/incomplete:/incomplete-downloads" \
 				--restart=always \
 				"$dockerimage"
+			# Auto-configure SWAG reverse proxy if available
+			docker_configure_swag_proxy "$dockername" "8080"
 		;;
 		"${commands[1]}") # remove
 			# Remove container and image (functions handle existence checks)

--- a/tools/modules/software/module_sonarr.sh
+++ b/tools/modules/software/module_sonarr.sh
@@ -9,7 +9,7 @@ module_options+=(
 	["module_sonarr,group"]="Downloaders"
 	["module_sonarr,port"]="8989"
 	["module_sonarr,arch"]="x86-64 arm64"
-	["module_sonarr,dockerimage"]="lscr.io/linuxserver/sonarr:latest"
+	["module_sonarr,dockerimage"]="linuxserver/sonarr:latest"
 	["module_sonarr,dockername"]="sonarr"
 )
 #
@@ -47,6 +47,8 @@ function module_sonarr () {
 				-v "${base_dir}/downloads:/downloads" \
 				--restart=always \
 				"$dockerimage"
+			# Auto-configure SWAG reverse proxy if available
+			docker_configure_swag_proxy "$dockername" "8989"
 		;;
 		"${commands[1]}") # remove
 			# Remove container and image (functions handle existence checks)

--- a/tools/modules/software/module_stirling.sh
+++ b/tools/modules/software/module_stirling.sh
@@ -37,6 +37,16 @@ function module_stirling () {
 			# Create subdirectories
 			mkdir -p "${base_dir}/trainingData" "${base_dir}/extraConfigs" "${base_dir}/logs" "${base_dir}/customFiles"
 
+			# When SWAG is on this host, tell Stirling PDF (Spring
+			# Boot) its base path via SERVER_SERVLET_CONTEXT_PATH so
+			# the app emits /stirling-pdf/-prefixed asset URLs and
+			# routes its own endpoints under that prefix. LSIO's
+			# stock subfolder.conf-sample expects exactly this.
+			local -a stirling_extra_env=()
+			if docker container ls -a --format "{{.Names}}" 2>/dev/null | grep -q "^swag$"; then
+				stirling_extra_env+=(-e "SERVER_SERVLET_CONTEXT_PATH=/stirling-pdf")
+			fi
+
 			# Run container
 			docker_operation_progress run "$dockername" \
 				-d \
@@ -50,8 +60,12 @@ function module_stirling () {
 				-e DOCKER_ENABLE_SECURITY=false \
 				-e INSTALL_BOOK_AND_ADVANCED_HTML_OPS=false \
 				-e LANGS=en_GB \
+				"${stirling_extra_env[@]}" \
 				--restart=always \
 				"$dockerimage"
+
+			# Auto-configure SWAG reverse proxy if available.
+			docker_configure_swag_proxy "$dockername" "8080"
 		;;
 		"${commands[1]}") # remove
 			docker_operation_progress rm "$dockername"

--- a/tools/modules/software/module_stirling.sh
+++ b/tools/modules/software/module_stirling.sh
@@ -65,6 +65,33 @@ function module_stirling () {
 				"$dockerimage"
 
 			# Auto-configure SWAG reverse proxy if available.
+			# linuxserver/reverse-proxy-confs:master doesn't ship a
+			# stirling-pdf sample, so we seed our own. Stirling PDF
+			# (Spring Boot) is configured via SERVER_SERVLET_CONTEXT_PATH
+			# above to serve at /stirling-pdf, so the upstream URI
+			# matches the request URI 1:1 — no rewrite needed.
+			# client_max_body_size is bumped because Stirling's PDF
+			# upload tools push multi-hundred-MB files; SWAG's default
+			# 2M would 413 on anything larger than a small report.
+			docker_seed_swag_proxy_conf "$dockername" <<- 'NGINX'
+				## Custom Armbian seed — stirling-pdf subfolder proxy.
+				## Pairs with SERVER_SERVLET_CONTEXT_PATH=/stirling-pdf
+				## set on the container.
+				location = /stirling-pdf { return 301 /stirling-pdf/; }
+
+				location ^~ /stirling-pdf/ {
+				include /config/nginx/proxy.conf;
+				include /config/nginx/resolver.conf;
+
+				set $upstream_app stirling-pdf;
+				set $upstream_port 8080;
+				set $upstream_proto http;
+
+				client_max_body_size 0;
+
+				proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+				}
+			NGINX
 			docker_configure_swag_proxy "$dockername" "8080"
 		;;
 		"${commands[1]}") # remove

--- a/tools/modules/software/module_swag.sh
+++ b/tools/modules/software/module_swag.sh
@@ -3,23 +3,25 @@ module_options+=(
 	["module_swag,maintainer"]="@igorpecovnik"
 	["module_swag,feature"]="module_swag"
 	["module_swag,example"]="install remove purge status password help"
-	["module_swag,desc"]="Secure Web Application Gateway "
+	["module_swag,desc"]="Secure Web Application Gateway"
 	["module_swag,status"]="Active"
 	["module_swag,doc_link"]="https://github.com/linuxserver/docker-swag"
 	["module_swag,group"]="WebHosting"
 	["module_swag,port"]="443"
 	["module_swag,arch"]="x86-64 arm64"
-	["module_swag,dockerimage"]="lscr.io/linuxserver/swag:latest"
+	["module_swag,dockerimage"]="linuxserver/swag:latest"
 	["module_swag,dockername"]="swag"
 )
 
+#
+# Module SWAG - Secure Web Application Gateway
+# A reverse proxy with SSL certification automation
+#
 function module_swag() {
 	local title="SWAG"
 	local dockerimage="${module_options["module_swag,dockerimage"]}"
 	local dockername="${module_options["module_swag,dockername"]}"
 	local port="${module_options["module_swag,port"]}"
-
-	local container=$(docker_get_container_id "$dockername")
 
 	local commands
 	IFS=' ' read -r -a commands <<< "${module_options["module_swag,example"]}"
@@ -29,84 +31,190 @@ function module_swag() {
 	case "$1" in
 		"${commands[0]}") # install
 			# Get URL via dialog
-			SWAG_URL=$(dialog --title \
-				"Secure Web Application Gateway URL?" \
-				--inputbox "\nExamples: myhome.domain.org (port 80 and 443 must be exposed to internet)" \
-				8 80 "" 3>&1 1>&2 2>&3);
+			local swag_url
+			swag_url=$(dialog_inputbox "Secure Web Application Gateway - URL" \
+				"Enter your fully qualified domain name\n\nExamples:\n  - myhome.domain.org\n  - example.com\n\nNote: Ports 80 and 443 must be exposed to the internet" \
+				"" 15 90)
 
-			if [[ ${SWAG_URL} && $? -eq 0 ]]; then
-				# Adjust hostname
-				hostnamectl set-hostname $(echo ${SWAG_URL} | sed -E 's/^\s*.*:\/\///g')
-
-				# Pull image
-				docker_operation_progress pull "$dockerimage"
-
-				# Create base directory
-				docker_manage_base_dir create "$base_dir" || return 1
-
-				# Run container
-				docker_operation_progress run "$dockername" \
-					-d \
-					--name="$dockername" \
-					--cap-add=NET_ADMIN \
-					--net=lsio \
-					-e PUID="${DOCKER_USERUID}" \
-					-e PGID="${DOCKER_GROUPUID}" \
-					-e TZ="$(cat /etc/timezone)" \
-					-e URL="${SWAG_URL}" \
-					-e VALIDATION=http \
-					-p 443:443 \
-					-p 80:80 \
-					-v "${base_dir}/config:/config" \
-					--restart unless-stopped \
-					"$dockerimage"
-
-				# Set password
-				${module_options["module_swag,feature"]} ${commands[4]}
-			else
-				show_message <<< "Entering fully qualified domain name is required!"
+			# Check if user cancelled or entered empty value
+			if [[ -z "$swag_url" ]]; then
+				dialog_msgbox "Installation Cancelled" \
+					"A fully qualified domain name is required for SWAG to function properly." 10 70
+				return 1
 			fi
-		;;
+
+			# Clean URL (remove protocol if present)
+			swag_url=$(echo "$swag_url" | sed -E 's|^\s*https?://||' | sed 's|/.*$||')
+
+			# Optional: Adjust system hostname
+			if dialog_yesno "Update System Hostname" \
+				"SWAG works best when the system hostname matches your domain.\n\nUpdate system hostname to: ${swag_url}?\n\nThis requires root privileges." \
+				"Update" "Keep" 15 80; then
+				if ! hostnamectl set-hostname "${swag_url}" 2>/dev/null; then
+					dialog_msgbox "Hostname Update Failed" \
+						"Failed to update hostname.\n\nYou can set it manually with:\n  sudo hostnamectl set-hostname ${swag_url}\n\nContinuing with installation..." 12 70
+				fi
+			fi
+
+			# Pull image
+			if ! docker_operation_progress pull "$dockerimage"; then
+				dialog_msgbox "Installation Failed" \
+					"Failed to pull Docker image:\n  $dockerimage\n\nPlease check your internet connection and try again." 12 70
+				return 1
+			fi
+
+			# Create base directory
+			if ! docker_manage_base_dir create "$base_dir"; then
+				dialog_msgbox "Installation Failed" \
+					"Failed to create directory:\n  $base_dir" 10 60
+				return 1
+			fi
+
+
+			# Run container
+			if ! docker_operation_progress run "$dockername" \
+				-d \
+				--name="$dockername" \
+				--cap-add=NET_ADMIN \
+				--net=lsio \
+				-e PUID="${DOCKER_USERUID}" \
+				-e PGID="${DOCKER_GROUPUID}" \
+				-e TZ="$(cat /etc/timezone)" \
+				-e URL="${swag_url}" \
+				-e VALIDATION=http \
+				-p 443:443 \
+				-p 80:80 \
+				-v "${base_dir}/config:/config" \
+				--restart unless-stopped \
+				"$dockerimage"; then
+				dialog_msgbox "Installation Failed" \
+					"Failed to start SWAG container.\n\nCheck logs with:\n  docker logs $dockername" 12 70
+				return 1
+			fi
+
+			# Store URL globally for module-wide use (replaces IP detection)
+			# This file is used by password, help, and status commands
+			echo "$swag_url" > "${base_dir}/config/SWAG_URL"
+
+			# Restart container to initialize SSL certificates
+			dialog_infobox "Initializing SSL Certificates" \
+				"SWAG installed. Restarting to initialize SSL certificates for:\n  ${swag_url}\n\nPlease wait..." 12 70
+			sleep 2
+			docker restart "$dockername" >/dev/null 2>&1
+
+			# Wait for SSL certificate initialization (up to 30 seconds)
+			local wait_count=0
+			while [[ $wait_count -lt 30 ]]; do
+				if docker exec "$dockername" test -f /config/nginx/dynamicssl.conf 2>/dev/null; then
+					break
+				fi
+				sleep 1
+				((wait_count++))
+			done
+
+			# Set password
+			${module_options["module_swag,feature"]} ${commands[4]}
+			;;
+
 		"${commands[1]}") # remove
 			docker_operation_progress rm "$dockername"
 			docker_operation_progress rmi "$dockerimage"
-		;;
+			;;
+
 		"${commands[2]}") # purge
 			# Remove container and image first
 			if ! ${module_options["module_swag,feature"]} ${commands[1]}; then
+				dialog_msgbox "Purge Failed" \
+					"Failed to remove SWAG container and/or image.\n\nData directory preserved at:\n  $base_dir" 12 70
 				return 1
 			fi
 			# Only remove data directory if container/image removal succeeded
 			docker_manage_base_dir remove "$base_dir"
-		;;
+			dialog_msgbox "Purge Complete" \
+				"SWAG has been completely removed, including all data." 10 60
+			;;
+
 		"${commands[3]}") # status
 			docker_is_installed "$dockername" "$dockerimage"
-		;;
+			;;
+
 		"${commands[4]}") # password
-			SWAG_USER=$(dialog_inputbox "Secure webserver with .htaccess username and password" \
-				"\nHit enter for USERNAME defaults" "armbian" 9 70)
+			# Check if container is running
+			if ! docker_get_container_id "$dockername" >/dev/null 2>&1; then
+				dialog_msgbox "Container Not Running" \
+					"SWAG container is not running.\n\nPlease install SWAG first:\n  ${module_options["module_swag,feature"]} ${commands[0]}" 12 70
+				return 1
+			fi
+
+			# Read global SWAG_URL configuration (fallback to IP if not found)
+			local display_url="$LOCALIPADD"
+			if [[ -f "${base_dir}/config/SWAG_URL" ]]; then
+				display_url=$(cat "${base_dir}/config/SWAG_URL")
+			fi
+
+			local swag_user
+			swag_user=$(dialog_inputbox "Configure .htaccess Authentication" \
+				"Enter username for .htaccess authentication\n\nThis will secure web access to your services" \
+				"armbian" 12 80)
+
+			if [[ -z "$swag_user" ]]; then
+				dialog_msgbox "Operation Cancelled" \
+					"Username cannot be empty. Operation cancelled." 10 60
+				return 1
+			fi
+
 			# Pre-generate default password
-			local default_password=$(tr -dc 'A-Za-z0-9=' < /dev/urandom | head -c 10)
+			local default_password
+			default_password=$(tr -dc 'A-Za-z0-9=' < /dev/urandom | head -c 10)
+
 			# Ask if user wants to use auto-generated password
+			local swag_password
 			if dialog_yesno "Password Configuration" \
-				"\nAuto-generated password for '${SWAG_USER}':\n\n  ${default_password}\n\nUse this password?" \
-				"Use Generated" "Enter Own" 12 70; then
-				SWAG_PASSWORD="$default_password"
+				"Auto-generated password for '${swag_user}':\n\n  ${default_password}\n\nUse this secure password?" \
+				"Use Generated" "Enter Own" 15 80; then
+				swag_password="$default_password"
 			else
-				SWAG_PASSWORD=$(dialog_passwordbox "Enter new password for ${SWAG_USER}" \
-					"\nEnter a custom password" 9 70)
+				swag_password=$(dialog_passwordbox "Enter Custom Password" \
+					"Enter a secure password for ${swag_user}\n\nMinimum 8 characters recommended" 12 80)
+
+				if [[ -z "$swag_password" ]]; then
+					dialog_msgbox "Operation Cancelled" \
+						"Password cannot be empty. Operation cancelled." 10 60
+					return 1
+				fi
 			fi
-			if [[ "${SWAG_USER}" && "${SWAG_PASSWORD}" ]]; then
-				docker exec -it "$dockername" htpasswd -b -c /config/nginx/.htpasswd ${SWAG_USER} ${SWAG_PASSWORD} >/dev/null 2>&1
-				docker restart "$dockername" >/dev/null
+
+			# Set the password in the container
+			if docker exec -it "$dockername" htpasswd -b -c /config/nginx/.htpasswd "${swag_user}" "${swag_password}" >/dev/null 2>&1; then
+				# Restart container to apply changes
+				docker restart "$dockername" >/dev/null 2>&1
+
+				# Show success message with credentials (using domain URL, not IP)
+				dialog_infobox "Password Configuration Complete" \
+					"Username: ${swag_user}\nPassword: ${swag_password}\n\nWeb Interface: https://${display_url}\n\nPlease save these credentials!" 15 80
+
+				# Keep the info box visible for 5 seconds
+				sleep 5
+			else
+				dialog_msgbox "Password Configuration Failed" \
+					"Failed to set .htaccess password.\n\nCheck container logs with:\n  docker logs $dockername" 12 70
+				return 1
 			fi
-		;;
+			;;
+
 		"${commands[5]}") # help
+			# Read global SWAG_URL configuration (fallback to IP if not found)
+			local stored_url="$LOCALIPADD"
+			if [[ -f "${base_dir}/config/SWAG_URL" ]]; then
+				stored_url=$(cat "${base_dir}/config/SWAG_URL")
+			fi
+
 			show_module_help "module_swag" "$title" \
-				"Docker Image: $dockerimage\nPorts: 80, 443\n\nThis module requires a domain name during install."
-		;;
+				"Web Interface: https://${stored_url}\nPorts: 80, 443\nDocker Image: $dockerimage\n\nThis module requires a domain name during install.\n\nDocumentation: ${module_options["module_swag,doc_link"]}"
+			;;
+
 		*)
 			${module_options["module_swag,feature"]} ${commands[5]}
-		;;
+			;;
 	esac
 }

--- a/tools/modules/software/module_swag.sh
+++ b/tools/modules/software/module_swag.sh
@@ -225,8 +225,12 @@ function module_swag() {
 
 			# Set the password in the container
 			if docker exec -it "$dockername" htpasswd -b -c /config/nginx/.htpasswd "${swag_user}" "${swag_password}" >/dev/null 2>&1; then
-				# Restart container to apply changes
-				docker restart "$dockername" >/dev/null 2>&1
+				# nginx re-reads .htpasswd on every request — no
+				# reload is strictly required for the new credentials
+				# to take effect. Send SIGHUP anyway so any concurrent
+				# config edit lands at the same time, without dropping
+				# active connections (a full `docker restart` would).
+				docker exec "$dockername" nginx -s reload >/dev/null 2>&1 || true
 
 				# Show success message with credentials (using domain URL, not IP)
 				dialog_infobox "Password Configuration Complete" \

--- a/tools/modules/software/module_swag.sh
+++ b/tools/modules/software/module_swag.sh
@@ -141,15 +141,43 @@ function module_swag() {
 			sleep 2
 			docker restart "$dockername" >/dev/null 2>&1
 
-			# Wait for SSL certificate initialization (up to 30 seconds)
+			# Wait for the actual cert file to appear, not for
+			# dynamicssl.conf — the latter is created during nginx
+			# config setup regardless of whether Let's Encrypt
+			# succeeded or failed, so the previous check passed for
+			# every install including ones that ended with no cert.
+			# 90 s is the practical upper bound: ACME provisioning
+			# typically completes within 15 s, but rate-limit holdoffs
+			# and slow LE acks can push to a minute.
 			local wait_count=0
-			while [[ $wait_count -lt 30 ]]; do
-				if docker exec "$dockername" test -f /config/nginx/dynamicssl.conf 2>/dev/null; then
+			local cert_path="/config/keys/letsencrypt/fullchain.pem"
+			while [[ $wait_count -lt 90 ]]; do
+				if docker exec "$dockername" test -f "$cert_path" 2>/dev/null; then
 					break
 				fi
 				sleep 1
 				((wait_count++))
 			done
+
+			# Verify the cert was actually issued. If not, pull the
+			# tail of the container log and grep for the typical ACME
+			# failure markers so the user sees *why* it failed instead
+			# of an opaque "installed" dialog. Don't return non-zero —
+			# SWAG itself is running and the user can fix DNS / unblock
+			# port 80 and `docker restart swag` to retry without
+			# reinstalling.
+			if ! docker exec "$dockername" test -f "$cert_path" 2>/dev/null; then
+				local cert_failure_excerpt
+				cert_failure_excerpt=$(docker logs --tail=200 "$dockername" 2>&1 \
+					| grep -iE 'error|failed|challenge|timeout|rate limit|invalid|unauthorized|connection refused' \
+					| tail -10)
+				if [[ -z "$cert_failure_excerpt" ]]; then
+					cert_failure_excerpt="(no obvious error markers found in last 200 log lines — run 'docker logs swag' for the full output)"
+				fi
+				dialog_msgbox "SSL Certificate Not Issued" \
+					"Waited 90 s but no Let's Encrypt cert appeared at:\n  ${cert_path}\n\nMost common causes:\n  - ${swag_url} doesn't resolve to this host's public IP\n  - Port 80 isn't reachable from the internet (firewall/NAT)\n  - Let's Encrypt rate-limit hit (5 cert/week per registered domain)\n\nLog excerpt:\n${cert_failure_excerpt}\n\nFix the underlying issue and run:\n  docker restart ${dockername}\nto retry. SWAG itself is running — services proxied through it will work once a cert is in place." \
+					25 100
+			fi
 
 			# Set password
 			${module_options["module_swag,feature"]} ${commands[4]}

--- a/tools/modules/software/module_swag.sh
+++ b/tools/modules/software/module_swag.sh
@@ -46,6 +46,45 @@ function module_swag() {
 			# Clean URL (remove protocol if present)
 			swag_url=$(echo "$swag_url" | sed -E 's|^\s*https?://||' | sed 's|/.*$||')
 
+			# DNS sanity check. Let's Encrypt's HTTP-01 challenge can
+			# only succeed if the user's FQDN resolves to this host's
+			# public IPv4. Detect mismatches early so the user can fix
+			# DNS before we pull a 200 MB image and discover the cert
+			# request fails. We don't hard-block — split-horizon DNS,
+			# users mid-DNS-propagation, or test deployments are
+			# legitimate cases for proceeding anyway.
+			local resolved_ip="" public_ip=""
+			# getent uses the system resolver (libc) — same resolver
+			# Docker/SWAG will use at runtime. Take only the first
+			# IPv4 to keep the comparison meaningful for users with
+			# split AAAA/A records.
+			resolved_ip=$(getent ahostsv4 "$swag_url" 2>/dev/null \
+				| awk 'NR==1 {print $1}')
+			# Try a few outbound endpoints; abort the loop on the
+			# first valid IPv4 response. Skip the comparison entirely
+			# if all fail (firewalled outbound, no internet) — better
+			# than a false-positive warning.
+			local endpoint
+			for endpoint in https://api.ipify.org https://ifconfig.me https://icanhazip.com; do
+				public_ip=$(curl -sS --max-time 4 -4 "$endpoint" 2>/dev/null | tr -d '[:space:]')
+				[[ "$public_ip" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]] && break
+				public_ip=""
+			done
+
+			if [[ -z "$resolved_ip" ]]; then
+				if ! dialog_yesno "DNS Resolution Failed" \
+					"${swag_url} did not resolve to any IPv4 address.\n\nLet's Encrypt cannot issue a certificate until the domain points at this host.\n\nProceed anyway?\n  (cert acquisition will retry on next container restart)" \
+					"Proceed" "Cancel" 14 80; then
+					return 1
+				fi
+			elif [[ -n "$public_ip" && "$resolved_ip" != "$public_ip" ]]; then
+				if ! dialog_yesno "DNS Mismatch" \
+					"${swag_url} resolves to:\n  ${resolved_ip}\n\nThis host's public IP is:\n  ${public_ip}\n\nLet's Encrypt's HTTP-01 challenge will land on ${resolved_ip}, not this host. Cert acquisition will fail.\n\nProceed anyway?" \
+					"Proceed" "Cancel" 18 80; then
+					return 1
+				fi
+			fi
+
 			# Optional: Adjust system hostname
 			if dialog_yesno "Update System Hostname" \
 				"SWAG works best when the system hostname matches your domain.\n\nUpdate system hostname to: ${swag_url}?\n\nThis requires root privileges." \

--- a/tools/modules/software/module_swag.sh
+++ b/tools/modules/software/module_swag.sh
@@ -254,11 +254,28 @@ function module_swag() {
 
 			# Set the password in the container
 			if docker exec -it "$dockername" htpasswd -b -c /config/nginx/.htpasswd "${swag_user}" "${swag_password}" >/dev/null 2>&1; then
+				# Retroactively enable HTTP basic auth on every
+				# service whose proxy-conf is already enabled.
+				# Newly-installed services pick up auth via
+				# docker_configure_swag_proxy directly, but services
+				# installed BEFORE the password was set still ship
+				# with auth_basic commented out — apply it now so the
+				# password actually gates everything proxied through
+				# SWAG, which is what the operator just asked for.
+				local enabled_conf service
+				while IFS= read -r enabled_conf; do
+					[[ -z "$enabled_conf" ]] && continue
+					service="${enabled_conf##*/}"
+					service="${service%.subfolder.conf.enabled}"
+					docker_swag_enable_basic_auth "$service"
+				done < <(docker exec "$dockername" sh -c 'ls /config/nginx/proxy-confs/*.subfolder.conf.enabled 2>/dev/null')
+
 				# nginx re-reads .htpasswd on every request — no
 				# reload is strictly required for the new credentials
-				# to take effect. Send SIGHUP anyway so any concurrent
-				# config edit lands at the same time, without dropping
-				# active connections (a full `docker restart` would).
+				# to take effect. Send SIGHUP anyway so the
+				# auth_basic edits above land alongside it, without
+				# dropping active connections (a full `docker restart`
+				# would).
 				docker exec "$dockername" nginx -s reload >/dev/null 2>&1 || true
 
 				# Show success message with credentials (using domain URL, not IP)

--- a/tools/modules/software/module_swag.sh
+++ b/tools/modules/software/module_swag.sh
@@ -85,14 +85,15 @@ function module_swag() {
 				fi
 			fi
 
-			# Optional: Adjust system hostname
-			if dialog_yesno "Update System Hostname" \
-				"SWAG works best when the system hostname matches your domain.\n\nUpdate system hostname to: ${swag_url}?\n\nThis requires root privileges." \
-				"Update" "Keep" 15 80; then
-				if ! hostnamectl set-hostname "${swag_url}" 2>/dev/null; then
-					dialog_msgbox "Hostname Update Failed" \
-						"Failed to update hostname.\n\nYou can set it manually with:\n  sudo hostnamectl set-hostname ${swag_url}\n\nContinuing with installation..." 12 70
-				fi
+			# Align the system hostname with the SWAG domain. armbian-config
+			# already runs with root, so do this silently rather than
+			# prompting — the original yes/no dialog was just noise on
+			# the install path. Only surface a message if the call
+			# fails (e.g. hostnamectl missing in a CI minimal image),
+			# in which case we continue without aborting the install.
+			if ! hostnamectl set-hostname "${swag_url}" 2>/dev/null; then
+				dialog_msgbox "Hostname Update Failed" \
+					"Could not set the system hostname to:\n  ${swag_url}\n\nSet it manually after install:\n  sudo hostnamectl set-hostname ${swag_url}\n\nContinuing with installation..." 12 70
 			fi
 
 			# Pull image

--- a/tools/modules/software/module_syncthing.sh
+++ b/tools/modules/software/module_syncthing.sh
@@ -9,7 +9,7 @@ module_options+=(
 	["module_syncthing,group"]="Media"
 	["module_syncthing,port"]="8884 22000 21027"
 	["module_syncthing,arch"]="x86-64 arm64"
-	["module_syncthing,dockerimage"]="lscr.io/linuxserver/syncthing:latest"
+	["module_syncthing,dockerimage"]="linuxserver/syncthing:latest"
 	["module_syncthing,dockername"]="syncthing"
 )
 #
@@ -55,6 +55,8 @@ function module_syncthing () {
 				-v "${base_dir}/data2:/data2" \
 				--restart=always \
 				"$dockerimage"
+			# Auto-configure SWAG reverse proxy if available
+			docker_configure_swag_proxy "$dockername" "8384"
 		;;
 		"${commands[1]}") # remove
 			docker_operation_progress rm "$dockername"

--- a/tools/modules/software/module_transmission.sh
+++ b/tools/modules/software/module_transmission.sh
@@ -9,8 +9,9 @@ module_options+=(
 	["module_transmission,group"]="Downloaders"
 	["module_transmission,port"]="9091"
 	["module_transmission,arch"]="x86-64 arm64"
-	["module_transmission,dockerimage"]="lscr.io/linuxserver/transmission:latest"
+	["module_transmission,dockerimage"]="linuxserver/transmission:latest"
 	["module_transmission,dockername"]="transmission"
+	["module_transmission,servicename"]="transmission"
 )
 #
 # Module Transmission
@@ -58,7 +59,9 @@ function module_transmission () {
 				-v "${base_dir}/watch:/watch" \
 				--restart=always \
 				"$dockerimage"
-		;;
+		# Auto-configure SWAG reverse proxy if available
+		docker_configure_swag_proxy "transmission" "9091"
+			;;
 		"${commands[1]}") # remove
 			# Remove container and image (functions handle existence checks)
 			docker_operation_progress rm "$dockername"

--- a/tools/modules/software/module_uptime-kuma.sh
+++ b/tools/modules/software/module_uptime-kuma.sh
@@ -74,12 +74,12 @@ function module_uptimekuma () {
 
 				proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
-				## Socket.IO live updates need an extended read
-				## timeout — LSIO's proxy.conf already handles the
-				## WebSocket Upgrade/Connection/HTTP-1.1 set; declaring
-				## those again here triggers nginx 'duplicate
-				## directive' errors. Just override the timeout.
-				proxy_read_timeout 86400;
+				## LSIO's proxy.conf (included above) already sets
+				## proxy_read_timeout, the WebSocket Upgrade /
+				## Connection headers, and proxy_http_version 1.1 —
+				## redeclaring any of them here triggers nginx
+				## 'duplicate directive' emerg errors and the reload
+				## silently keeps the previous (broken) config.
 
 				## sub_filter operates on uncompressed bytes only;
 				## strip Accept-Encoding so the upstream returns plain

--- a/tools/modules/software/module_uptime-kuma.sh
+++ b/tools/modules/software/module_uptime-kuma.sh
@@ -87,7 +87,9 @@ function module_uptimekuma () {
 				proxy_set_header Accept-Encoding "";
 
 				sub_filter_once off;
-				sub_filter_types text/html text/css application/javascript;
+				## text/html is always processed by default; listing it
+				## here triggers a 'duplicate MIME type' nginx warn.
+				sub_filter_types text/css application/javascript;
 				sub_filter 'href="/'    'href="/uptime-kuma/';
 				sub_filter "href='/"    "href='/uptime-kuma/";
 				sub_filter 'src="/'     'src="/uptime-kuma/';

--- a/tools/modules/software/module_uptime-kuma.sh
+++ b/tools/modules/software/module_uptime-kuma.sh
@@ -43,6 +43,60 @@ function module_uptimekuma () {
 				-p "${port}:3001" \
 				-v "${base_dir}:/app/data" \
 				"$dockerimage"
+
+			# Auto-configure SWAG reverse proxy if available — best
+			# effort. linuxserver/reverse-proxy-confs:master doesn't
+			# ship an uptime-kuma sample, and Uptime Kuma itself has
+			# no subpath support — its app uses absolute URLs and a
+			# Socket.IO connection for live updates. We rewrite at
+			# the proxy and sub_filter the literal absolute paths in
+			# the served HTML/CSS/JS, plus pass through the WebSocket
+			# upgrade. Runtime-built URLs (template literals, fetch
+			# calls inside JS modules) will still target / and may
+			# 404 against SWAG. Subdomain proxying is the unbroken
+			# path; subfolder is best-effort. set/rewrite ordering
+			# matters — set vars must precede rewrite … break;.
+			docker_seed_swag_proxy_conf "uptime-kuma" <<- 'NGINX'
+				## Custom Armbian seed — uptime-kuma subfolder proxy.
+				## Best-effort: Uptime Kuma is not subpath-aware.
+				## Subdomain proxying is the recommended path.
+				location = /uptime-kuma { return 301 /uptime-kuma/; }
+
+				location ^~ /uptime-kuma/ {
+				include /config/nginx/proxy.conf;
+				include /config/nginx/resolver.conf;
+
+				set $upstream_app uptime-kuma;
+				set $upstream_port 3001;
+				set $upstream_proto http;
+
+				rewrite ^/uptime-kuma/(.*)$ /$1 break;
+
+				proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+				## Socket.IO live updates need an extended read
+				## timeout — LSIO's proxy.conf already handles the
+				## WebSocket Upgrade/Connection/HTTP-1.1 set; declaring
+				## those again here triggers nginx 'duplicate
+				## directive' errors. Just override the timeout.
+				proxy_read_timeout 86400;
+
+				## sub_filter operates on uncompressed bytes only;
+				## strip Accept-Encoding so the upstream returns plain
+				## text we can rewrite.
+				proxy_set_header Accept-Encoding "";
+
+				sub_filter_once off;
+				sub_filter_types text/html text/css application/javascript;
+				sub_filter 'href="/'    'href="/uptime-kuma/';
+				sub_filter "href='/"    "href='/uptime-kuma/";
+				sub_filter 'src="/'     'src="/uptime-kuma/';
+				sub_filter "src='/"     "src='/uptime-kuma/";
+				sub_filter 'action="/'  'action="/uptime-kuma/';
+				sub_filter 'url(/'      'url(/uptime-kuma/';
+				}
+			NGINX
+			docker_configure_swag_proxy "uptime-kuma" "3001"
 		;;
 		"${commands[1]}") # remove
 			docker_operation_progress rm "$dockername"

--- a/tools/modules/software/module_wireguard.sh
+++ b/tools/modules/software/module_wireguard.sh
@@ -9,7 +9,7 @@ module_options+=(
 	["module_wireguard,group"]="Network"
 	["module_wireguard,port"]="51820"
 	["module_wireguard,arch"]="x86-64 arm64"
-	["module_wireguard,dockerimage"]="lscr.io/linuxserver/wireguard:latest"
+	["module_wireguard,dockerimage"]="linuxserver/wireguard:latest"
 	["module_wireguard,dockername"]="wireguard"
 )
 
@@ -292,7 +292,7 @@ function module_wireguard () {
 			if [[ "$2" == server && -f "${base_dir}/config/wg_confs/client.conf" ]]; then
 				return 1
 			fi
-			docker_is_installed "wireguard" "lscr.io/linuxserver/wireguard"
+			docker_is_installed "wireguard" "linuxserver/wireguard"
 		;;
 		"${commands[7]}")
 			show_module_help "module_wireguard" "$title" \


### PR DESCRIPTION
## Summary

[`docker_configure_swag_proxy()`](tools/modules/functions/module_docker_utils.sh) enables the matching SWAG proxy-conf for a service after install. Until now it was wired for only 5 modules: `homepage`, `immich`, `netbox`, `portainer`, `transmission`. Every other proxied service had to be hand-enabled inside the SWAG container.

This PR wires the call into the **22 modules whose dockername matches a stock proxy-conf** in [linuxserver/reverse-proxy-confs:master](https://github.com/linuxserver/reverse-proxy-confs).

The call passes the container's **internal** port (not the host-mapped one). The function `sed`s `upstream_port` in the proxy-conf before enabling, so SWAG reaches each service via the LSIO docker bridge (`http://${dockername}:${port}`) regardless of how it was published on the host.

## Test matrix

URLs are the predicted SWAG subfolder paths (`https://my.home.org/<service>/`); replace `my.home.org` with your own SWAG-fronted hostname when testing. Tick the box once verified.

- [x] transmission | my.home.org/transmission | 9091/http
- [x] octoprint
- [x] prometheus
- [ ] uptime-kuma (NOT WORKS CORRECTLY)
- [ ] netalertx (NOT WORKS CORRECTLY)
- [ ] bazarr | my.home.org/bazarr | 6767/http
- [x] deluge | my.home.org/deluge | 8112/http
- [ ] domoticz | my.home.org/domoticz | 8080/http
- [x] dozzle | my.home.org/dozzle**/** | 8080/http
- [ ] duplicati | my.home.org/duplicati | 8200/http
- [ ] embyserver | my.home.org/emby | 8096/http
- [x] filebrowser | my.home.org/filebrowser | 80/http
- [ ] ghost | my.home.org/ghost | 2368/http
- [x] grafana | my.home.org/grafana | 3000/http
- [x] jellyfin | my.home.org/jellyfin | 8096/http
- [ ] lidarr | my.home.org/lidarr | 8686/http
- [ ] medusa | my.home.org/medusa | 8081/http
- [x] netdata | my.home.org/netdata | 19999/http
- [ ] nextcloud | my.home.org/nextcloud | 443/https
- [ ] phpmyadmin | my.home.org/phpmyadmin | 80/http
- [ ] pi-hole | my.home.org/pihole | 80/http
- [ ] prowlarr | my.home.org/prowlarr | 9696/http
- [x] qbittorrent | my.home.org/qbittorrent | 8090/http
- [ ] radarr | my.home.org/radarr | 7878/http
- [ ] sabnzbd | my.home.org/sabnzbd | 8080/http
- [ ] sonarr | my.home.org/sonarr | 8989/http
- [ ] syncthing | my.home.org/syncthing | 8384/http

Notes on dockername mapping:
- `embyserver` already sets `dockername="emby"` so the proxy-conf name matches.
- `pi-hole` already sets `dockername="pihole"` so the proxy-conf name matches.
- `nextcloud`'s container exposes 443/TLS, so the call passes `protocol="https"`.

## No regression for users without SWAG

`docker_configure_swag_proxy` returns 2 if the `swag` container doesn't exist and 1 if the proxy-conf sample isn't present, neither of which is checked by the caller. Modules behave unchanged on a host without SWAG.

## Modules deliberately *not* wired

Modules whose service has no stock proxy-conf in `linuxserver/reverse-proxy-confs:master` are skipped — adding the call would just produce a silent no-op:

`actualbudget`, `adguardhome`, `armbianrouter`, `code-server`, `evcc`, `hastebin`, `jellyseerr`, `mariadb`, `mysql`, `navidrome`, `netalertx`, `octoprint`, `openhab`, `owncloud`, `postgres`, `prometheus`, `redis`, `stirling`, `unbound`, `uptime-kuma`, `wallos`, `watchtower`, `wireguard`.

(Note: `module_immich.sh` and `module_netbox.sh` already call the function but the upstream repo doesn't ship `immich.subfolder.conf.sample` or `netbox.subfolder.conf.sample` — those calls are silent no-ops too. Left as-is for forward-compat if upstream adds them.)