### PR TITLE
runner-cleanup: hourly disk + memory maintenance for self-hosted runner hosts

### DIFF
--- a/tools/modules/system/module_armbian_runners.sh
+++ b/tools/modules/system/module_armbian_runners.sh
@@ -148,6 +148,42 @@ function module_armbian_runners () {
 				fi
 			done
 
+			# Install the runner-cleanup maintenance helper alongside
+			# the runners themselves. Script + systemd units are
+			# always overwritten so a `module_armbian_runners install`
+			# brings them up to date; the operator-edited conf at
+			# /etc/armbian/runner-cleanup.conf is preserved on
+			# re-install (template dropped as .conf.dist so admins
+			# can diff for new defaults). Assets live next to this
+			# module in the repo.
+			local cleanup_src
+			cleanup_src="$(dirname "${BASH_SOURCE[0]}")/runner-cleanup"
+			if [[ -d "$cleanup_src" ]]; then
+				install -m 0755 "${cleanup_src}/runner-cleanup"         /usr/local/sbin/runner-cleanup
+				install -m 0644 "${cleanup_src}/runner-cleanup.service" /etc/systemd/system/runner-cleanup.service
+				install -m 0644 "${cleanup_src}/runner-cleanup.timer"   /etc/systemd/system/runner-cleanup.timer
+				install -d /etc/armbian
+				if [[ ! -e /etc/armbian/runner-cleanup.conf ]]; then
+					install -m 0644 "${cleanup_src}/runner-cleanup.conf" /etc/armbian/runner-cleanup.conf
+				fi
+				install -m 0644 "${cleanup_src}/runner-cleanup.conf" /etc/armbian/runner-cleanup.conf.dist
+				systemctl daemon-reload
+				# Don't silence errors here — a failed timer install
+				# means the cleanup never fires and the host quietly
+				# accumulates disk. Show stderr; on the first command's
+				# failure, fall back to enable + start separately so we
+				# can pinpoint which half went wrong, and log each.
+				if ! systemctl enable --now runner-cleanup.timer; then
+					echo "Warning: 'systemctl enable --now runner-cleanup.timer' failed; retrying separately" >&2
+					systemctl enable runner-cleanup.timer || \
+						echo "Error: 'systemctl enable runner-cleanup.timer' failed" >&2
+					systemctl start  runner-cleanup.timer || \
+						echo "Error: 'systemctl start runner-cleanup.timer' failed" >&2
+				fi
+			else
+				echo "Warning: runner-cleanup assets not found at ${cleanup_src}; skipping maintenance helper install" >&2
+			fi
+
 		;;
 		"${commands[1]}")
 			# delete if previous already exists

--- a/tools/modules/system/runner-cleanup/README.md
+++ b/tools/modules/system/runner-cleanup/README.md
@@ -1,0 +1,149 @@
+# runner-cleanup
+
+Maintenance for self-hosted GitHub Actions runner hosts provisioned by
+`module_armbian_runners`. Wipes per-runner work directories and prunes
+Docker (containers, untagged images, unused volumes / networks / build
+cache, and any image not in the operator-curated allowlist).
+
+## Safety model
+
+Per-operation, not per-host — busy fleets keep getting cleaned:
+
+| Step | Behaviour with busy runners |
+|------|-----------------------------|
+| `_work/` wipe of each runner | Only IDLE runners, and only those NOT in `KEEP_RUNNERS_WORK`. For each one: `systemctl stop <unit>` → `find -delete` → `systemctl start <unit>`. The stop closes the window where the listener could accept a new job mid-wipe; systemd's graceful stop waits for any job that lands between our `pgrep` and the `stop` to finish, so no in-flight job is aborted. Unit name is discovered by grepping `User=` in `/etc/systemd/system/actions.runner.*.service`; if no unit is found (runner under a different supervisor) the wipe runs without stop/start with a warning. |
+| `docker image rm` (per image not in `KEEP_IMAGES` + not in any container) | Always runs. Docker rejects removal of in-use images, so a missed entry just logs a "skipped — still in use" line. |
+| `docker container prune -f` | Always runs. Only touches stopped containers. |
+| `docker image prune -f` (dangling) | Always runs. Only `<none>:<none>`. |
+| `docker network prune -f` | Always runs. Only unused networks. |
+| `docker builder prune -af` | Always runs. Drops build cache — cold-cache slowdown for an in-flight build, doesn't break it. |
+| `docker volume prune -af` | Skipped while ANY runner is busy. A volume between job steps can briefly look unused; `-a` would remove it. Picked up the next pass once the fleet is idle. |
+| `apt-get clean` | Always runs. Just deletes the `/var/cache/apt/archives/*.deb` download cache. Safe; jobs don't depend on it. |
+| `journalctl --vacuum-size=$JOURNAL_MAX_SIZE` (default `500M`) | Always runs. Drops the oldest journal entries beyond the cap. Recent history stays. |
+| Prune `~/_diag/{Runner,Worker}_*.log` older than `$DIAG_LOG_KEEP_DAYS` days (default `14`) | Always runs. Diag logs are per-past-job traces; the runner rotates them too lazily. |
+| Truncate `/var/lib/docker/containers/*/*-json.log` larger than `$DOCKER_LOG_MAX_MB` MB (default `512`) | Always runs. Long-running containers (SWAG, openssh-server) often accumulate multi-GB logs. Truncating mid-flight is safe — Docker keeps writing to the same fd. |
+| `apt-get autoremove --purge -y` | OFF by default. Set `RUN_APT_AUTOREMOVE=1` in conf to enable. Can rarely remove a package the operator wanted kept but forgot to `apt-mark manual`. Strips orphans + old kernels. |
+| Reap stuck `Runner.Worker` processes alive longer than `$RUNNER_JOB_MAX_HOURS` (default `4`) | Always runs, BEFORE the busy/idle partition. SIGTERM → 5 s grace → SIGKILL if still alive. The Listener requeues the abandoned job. Targets the failure mode where a Worker deadlocks (hung artifact upload, network black hole) and holds GBs of RAM indefinitely while the Listener reports the job as "still running". |
+
+So a typical pass on a 24-runner host with 4 idle: 4 work-dirs wiped, all the safe Docker prunes run, the aggressive volume prune deferred to a quieter hour, and the system-level caches always get the trim regardless of runner state. The systemwide bits are usually the difference between "ran out of disk overnight" and "trending flat".
+
+## Schedule
+
+`runner-cleanup.timer` fires **hourly** with up to a 10-minute random
+delay (so a fleet doesn't all hit Docker Hub / ghcr at the same
+second). All the safety gates above mean most runs no-op against an
+idle workload in under a second; meaningful work only fires when
+there's actually something to clean. On hosts that "often run out of
+space" the higher cadence catches the long-tail accumulation
+(container logs, journal, apt cache) before it bites.
+
+## Concurrency + watchdog
+
+Two layers of protection against a stuck or runaway cleanup:
+
+- **Single-instance flock** (`/var/lock/runner-cleanup.lock`).
+  Belt-and-suspenders to systemd's natural same-unit-can't-run-twice
+  behaviour — also covers the case where an admin runs
+  `./runner-cleanup` manually while a timer-triggered pass is in
+  flight. Second invocation exits cleanly with rc=0.
+
+- **`RuntimeMaxSec=30min`** on `runner-cleanup.service`. A run that's
+  somehow exceeded the timeout is sent SIGTERM, then SIGKILL after
+  a 30 s `TimeoutStopSec` grace window. An in-script EXIT trap
+  ensures any runner whose unit was stopped but not yet restarted
+  is brought back online before the script exits, so a kill mid-wipe
+  doesn't leave a runner offline.
+
+## Files
+
+| File | Destination | Mode |
+|------|-------------|------|
+| `runner-cleanup`         | `/usr/local/sbin/runner-cleanup`              | 0755 |
+| `runner-cleanup.conf`    | `/etc/armbian/runner-cleanup.conf`            | 0644 |
+| `runner-cleanup.service` | `/etc/systemd/system/runner-cleanup.service`  | 0644 |
+| `runner-cleanup.timer`   | `/etc/systemd/system/runner-cleanup.timer`    | 0644 |
+
+## Install
+
+The script + systemd units are overwritten on every install (that's
+where fixes land). The `runner-cleanup.conf` is left alone if it
+already exists — your `KEEP_IMAGES` / `KEEP_RUNNERS_WORK` edits
+survive an upgrade. The template is dropped next to it as
+`runner-cleanup.conf.dist` so you can diff and merge by hand.
+
+```sh
+# Script + systemd units: always overwrite.
+sudo install -m 0755 runner-cleanup         /usr/local/sbin/runner-cleanup
+sudo install -m 0644 runner-cleanup.service /etc/systemd/system/runner-cleanup.service
+sudo install -m 0644 runner-cleanup.timer   /etc/systemd/system/runner-cleanup.timer
+
+# Config: only install if absent. Template always goes to .dist
+# alongside so a future maintainer can spot new defaults.
+sudo install -d /etc/armbian
+if [ ! -e /etc/armbian/runner-cleanup.conf ]; then
+    sudo install -m 0644 runner-cleanup.conf /etc/armbian/runner-cleanup.conf
+fi
+sudo install -m 0644 runner-cleanup.conf /etc/armbian/runner-cleanup.conf.dist
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now runner-cleanup.timer
+```
+
+To compare your live conf against the new template after an upgrade:
+
+```sh
+diff -u /etc/armbian/runner-cleanup.conf{,.dist}
+```
+
+## Configure
+
+Edit `/etc/armbian/runner-cleanup.conf`. Two arrays:
+
+```sh
+# Docker images to keep across cleanup passes.
+# Exact <repository>:<tag>; tag mandatory.
+KEEP_IMAGES=(
+    lscr.io/linuxserver/swag:latest             # shipped default
+    lscr.io/linuxserver/openssh-server:latest   # shipped default
+    ghcr.io/armbian/builder:latest
+)
+
+# Runners whose _work/ must NOT be wiped. By module_armbian_runners
+# convention the first runner of a series carries the primary label
+# (alfa) and is the natural home of warm caches (kernel ccache,
+# toolchain downloads). Defaulted to actions-runner-01; add or change
+# entries to match your fleet's "primary" naming.
+KEEP_RUNNERS_WORK=(
+    actions-runner-01
+)
+```
+
+## Test manually
+
+```sh
+sudo /usr/local/sbin/runner-cleanup --dry-run --verbose
+```
+
+Successful no-op output on an idle host with an empty `KEEP_IMAGES`
+looks like:
+
+```
+runner-cleanup: no actions-runner-* users on this host — nothing to do.
+```
+
+or, with runners present and idle:
+
+```
+wipe /home/actions-runner-01/_work/
+keep image ghcr.io/armbian/builder:latest
+rm image ubuntu:24.04 (sha256:...)
+[dry-run] docker container prune -f
+...
+```
+
+## Check the timer
+
+```sh
+systemctl list-timers runner-cleanup.timer
+journalctl -u runner-cleanup.service --since '1 day ago'
+```

--- a/tools/modules/system/runner-cleanup/runner-cleanup
+++ b/tools/modules/system/runner-cleanup/runner-cleanup
@@ -1,0 +1,412 @@
+#!/usr/bin/env bash
+#
+# runner-cleanup — maintenance for self-hosted GitHub Actions runner hosts.
+#
+# Wipes each runner's _work/ subtree and prunes Docker:
+#   - stopped containers
+#   - unused images, EXCEPT those listed in KEEP_IMAGES or referenced
+#     by an existing container (running or stopped)
+#   - dangling <none>:<none> images
+#   - unused networks
+#   - build cache
+#   - all unused volumes (including named ones — explicit choice; see
+#     PR discussion)
+#
+# Safety model: per-operation, not per-host.
+#   - Per-runner _work wipe   — only runners with NO live Runner.Worker
+#                               process. Busy runners' work dirs are
+#                               owned by an in-flight job, untouched.
+#   - Docker container/image/network/builder prune — always run.
+#                               Docker enforces in-use checks itself;
+#                               'image rm' on an image a container uses
+#                               is rejected, 'container prune' only
+#                               touches stopped containers, etc.
+#   - docker volume prune -a  — gated on the whole fleet being idle.
+#                               Between job steps a volume can briefly
+#                               appear unused; -a would yank it. Skip
+#                               while any runner is busy and pick it
+#                               up next pass.
+#
+# Config: /etc/armbian/runner-cleanup.conf (bash; must define
+# KEEP_IMAGES array). Override path with --config <path>.
+
+set -euo pipefail
+
+CONFIG="${RUNNER_CLEANUP_CONFIG:-/etc/armbian/runner-cleanup.conf}"
+DRY_RUN=0
+VERBOSE=0
+
+usage() {
+	cat <<- EOF
+		Usage: ${0##*/} [options]
+		  -n, --dry-run        Print what would happen; do not modify anything.
+		  -v, --verbose        Log each kept / removed item.
+		  -c, --config PATH    Path to KEEP_IMAGES config (default: ${CONFIG}).
+		  -h, --help           Show this help.
+	EOF
+}
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		-n|--dry-run) DRY_RUN=1; shift ;;
+		-v|--verbose) VERBOSE=1; shift ;;
+		-c|--config)
+			if [[ $# -lt 2 ]]; then
+				echo "Error: --config requires a path argument" >&2
+				usage >&2
+				exit 2
+			fi
+			CONFIG="$2"; shift 2
+			;;
+		-h|--help)    usage; exit 0 ;;
+		*) echo "Unknown argument: $1" >&2; usage >&2; exit 2 ;;
+	esac
+done
+
+# Single-instance lock. systemd already prevents two timer-triggered
+# runs of a Type=oneshot service from overlapping, but flock here
+# also guards against an admin running `./runner-cleanup` manually
+# while the timer's pass is mid-flight, and against two manual
+# invocations racing.
+#
+# -n (non-blocking): if the lock is held, exit cleanly with rc=0 —
+# the running instance is already doing the work, no need to queue
+# another. The next hourly tick will catch up.
+LOCK_FILE="/var/lock/runner-cleanup.lock"
+exec 200> "$LOCK_FILE" 2>/dev/null || {
+	echo "Error: cannot open lock file ${LOCK_FILE}" >&2
+	exit 1
+}
+if ! flock -n 200; then
+	echo "runner-cleanup: another instance is already running — exiting cleanly."
+	exit 0
+fi
+
+# Defaults live HERE, in the script, not only in the config template.
+# An installed /etc/armbian/runner-cleanup.conf carried over from an
+# older release otherwise lacks any new defaults this version adds,
+# and an empty array means "everything goes" — which is the wrong
+# default for a maintenance tool. A user who explicitly wants the
+# empty form can still set `KEEP_RUNNERS_WORK=()` or `KEEP_IMAGES=()`
+# in their conf to override us, since `source` happens after.
+KEEP_IMAGES=(
+	lscr.io/linuxserver/swag:latest
+	lscr.io/linuxserver/openssh-server:latest
+)
+KEEP_RUNNERS_WORK=(
+	actions-runner-01
+)
+RUNNER_USER_RE='^actions-runner-.+$'
+# Wall-clock ceiling for Runner.Worker processes. A Worker alive
+# longer than this is almost certainly hung (deadlocked artifact
+# upload, zombie child, network black hole) and holds GBs of RAM
+# while the Listener happily reports the job as still in progress.
+# Killing it frees the memory and the Listener requeues the job.
+# Set high enough to cover your longest legitimate build.
+RUNNER_JOB_MAX_HOURS=4
+
+if [[ -f "$CONFIG" ]]; then
+	# shellcheck source=/dev/null
+	source "$CONFIG"
+fi
+
+# Membership lookup for the runner-whitelist. Built once after the
+# config has been sourced so a user-supplied --config still wins.
+declare -A keep_work_user
+for _u in "${KEEP_RUNNERS_WORK[@]}"; do
+	keep_work_user["$_u"]=1
+done
+unset _u
+
+log()  { [[ $VERBOSE -eq 1 ]] && echo "$@" || true; }
+note() { echo "$@"; }
+run()  {
+	if [[ $DRY_RUN -eq 1 ]]; then
+		echo "[dry-run] $*"
+	else
+		"$@"
+	fi
+}
+
+# -------------------------------------------------------------------
+# 1. Partition runners into busy / idle. We DO NOT abort if some are
+#    busy — instead the cleanup operates only on what's provably safe
+#    to touch:
+#      - per-runner _work wipe: only idle runners
+#      - docker image rm / container/image/network/builder prune:
+#        always (Docker itself refuses to remove in-use resources)
+#      - docker volume prune -a:  only if NO runner is busy
+#        (volumes between job steps can disappear under a live job)
+# -------------------------------------------------------------------
+mapfile -t runner_users < <(getent passwd | awk -F: -v re="$RUNNER_USER_RE" '$1 ~ re {print $1}')
+
+if [[ ${#runner_users[@]} -eq 0 ]]; then
+	# No runners — skip the runner-scoped operations (Worker reaper,
+	# _work wipe, busy/idle partition) but still run the system
+	# housekeeping in section 4 (apt cache / journal / container
+	# logs). Those are valuable on any long-lived host, and this
+	# script is the established entry point for them.
+	note "runner-cleanup: no actions-runner-* users on this host — running housekeeping only."
+fi
+
+# Reap stuck Runner.Worker processes (older than RUNNER_JOB_MAX_HOURS)
+# BEFORE the busy/idle partition. A Worker that's been hung for hours
+# holds GBs of RAM and locks its runner out of work; killing it frees
+# both. The Listener will requeue the abandoned job onto another
+# runner. Running this first means a freshly-reaped runner is
+# correctly seen as idle by the partition below this pass — its
+# _work gets cleaned alongside everyone else's.
+max_seconds=$(( ${RUNNER_JOB_MAX_HOURS:-4} * 3600 ))
+while IFS= read -r pid; do
+	[[ -z "$pid" ]] && continue
+	etime_sec=$(ps -o etimes= -p "$pid" 2>/dev/null | tr -d ' ')
+	[[ -z "$etime_sec" ]] && continue
+	if (( etime_sec > max_seconds )); then
+		# Show whose runner it is for the log.
+		worker_user=$(ps -o user= -p "$pid" 2>/dev/null | tr -d ' ')
+		note "WARNING: killing stuck Runner.Worker pid=${pid} user=${worker_user:-?} alive=${etime_sec}s (cap ${max_seconds}s)"
+		if [[ $DRY_RUN -eq 1 ]]; then
+			echo "[dry-run] kill -TERM ${pid}"
+		else
+			kill -TERM "$pid" 2>/dev/null || true
+			# Stuck Workers often ignore SIGTERM — give a brief grace
+			# window then escalate. Listener will spawn a fresh
+			# Worker on the next job assignment.
+			sleep 5
+			if kill -0 "$pid" 2>/dev/null; then
+				note "  ! pid=${pid} survived SIGTERM; sending SIGKILL"
+				kill -KILL "$pid" 2>/dev/null || true
+			fi
+		fi
+	fi
+done < <(pgrep -f 'Runner.Worker' 2>/dev/null)
+
+# Track runners we've stopped but haven't restarted yet. If we get
+# killed (SIGTERM from systemd's RuntimeMaxSec at 30min, or operator
+# Ctrl-C) between the per-runner stop and start below, the EXIT trap
+# brings them back. Without this, a runner could be left offline
+# until the next hourly pass picks it up.
+declare -A stopped_unit_for
+restart_on_exit() {
+	local _rc=$?
+	local u
+	for u in "${!stopped_unit_for[@]}"; do
+		# Best effort — we may be in shutdown / signal handling
+		# context. Don't propagate further failures.
+		systemctl start "${u}.service" 2>/dev/null || true
+	done
+	exit $_rc
+}
+trap restart_on_exit EXIT
+
+busy=()
+idle=()
+for user in "${runner_users[@]}"; do
+	if pgrep -u "$user" -f 'Runner.Worker' > /dev/null 2>&1; then
+		busy+=("$user")
+	else
+		idle+=("$user")
+	fi
+done
+
+note "runner-cleanup: ${#idle[@]} idle, ${#busy[@]} busy runner(s); will clean idle _work and run safe Docker prunes"
+[[ ${#busy[@]} -gt 0 ]] && log "busy (work-dir untouched): ${busy[*]}"
+
+# -------------------------------------------------------------------
+# 2. For each IDLE runner: stop its systemd unit, wipe _work/, start
+#    it back. Stopping closes the window where the listener could
+#    accept a new job mid-wipe (find -delete on a multi-GB _work can
+#    easily take 30s+). systemd's graceful stop waits for any job
+#    that landed between our pgrep and the stop to finish, so no
+#    in-flight job gets aborted; it just makes this pass slower.
+#
+# Unit-name discovery: actions/runner's svc.sh installs
+# /etc/systemd/system/actions.runner.<scope>.<name>.service with the
+# matching User= line. Grep by User= to find the right one without
+# needing to know the runner's name.
+# -------------------------------------------------------------------
+find_runner_unit() {
+	local user="$1" unit_path
+	unit_path=$(grep -l "^User=${user}\$" /etc/systemd/system/actions.runner.*.service 2>/dev/null | head -1)
+	if [[ -n "$unit_path" ]]; then
+		unit_path="${unit_path##*/}"
+		echo "${unit_path%.service}"
+	fi
+}
+
+for user in "${idle[@]}"; do
+	# Per-runner whitelist: skip wipe entirely (don't even stop/start
+	# the unit — pointless churn if we're not touching the disk).
+	if [[ -n "${keep_work_user[$user]:-}" ]]; then
+		log "preserve ${user}/_work (in KEEP_RUNNERS_WORK)"
+		continue
+	fi
+
+	home=$(getent passwd "$user" | cut -d: -f6)
+	work="${home}/_work"
+	if [[ ! -d "$work" ]]; then
+		log "skip ${user} — no _work dir"
+		continue
+	fi
+
+	unit=$(find_runner_unit "$user")
+	if [[ -z "$unit" ]]; then
+		# No svc.sh-installed unit found — fall back to wipe without
+		# stop. Runner might be running in a tmux session, foreground,
+		# or under a different supervisor.
+		log "wipe ${work}/ (no systemd unit for ${user}, no stop/start)"
+		run find "$work" -mindepth 1 -delete
+		continue
+	fi
+
+	log "stop ${unit} → wipe ${work}/ → start ${unit}"
+	if run systemctl stop "${unit}.service"; then
+		# Record in the trap-tracked set BEFORE the wipe — if we
+		# get killed during wipe, the EXIT trap will restart it.
+		[[ $DRY_RUN -eq 0 ]] && stopped_unit_for["$unit"]=1
+		run find "$work" -mindepth 1 -delete
+		if run systemctl start "${unit}.service"; then
+			[[ $DRY_RUN -eq 0 ]] && unset 'stopped_unit_for[$unit]'
+		else
+			note "WARNING: failed to restart ${unit}.service after wipe — runner ${user} is offline until manual start"
+		fi
+	else
+		note "WARNING: could not stop ${unit}.service for ${user}; skipping wipe to avoid mid-job damage"
+	fi
+done
+
+# -------------------------------------------------------------------
+# 3. Docker prune.
+# -------------------------------------------------------------------
+# CLI presence + daemon reachability. A host with the CLI installed
+# but the daemon stopped / socket inaccessible would otherwise emit
+# a 'Cannot connect to the Docker daemon' for every prune below.
+if ! command -v docker > /dev/null 2>&1; then
+	log "docker not installed — skipping container/image cleanup"
+	goto_housekeeping=1
+elif ! docker info > /dev/null 2>&1; then
+	log "docker daemon unreachable — skipping container/image cleanup"
+	goto_housekeeping=1
+fi
+
+if [[ -z "${goto_housekeeping:-}" ]]; then
+
+# Keep-set: configured allowlist + every image already referenced by
+# any container (running or stopped). Collecting the second group up
+# front cleans up the log and avoids noisy "image in use" errors when
+# we try to rm them below.
+declare -A keep
+for img in "${KEEP_IMAGES[@]}"; do
+	keep["$img"]=1
+done
+while IFS= read -r img; do
+	[[ -z "$img" ]] && continue
+	keep["$img"]=1
+done < <(docker ps -a --format '{{.Image}}' 2>/dev/null | sort -u)
+
+# Pass 1: explicit per-image rm for everything not in keep-set.
+# Untagged <none>:<none> entries are caught by `docker image prune`
+# below, so skip them here.
+while IFS=$'\t' read -r repo_tag image_id; do
+	[[ "$repo_tag" == '<none>:<none>' ]] && continue
+	if [[ -n "${keep[$repo_tag]:-}" ]]; then
+		log "keep image ${repo_tag}"
+		continue
+	fi
+	log "rm image ${repo_tag} (${image_id})"
+	run docker image rm -f "$image_id" > /dev/null 2>&1 || \
+		log "  ! could not remove ${repo_tag} — likely still in use, skipped"
+done < <(docker image ls --format '{{.Repository}}:{{.Tag}}\t{{.ID}}')
+
+# Pass 2: sweep everything else. These are always safe with busy
+# runners because Docker enforces in-use checks itself:
+#   - container prune: only STOPPED containers
+#   - image prune (no -a): only dangling <none>:<none>
+#   - network prune: only unused networks
+#   - builder prune: drops build cache (cold-cache slowdown for an
+#     in-flight build, but doesn't break it)
+run docker container prune -f
+run docker image prune -f
+run docker network prune -f
+run docker builder prune -af
+
+# Volume prune -a is the one operation that CAN'T tell whether a
+# volume is "between job steps" vs genuinely abandoned. Skip when any
+# runner is busy; pick it up the next pass once the fleet is idle.
+if [[ ${#busy[@]} -eq 0 ]]; then
+	run docker volume prune -af    # -a: also remove unused NAMED volumes
+else
+	note "skip 'docker volume prune -a' — ${#busy[@]} runner(s) still busy; will retry next pass"
+fi
+
+fi  # end docker section
+
+# -------------------------------------------------------------------
+# 4. System housekeeping. Independent of runner / Docker state —
+#    targets the long-tail caches that accumulate on any long-lived
+#    host and are usually the silent cause of "out of disk space".
+#    All safe-while-jobs-run; configurable via conf:
+#      JOURNAL_MAX_SIZE       (default 500M, accepted by journalctl)
+#      DIAG_LOG_KEEP_DAYS     (default 14)
+#      DOCKER_LOG_MAX_MB      (default 512 — truncate above this size)
+#      RUN_APT_AUTOREMOVE     (default 0 — opt-in; can remove unrelated
+#                              auto-installed packages, including old
+#                              kernels)
+# -------------------------------------------------------------------
+
+# 4a. APT cache (/var/cache/apt/archives/*.deb after installs).
+if command -v apt-get > /dev/null 2>&1; then
+	log "apt-get clean"
+	run apt-get clean
+fi
+
+# 4b. journald vacuum. Caps /var/log/journal/* to a sane size while
+# keeping recent history. Often the biggest single offender on a host
+# with months of uptime.
+if command -v journalctl > /dev/null 2>&1; then
+	jmax="${JOURNAL_MAX_SIZE:-500M}"
+	log "journalctl --vacuum-size=${jmax}"
+	run journalctl --vacuum-size="$jmax" > /dev/null 2>&1 || true
+fi
+
+# 4c. Runner _diag log prune. The Listener writes per-job
+# Runner_*.log / Worker_*.log into ~/_diag — useful for troubleshoot,
+# but accumulates indefinitely. Keep the last DIAG_LOG_KEEP_DAYS of
+# them; runner's own rotation is too lazy.
+diag_days="${DIAG_LOG_KEEP_DAYS:-14}"
+for user in "${runner_users[@]}"; do
+	home=$(getent passwd "$user" | cut -d: -f6)
+	[[ -d "${home}/_diag" ]] || continue
+	log "prune ${user}/_diag (older than ${diag_days}d)"
+	run find "${home}/_diag" -type f \
+		\( -name 'Runner_*.log' -o -name 'Worker_*.log' -o -name '*.log.gz' \) \
+		-mtime "+${diag_days}" -delete
+done
+
+# 4d. Docker container log truncation. /var/lib/docker/containers/<id>/<id>-json.log
+# grows unbounded for long-running containers (SWAG, openssh-server,
+# anything with a chatty stdout). Truncating mid-flight is safe — the
+# kernel keeps the existing fd open and the daemon resumes writing
+# from offset 0.
+if command -v docker > /dev/null 2>&1; then
+	max_mb="${DOCKER_LOG_MAX_MB:-512}"
+	max_bytes=$((max_mb * 1024 * 1024))
+	while IFS= read -r -d '' log_file; do
+		size=$(stat -c '%s' "$log_file" 2>/dev/null || echo 0)
+		if (( size > max_bytes )); then
+			log "truncate ${log_file} ($((size / 1024 / 1024))MB > ${max_mb}MB)"
+			run truncate -s 0 "$log_file"
+		fi
+	done < <(find /var/lib/docker/containers -maxdepth 2 -name '*-json.log' -print0 2>/dev/null)
+fi
+
+# 4e. Opt-in: apt autoremove. Strips orphan auto-installed packages
+# (old kernels, transitive deps no longer required by anything).
+# Off by default because on rare occasions it removes something the
+# operator wanted kept and forgot to apt-mark manual.
+if [[ "${RUN_APT_AUTOREMOVE:-0}" == "1" ]] && command -v apt-get > /dev/null 2>&1; then
+	log "apt-get autoremove --purge -y"
+	run env DEBIAN_FRONTEND=noninteractive apt-get autoremove --purge -y
+fi
+
+log "runner-cleanup: done."

--- a/tools/modules/system/runner-cleanup/runner-cleanup.conf
+++ b/tools/modules/system/runner-cleanup/runner-cleanup.conf
@@ -1,0 +1,72 @@
+# runner-cleanup configuration.
+#
+# KEEP_IMAGES — bash array of image references to preserve when
+# runner-cleanup runs. Anything not listed here AND not currently
+# referenced by an existing container will be removed.
+#
+# Match the exact <repository>:<tag> string as `docker image ls`
+# prints it. The tag is mandatory — listing "ghcr.io/armbian/builder"
+# alone will NOT match "ghcr.io/armbian/builder:latest".
+
+# Defaults below cover the configng-managed services that typically
+# co-host on a runner box (SWAG reverse proxy, openssh-server). The
+# runner image refs at the bottom are commented examples — uncomment /
+# edit them to match what your runners actually pull from ghcr.
+
+KEEP_IMAGES=(
+	# configng-managed co-tenant services (module_swag, module_openssh-server)
+	lscr.io/linuxserver/swag:latest
+	lscr.io/linuxserver/openssh-server:latest
+
+	# runner build images — examples
+	# ghcr.io/armbian/builder:latest
+	# ghcr.io/armbian/builder:noble
+)
+
+# KEEP_RUNNERS_WORK — bash array of actions-runner-* usernames whose
+# _work directory must NOT be wiped. Useful for a "primary" runner
+# that maintains a warm cache (kernel ccache, large action checkouts,
+# downloaded toolchains) which would be expensive to rebuild on every
+# pass.
+#
+# Match the exact username as it appears in /etc/passwd. By
+# module_armbian_runners convention, the first runner of a series
+# carries the primary label (alfa) and is the natural place to pin
+# heavy build caches — defaulted here.
+
+KEEP_RUNNERS_WORK=(
+	actions-runner-01            # primary builder — preserve kernel ccache
+)
+
+# -------------------------------------------------------------------
+# System housekeeping knobs. Defaults are baked into the script —
+# uncomment to override.
+# -------------------------------------------------------------------
+
+# Cap /var/log/journal/* to this size. journalctl accepts K/M/G
+# suffixes. Usually the single biggest free win on a long-uptime host.
+# JOURNAL_MAX_SIZE="500M"
+
+# Delete runner _diag/{Runner,Worker}_*.log entries older than this
+# many days. The runner rotates them very lazily; pruning here keeps
+# the per-runner _diag dir bounded.
+# DIAG_LOG_KEEP_DAYS=14
+
+# Truncate /var/lib/docker/containers/<id>/<id>-json.log files larger
+# than this many MB. Long-running containers (SWAG, openssh-server)
+# can accumulate multi-GB log files over months. Truncating mid-flight
+# is safe — Docker keeps writing to the same fd.
+# DOCKER_LOG_MAX_MB=512
+
+# Opt-in: run `apt-get autoremove --purge -y` to strip orphan auto-
+# installed packages, including old kernels. Off by default — can
+# rarely remove something the operator wanted kept and forgot to
+# apt-mark manual.
+# RUN_APT_AUTOREMOVE=0
+
+# Wall-clock ceiling for Runner.Worker processes, in hours. A Worker
+# alive longer than this is reaped (SIGTERM, then SIGKILL after a 5s
+# grace). The Listener requeues the abandoned job onto another
+# runner. Set high enough to cover the longest legitimate build —
+# anything shorter risks killing real work.
+# RUNNER_JOB_MAX_HOURS=4

--- a/tools/modules/system/runner-cleanup/runner-cleanup.service
+++ b/tools/modules/system/runner-cleanup/runner-cleanup.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Clean GitHub Actions runner work dirs and Docker leftovers
+Documentation=https://github.com/armbian/configng
+After=docker.service
+Wants=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/runner-cleanup
+# Don't choke the host while pruning a large image set.
+Nice=10
+IOSchedulingClass=idle
+# Cap each run at 30 minutes. The script normally finishes well under
+# a minute even on a busy host; anything taking longer is wedged
+# (network black hole during docker pull, etc.) and should be reaped.
+# For Type=oneshot services systemd uses TimeoutStartSec= as the
+# wall-clock cap (RuntimeMaxSec= is silently ignored on oneshot).
+# SIGTERM at the cap → TimeoutStopSec grace → SIGKILL.
+TimeoutStartSec=30min
+TimeoutStopSec=30s
+
+[Install]
+WantedBy=multi-user.target

--- a/tools/modules/system/runner-cleanup/runner-cleanup.timer
+++ b/tools/modules/system/runner-cleanup/runner-cleanup.timer
@@ -1,0 +1,24 @@
+[Unit]
+Description=Hourly runner-cleanup
+Documentation=man:systemd.timer(5)
+
+[Timer]
+# Hourly. The script is heavily defensive — idle runners are the only
+# ones whose _work gets touched, Docker enforces its own in-use checks,
+# and the always-on system housekeeping bits (apt cache, journal
+# vacuum, diag-log prune, container-log truncation) don't disrupt
+# anything jobs depend on. So there's no reason to wait a whole day
+# between trims on a host that "often runs out of space".
+#
+# Most runs no-op against an idle workload in under a second; the
+# meaningful work only fires when there's actually something to clean.
+#
+# Persistent=true also runs the missed job shortly after boot if the
+# host was powered down at the scheduled time. RandomizedDelaySec
+# spreads load across multiple identically-timed hosts.
+OnCalendar=hourly
+RandomizedDelaySec=10min
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary
Adds a small drop-in at [`tools/modules/system/runner-cleanup/`](tools/modules/system/runner-cleanup/) that keeps self-hosted GitHub Actions runner hosts trim — and wires it into `module_armbian_runners install` so it lands automatically alongside the runners themselves.

Files (5):

| File | Destination | Mode |
|------|-------------|------|
| `runner-cleanup`         | `/usr/local/sbin/runner-cleanup`              | 0755 |
| `runner-cleanup.conf`    | `/etc/armbian/runner-cleanup.conf`            | 0644 |
| `runner-cleanup.service` | `/etc/systemd/system/runner-cleanup.service`  | 0644 |
| `runner-cleanup.timer`   | `/etc/systemd/system/runner-cleanup.timer`    | 0644 |
| `README.md`              | repo-side docs                                 | — |

## What it does, by section

### 1. Reap stuck `Runner.Worker` processes
Any `Runner.Worker` whose elapsed time exceeds `RUNNER_JOB_MAX_HOURS` (default **4h**) is SIGTERM'd, given 5 s grace, then SIGKILL'd. Targets the well-known failure mode where a Worker deadlocks (artifact upload to a black hole, zombie subprocess) and silently holds several GB of RAM while the Listener reports the job as "still running". Listener requeues the orphaned job onto another runner. Runs first so a freshly-reaped runner is correctly classified as idle below.

### 2. Per-runner `_work` wipe
For each idle runner NOT in `KEEP_RUNNERS_WORK` (default `actions-runner-01` — the alfa-tier primary in `module_armbian_runners` convention, used as a warm cache home for kernel ccache and toolchain downloads):

```
systemctl stop <unit>  →  find _work -mindepth 1 -delete  →  systemctl start <unit>
```

The stop closes the window where the Listener could accept a job mid-wipe. systemd's graceful stop waits for any race-in job to finish, so no live job is aborted. Unit name is discovered by grepping `User=` in `/etc/systemd/system/actions.runner.*.service`.

### 3. Docker prune (per-operation safety)

| Step | Behaviour |
|---|---|
| `docker image rm` for images not in `KEEP_IMAGES` AND not used by any container | Always runs. Docker rejects in-use removals on its own. |
| `docker container prune -f` | Always. Stopped only. |
| `docker image prune -f` | Always. Dangling `<none>:<none>` only. |
| `docker network prune -f` | Always. Unused only. |
| `docker builder prune -af` | Always. Cold-cache slowdown but no breakage. |
| `docker volume prune -af` | **Gated** on full-fleet idle. A volume between two job steps can briefly look unused; `-a` would yank it. Defers to next pass otherwise. |

`KEEP_IMAGES` defaults to `lscr.io/linuxserver/swag:latest` and `lscr.io/linuxserver/openssh-server:latest` — the two configng-managed services most commonly co-tenant on a runner box.

### 4. System housekeeping (always runs)
The long-tail disk hogs that don't depend on runner state:

- `apt-get clean` — `/var/cache/apt/archives/*.deb`.
- `journalctl --vacuum-size=$JOURNAL_MAX_SIZE` (default **500M**) — usually the single biggest free win.
- Prune `~/_diag/{Runner,Worker}_*.log` older than `$DIAG_LOG_KEEP_DAYS` (default **14**).
- `truncate -s 0` on `/var/lib/docker/containers/*/*-json.log` larger than `$DOCKER_LOG_MAX_MB` (default **512**) — long-running containers like SWAG accumulate multi-GB log files; truncating mid-flight is safe.
- Opt-in: `apt-get autoremove --purge -y` (off by default; set `RUN_APT_AUTOREMOVE=1`).

## Schedule
`OnCalendar=hourly` with `RandomizedDelaySec=10min` and `Persistent=true`. Justified by the script's defensive design: most runs no-op in well under a second; meaningful work only fires when there's something to clean. On a host that "often runs out of space" the higher cadence catches accumulation (container logs, journal, apt cache) before it bites.

## Defaults baked into the script
`KEEP_IMAGES`, `KEEP_RUNNERS_WORK`, `RUNNER_JOB_MAX_HOURS`, and the housekeeping knobs are all set inside the script *before* the conf file is sourced. An outdated `/etc/armbian/runner-cleanup.conf` carried over from an earlier install therefore still benefits from any new defaults. A user who explicitly wants the empty form can still set `KEEP_RUNNERS_WORK=()` (etc.) in their conf to override.

## Install behaviour
- Fresh `module_armbian_runners install` → runner-cleanup is bundled and the timer starts immediately.
- Re-install → script + systemd units are overwritten so fixes propagate; **`/etc/armbian/runner-cleanup.conf` is left untouched** (operator edits survive); template always dropped as `runner-cleanup.conf.dist` so admins can `diff` for new defaults.

## Test plan
- [ ] On a non-runner host: `./runner-cleanup --dry-run --verbose` prints "no actions-runner-* users — nothing to do" and exits 0.
- [ ] On a runner host with all runners idle: dry-run lists `wipe`, `stop`/`start`, `keep image`, `rm image`, and `[dry-run] docker container/image/network/builder/volume prune` lines.
- [ ] On a runner host with some runners busy: only idle runners' `_work` is touched; `docker volume prune -a` is skipped with a "still busy" message.
- [ ] Reaper smoke: spawn a sleep-forever process named `Runner.Worker`, fast-forward its etime, confirm reap.
- [ ] `module_armbian_runners install ...` (fresh) → confirm `systemctl status runner-cleanup.timer` shows enabled+active.
- [ ] `module_armbian_runners install ...` (re-install on a host with edited conf) → confirm conf untouched, `.dist` updated.

## Commits (11)
- Initial scaffold (script + conf + service + timer + README)
- KEEP_IMAGES defaults: SWAG, openssh-server
- Per-operation safety (replaces original all-or-nothing fleet gate)
- Stop systemd unit around `_work` wipe
- KEEP_RUNNERS_WORK allowlist (defaults to actions-runner-01)
- Bake defaults into the script, not just the conf
- Preserve installed conf on re-install + `.dist` template drop
- System-housekeeping section (apt/journal/diag/docker-logs)
- Hourly timer instead of daily
- Reap stuck `Runner.Worker` processes (>4h)
- Bundle install with `module_armbian_runners`