### PR TITLE
module_netbox: pass postgres image and tag as separate args (fix HTTP 404 pull)

### DIFF
--- a/tools/modules/software/module_netbox.sh
+++ b/tools/modules/software/module_netbox.sh
@@ -31,7 +31,8 @@ function module_netbox () {
 	local DATABASE_PASSWORD="netbox"
 	local DATABASE_NAME="netbox"
 	local DATABASE_HOST="postgres-netbox"
-	local DATABASE_IMAGE="postgres:17-alpine"
+	local DATABASE_IMAGE="postgres"
+	local DATABASE_TAG="17-alpine"
 	local DATABASE_PORT="5432"
 
 	local commands
@@ -59,7 +60,11 @@ function module_netbox () {
 				module_redis install
 			fi
 			if ! docker container ls -a --format '{{.Names}}' | grep -q "^$DATABASE_HOST$"; then
-				module_postgres install $DATABASE_USER $DATABASE_PASSWORD $DATABASE_NAME $DATABASE_IMAGE $DATABASE_HOST
+				# module_postgres install <user> <password> <db> <image-repo> <image-tag> <container-name>
+				# (six positional args; image and tag must be passed separately, the
+				# previous five-arg form fused them and produced
+				# "postgres:17-alpine:postgres-netbox" — Docker 404 on pull.)
+				module_postgres install "$DATABASE_USER" "$DATABASE_PASSWORD" "$DATABASE_NAME" "$DATABASE_IMAGE" "$DATABASE_TAG" "$DATABASE_HOST"
 			fi
 
 			# Generate a random secret key (50+ chars)


### PR DESCRIPTION
## Symptom

Installing `netbox` fails on the first dependency step with:

> Failed to pull: `postgres:17-alpine:postgres-netbox`
> HTTP 404 from Docker API

(see screenshot)

## Root cause

[`module_postgres`](tools/modules/software/module_postgres.sh) accepts six positional args after `install`:

```
module_postgres install <user> <password> <db> <image-repo> <image-tag> <container-name>
```

and assembles `dockerimage="${image-repo}:${image-tag}"` and `dockername="${container-name}"`.

[`module_netbox`](tools/modules/software/module_netbox.sh) was passing **five** — fusing image and tag into one arg and dropping the container-name slot:

```bash
local DATABASE_IMAGE="postgres:17-alpine"
local DATABASE_HOST="postgres-netbox"
…
module_postgres install $DATABASE_USER $DATABASE_PASSWORD $DATABASE_NAME $DATABASE_IMAGE $DATABASE_HOST
```

So inside `module_postgres`:
- `postgres_image="postgres:17-alpine"` (already contains a tag)
- `postgres_tag="postgres-netbox"` (was meant to be the container name)
- `postgres_container=""` → defaulted to `"postgres"`

Result: `dockerimage="postgres:17-alpine:postgres-netbox"` (Docker rejects with 404 — image refs only allow one `:`), and the postgres container would have spawned under the name `postgres`, colliding with any standalone postgres install.

## Fix

Split `DATABASE_IMAGE` into `DATABASE_IMAGE` (`postgres`) + `DATABASE_TAG` (`17-alpine`) and pass `DATABASE_HOST` in its proper sixth slot:

```bash
module_postgres install "$DATABASE_USER" "$DATABASE_PASSWORD" "$DATABASE_NAME" \
    "$DATABASE_IMAGE" "$DATABASE_TAG" "$DATABASE_HOST"
```

This matches the pattern [`module_immich`](tools/modules/software/module_immich.sh#L61) already uses — netbox was the one outlier.

## Test plan

- [ ] On a host without an existing postgres container: `module_netbox install` pulls `postgres:17-alpine`, names the resulting container `postgres-netbox`, and proceeds to install netbox itself without the 404 dialog.
- [ ] On a host that already has a standalone `postgres` container: `module_netbox install` doesn't disturb it (creates `postgres-netbox` alongside).
- [ ] `docker container ls -a` after install shows both `postgres-netbox` and `netbox` running.