### PR TITLE
ci/maintenance-unit-tests: skip draft PRs

### DIFF
--- a/.github/workflows/maintenance-unit-tests.yml
+++ b/.github/workflows/maintenance-unit-tests.yml
@@ -6,7 +6,11 @@ on:
   schedule:
     - cron: '0 2 * * *'
   pull_request:
-    types: [opened, reopened, edited, synchronize, review_requested]
+    # `ready_for_review` is the draft → ready transition; without it,
+    # a PR opened as a draft and later marked ready would never trigger
+    # the suite. The job-level `if:` below filters out drafts so opens
+    # / synchronizes that arrive while still in draft are skipped.
+    types: [opened, reopened, edited, synchronize, review_requested, ready_for_review]
 
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -26,6 +30,13 @@ jobs:
 
   prepare:
     name: "Armbian configurator unit tests"
+    # Skip draft PRs — gate the whole pipeline on the prepare job, so
+    # gradle-native / gradle-emulated / stop (which all `needs: prepare`)
+    # are skipped automatically too. For non-PR triggers (schedule,
+    # workflow_dispatch, repository_dispatch) `pull_request` is null,
+    # `draft` evaluates to null, and the condition stays true so the
+    # nightly cron and ad-hoc reruns are unaffected.
+    if: ${{ github.event.pull_request.draft != true }}
     runs-on: "ubuntu-24.04"
     outputs:
       DEPLOYMENT_MATRIX_NATIVE:   "${{ steps.json.outputs.DEPLOYMENT_MATRIX_NATIVE }}"


### PR DESCRIPTION
## Summary

Don't burn CI on PRs that are still in draft. Two coupled tweaks to [`.github/workflows/maintenance-unit-tests.yml`](.github/workflows/maintenance-unit-tests.yml):

1. **Add `ready_for_review` to the `pull_request` trigger types.**
   Without it, a PR opened as a draft and later marked ready would never fire the workflow — there's no guaranteed `synchronize` edge across the draft → ready transition, so the suite would only run on the next code push.

2. **Gate the `prepare` job on `github.event.pull_request.draft != true`.**
   The three downstream jobs (`gradle-native`, `gradle-emulated`, `stop`) all `needs: prepare`, so skipping `prepare` cascades — the whole pipeline becomes a no-op on a draft PR. When the author marks it ready, the new `ready_for_review` trigger fires the suite once.

## No regression for non-PR triggers

`schedule`, `workflow_dispatch`, and `repository_dispatch` events have no `pull_request` payload, so `github.event.pull_request.draft` evaluates to `null`. The condition `null != true` is true, so:

- nightly cron at 02:00 UTC: still runs.
- the watchdog rerun: still runs.
- manual `workflow_dispatch`: still runs.

## Test plan

- [ ] Open a draft PR — workflow either doesn't trigger, or runs and the `prepare` job appears as `Skipped`. Either way, no compute consumed past the trigger.
- [ ] Same PR: convert to ready-for-review → workflow fires, full matrix runs.
- [ ] Push another commit on the (now non-draft) PR → `synchronize` fires it again.
- [ ] Nightly schedule run still goes through unchanged.