### PR TITLE
swag: docker_seed_swag_proxy_conf helper, wire netbox subfolder proxy

### DIFF
--- a/tools/modules/functions/module_docker_utils.sh
+++ b/tools/modules/functions/module_docker_utils.sh
@@ -525,3 +525,50 @@ docker_configure_swag_proxy() {
 
 	return 1
 }
+
+#
+# Seed a custom SWAG subfolder proxy-conf sample inside the SWAG container.
+# Usage: docker_seed_swag_proxy_conf <servicename> <<'NGINX'
+#            location ^~ /<servicename> { … }
+#        NGINX
+#
+# Used for services that linuxserver/reverse-proxy-confs:master does NOT
+# ship a stock sample for (e.g. netbox, immich). Reads the conf body from
+# stdin and writes it to:
+#   /config/nginx/proxy-confs/<servicename>.subfolder.conf.sample
+# inside the SWAG container, where docker_configure_swag_proxy() picks
+# it up on its next call.
+#
+# Behaviour:
+#   - If the SWAG container isn't installed, returns 2 (no-op).
+#   - If a `.sample` is already present (whether stock LSIO or seeded by
+#     a prior call), returns 0 without overwriting — defer to upstream
+#     when it eventually ships one, and keep an admin's hand-edited
+#     sample intact across re-installs.
+#   - Otherwise writes the body and returns 0 on success, 1 on docker
+#     exec failure.
+#
+# Returns: 0 on success / no-op skip, 1 on failure, 2 if no SWAG.
+#
+docker_seed_swag_proxy_conf() {
+	local servicename="$1"
+
+	if ! docker container ls -a --format "{{.Names}}" | grep -q "^swag$"; then
+		return 2
+	fi
+
+	local proxy_sample="/config/nginx/proxy-confs/${servicename}.subfolder.conf.sample"
+
+	# Already there — let it be (LSIO upstream may have started shipping
+	# one between releases; the admin may have hand-edited it).
+	if docker exec swag test -f "$proxy_sample" 2>/dev/null; then
+		return 0
+	fi
+
+	# `docker exec -i ... sh -c "cat > FILE"` is the portable way to
+	# stream stdin into a file inside the container.
+	if docker exec -i swag sh -c "cat > '${proxy_sample}'" 2>/dev/null; then
+		return 0
+	fi
+	return 1
+}

--- a/tools/modules/software/module_netbox.sh
+++ b/tools/modules/software/module_netbox.sh
@@ -66,11 +66,34 @@ function module_netbox () {
 			# Generate a random secret key (50+ chars)
 			NETBOX_SECRET_KEY=$(tr -dc 'A-Za-z0-9!@#$%^&*()-_=+' </dev/urandom | head -c 64)
 
+			# When SWAG is on this host, NetBox needs to know it lives
+			# at /netbox/ — otherwise Django renders absolute paths
+			# (form action="/login/?next=/netbox", static URIs like
+			# /static/…) that 404 once SWAG strips them at /netbox.
+			# Same applies to CSRF: Django rejects POSTs whose Origin
+			# header isn't in CSRF_TRUSTED_ORIGINS, so the SWAG host
+			# has to be listed there.
+			#
+			# Both settings are real Python in configuration.py, not
+			# env vars — netboxcommunity/netbox reads /etc/netbox/
+			# config/configuration.py, not BASE_PATH/CSRF_TRUSTED_*
+			# from the container env.
+			local netbox_base_path=""
+			local netbox_csrf_origins=""
+			if docker container ls -a --format "{{.Names}}" 2>/dev/null | grep -q "^swag$"; then
+				netbox_base_path="BASE_PATH = 'netbox/'"
+				if [[ -n "${SWAG_URL:-}" ]]; then
+					netbox_csrf_origins="CSRF_TRUSTED_ORIGINS = ['https://${SWAG_URL}']"
+				fi
+			fi
+
 			# Create configuration directory and file
 			mkdir -p "$base_dir/config"
 			if [[ ! -f "$base_dir/config/configuration.py" ]]; then
 				cat > "$base_dir/config/configuration.py" <<- EOT
 				ALLOWED_HOSTS = ['*']
+				${netbox_base_path}
+				${netbox_csrf_origins}
 				DATABASE = {
 					'NAME': '$DATABASE_NAME',
 					'USER': '$DATABASE_USER',
@@ -102,7 +125,10 @@ function module_netbox () {
 			# Pull image
 			docker_operation_progress pull "$dockerimage"
 
-			# Run container
+			# Run container. The BASE_PATH / CSRF_TRUSTED_ORIGINS
+			# settings that make NetBox SWAG-aware are baked into
+			# configuration.py above (env vars are not consumed by
+			# upstream NetBox).
 			if ! docker_operation_progress run "$dockername" \
 				-d \
 				--name="$dockername" \
@@ -144,7 +170,26 @@ function module_netbox () {
 				done
 			fi
 
-			# Auto-configure SWAG reverse proxy if available
+			# Auto-configure SWAG reverse proxy if available.
+			# linuxserver/reverse-proxy-confs:master doesn't ship a
+			# netbox sample, so seed our own first.  No-op on hosts
+			# without SWAG, and skipped if a sample is already in
+			# place (LSIO upstream / hand-edited admin override).
+			docker_seed_swag_proxy_conf "netbox" <<- 'NGINX'
+				## Custom Armbian seed — netbox subfolder proxy.
+				## upstream NetBox runs with BASE_PATH=netbox so the
+				## upstream URI is /netbox, not /. No path rewriting.
+				location ^~ /netbox {
+				    include /config/nginx/proxy.conf;
+				    include /config/nginx/resolver.conf;
+
+				    set $upstream_app netbox;
+				    set $upstream_port 8080;
+				    set $upstream_proto http;
+
+				    proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+				}
+			NGINX
 			docker_configure_swag_proxy "netbox" "8080"
 
 			# Delete default API Token


### PR DESCRIPTION
## Summary

Generic helper for shipping our own SWAG proxy-conf samples + first consumer (netbox), with the proper Django settings for subfolder operation.

[`linuxserver/reverse-proxy-confs:master`](https://github.com/linuxserver/reverse-proxy-confs) doesn't ship a sample for every service we package. `netbox` is one of the visible gaps in this PR set: its install path already calls `docker_configure_swag_proxy`, but the function returns `1` when no sample is present, so on real deployments the call silently no-ops and no proxy gets configured.

## New helper

In [`tools/modules/functions/module_docker_utils.sh`](tools/modules/functions/module_docker_utils.sh):

```bash
docker_seed_swag_proxy_conf <servicename> <<'NGINX'
    location ^~ /<svc> { … }
NGINX
```

Reads the conf body from stdin and writes it as `/config/nginx/proxy-confs/<svc>.subfolder.conf.sample` inside the SWAG container. The existing `docker_configure_swag_proxy` then picks it up on its next call and copies → enables → reloads nginx as usual.

Behaviour:

- No SWAG container → returns 2 (no-op).
- A `.sample` already exists (LSIO upstream may have started shipping one between releases, or an admin hand-edited it) → returns 0 without overwriting.
- Otherwise writes the body. 0 on success, 1 on docker exec failure.

## First consumer: netbox

[`module_netbox.sh`](tools/modules/software/module_netbox.sh) now:

1. **Seeds a hand-authored `netbox.subfolder.conf.sample`** into SWAG before calling `docker_configure_swag_proxy "netbox" "8080"` — no path rewrite, because Django wants its `BASE_PATH` and the upstream URI to match:
   ```nginx
   location ^~ /netbox {
       include /config/nginx/proxy.conf;
       include /config/nginx/resolver.conf;
       set $upstream_app netbox;
       set $upstream_port 8080;
       set $upstream_proto http;
       proxy_pass $upstream_proto://$upstream_app:$upstream_port;
   }
   ```
2. **Bakes the right Django settings into `configuration.py`** when the `swag` container is present at install time. Specifically:
   - `BASE_PATH = 'netbox/'` — so Django emits `/netbox/login/`, `/netbox/static/…`, etc., instead of absolute `/login/` paths that 404 once SWAG strips them at `/netbox`.
   - `CSRF_TRUSTED_ORIGINS = ['https://${SWAG_URL}']` — Django rejects POSTs whose Origin isn't trusted; without it, the login form would 403 even with `BASE_PATH` correct.

   These are real Python in `configuration.py`, not container env vars — `netboxcommunity/netbox` reads `/etc/netbox/config/configuration.py` and ignores `BASE_PATH=` / `CSRF_TRUSTED_ORIGINS=` from the container env unless something explicitly bridges them.

**Trade-off:** with `BASE_PATH` set, direct port access (`http://host:port/`) no longer works at `/` — only `http://host:port/netbox/`. SWAG is the intended way in once it's set up. To revert to root mode, `purge` netbox and re-install on a host without the swag container running.

## Follow-ups (not in this PR)

- Same helper can wire `immich`, `vaultwarden`, and any other module without a stock LSIO sample — left for a follow-up to keep this PR's diff narrow.
- `configuration.py` is only written if it doesn't already exist (`if [[ ! -f … ]]`), so changing `BASE_PATH` or `CSRF_TRUSTED_ORIGINS` post-install requires a `purge` + reinstall. Adding an idempotent rewrite path would be its own change.

## Depends on

#908 (passes postgres image + tag as separate args) — without that, `module_netbox install` fails on the dependency pull before reaching this code.

## Test plan

- [ ] On a host with SWAG: `module_netbox install` writes `netbox.subfolder.conf.sample` inside the swag container, `docker_configure_swag_proxy` enables it, and nginx reloads.
- [ ] `cat $SOFTWARE_FOLDER/netbox/config/configuration.py` shows `BASE_PATH = 'netbox/'` and `CSRF_TRUSTED_ORIGINS` listing the SWAG URL.
- [ ] `https://my.home.org/netbox/` reaches the NetBox login form. Form's `action` attribute is `/netbox/login/?next=/netbox/`, not `/login/?next=/netbox`.
- [ ] Logging in succeeds — no Django CSRF rejection.
- [ ] Static assets (CSS/JS) resolve via `/netbox/static/...` and load.
- [ ] On a host **without** SWAG: install behaviour unchanged. NetBox config has no `BASE_PATH` / `CSRF_TRUSTED_ORIGINS` lines. `http://host:8222/` still works at the root.