### PR TITLE
module_armbian_runners: skip busy runners + ship runner-cleanup assets via .deb

### DIFF
--- a/debian.conf
+++ b/debian.conf
@@ -2,4 +2,5 @@ lib:/usr/
 bin:/usr/
 share:/usr/
 tools/modules/desktops:/usr/share/armbian-config/
+tools/modules/system/runner-cleanup:/usr/share/armbian-config/
 tools/repository/armbian-config.sources:/etc/apt/sources.list.d/

--- a/tools/modules/system/module_armbian_runners.sh
+++ b/tools/modules/system/module_armbian_runners.sh
@@ -163,11 +163,22 @@ function module_armbian_runners () {
 			# brings them up to date; the operator-edited conf at
 			# /etc/armbian/runner-cleanup.conf is preserved on
 			# re-install (template dropped as .conf.dist so admins
-			# can diff for new defaults). Assets live next to this
-			# module in the repo.
-			local cleanup_src
-			cleanup_src="$(dirname "${BASH_SOURCE[0]}")/runner-cleanup"
-			if [[ -d "$cleanup_src" ]]; then
+			# can diff for new defaults).
+			#
+			# Asset path resolution: in a source checkout the assets
+			# sit next to this module under tools/modules/system/.
+			# In the installed .deb they ship to
+			# /usr/share/armbian-config/runner-cleanup/ — debian.conf
+			# adds the rule, mirroring how the desktops assets are
+			# laid out. Try BASH_SOURCE-relative first (dev), fall
+			# back to the install path (production).
+			local cleanup_src=""
+			if [[ -d "$(dirname "${BASH_SOURCE[0]}")/runner-cleanup" ]]; then
+				cleanup_src="$(dirname "${BASH_SOURCE[0]}")/runner-cleanup"
+			elif [[ -d /usr/share/armbian-config/runner-cleanup ]]; then
+				cleanup_src=/usr/share/armbian-config/runner-cleanup
+			fi
+			if [[ -n "$cleanup_src" ]]; then
 				install -m 0755 "${cleanup_src}/runner-cleanup"         /usr/local/sbin/runner-cleanup
 				install -m 0644 "${cleanup_src}/runner-cleanup.service" /etc/systemd/system/runner-cleanup.service
 				install -m 0644 "${cleanup_src}/runner-cleanup.timer"   /etc/systemd/system/runner-cleanup.timer
@@ -190,7 +201,7 @@ function module_armbian_runners () {
 						echo "Error: 'systemctl start runner-cleanup.timer' failed" >&2
 				fi
 			else
-				echo "Warning: runner-cleanup assets not found at ${cleanup_src}; skipping maintenance helper install" >&2
+				echo "Warning: runner-cleanup assets not found in source tree next to module or at /usr/share/armbian-config/runner-cleanup; skipping maintenance helper install" >&2
 			fi
 
 		;;

--- a/tools/modules/system/module_armbian_runners.sh
+++ b/tools/modules/system/module_armbian_runners.sh
@@ -119,7 +119,16 @@ function module_armbian_runners () {
 				-H "X-GitHub-Api-Version: 2022-11-28" \
 				https://api.github.com/${prefix}/${registration_url}/actions/runners/registration-token | jq -r .token)
 
-				${module_options["module_armbian_runners,feature"]} ${commands[1]} ${runner_name} "${i}"
+				if ! ${module_options["module_armbian_runners,feature"]} ${commands[1]} ${runner_name} "${i}"; then
+					# `remove` returns non-zero when GitHub refused
+					# the DELETE — almost always because the runner
+					# is currently running a job. Skip this index;
+					# the existing runner keeps doing its work
+					# untouched, and the next install pass will
+					# pick it up when it's idle.
+					echo "Skipping install of runner ${i} (${runner_name}-${i}) — currently busy on GitHub" >&2
+					continue
+				fi
 
 				adduser --quiet --disabled-password --shell /bin/bash \
 				--home /home/actions-runner-${i} --gecos "actions-runner-${i}" actions-runner-${i}
@@ -188,7 +197,16 @@ function module_armbian_runners () {
 		"${commands[1]}")
 			# delete if previous already exists
 			echo "Removing runner $3 on GitHub"
-			${module_options["module_armbian_runners,feature"]} ${commands[2]} "$2-$3"
+			if ! ${module_options["module_armbian_runners,feature"]} ${commands[2]} "$2-$3"; then
+				# Most common failure: GitHub returned 422 because
+				# the runner is currently running a job. Don't proceed
+				# with the local cleanup — that would leave a state
+				# where GitHub still thinks the runner exists, the
+				# host has no install, and the subsequent config.sh
+				# would fail with 'A runner exists with the same name'.
+				echo "Skipping local removal of actions-runner-$3 — GitHub delete failed (runner likely busy)" >&2
+				return 1
+			fi
 			echo "Removing runner $3 locally"
 			runner_home=$(getent passwd "actions-runner-${3}" | cut -d: -f6)
 			if [[ -f "${runner_home}/svc.sh" ]]; then
@@ -202,6 +220,13 @@ function module_armbian_runners () {
 		"${commands[2]}")
 			DELETE=$2
 			x=1
+			# Failure flag — set on any non-204 DELETE response. The
+			# most common case is HTTP 422 'runner is currently
+			# running a job', which we don't want to silently swallow:
+			# without it the caller proceeds with local cleanup and
+			# leaves a half-state where GitHub thinks the runner exists
+			# but the host has nothing for it.
+			local delete_failed=0
 			while [ $x -le 9 ] # need to do it different as it can be more then 9 pages
 			do
 			RUNNER=$(
@@ -218,16 +243,27 @@ function module_armbian_runners () {
 				# deleting a runner
 				if [[ $RUNNER_NAME == ${DELETE} ]]; then
 					echo "Delete existing: $RUNNER_NAME"
-					curl -s -L \
+					local resp_body http_code
+					resp_body=$(mktemp)
+					http_code=$(curl -s -L \
 					-X DELETE \
 					-H "Accept: application/vnd.github+json" \
 					-H "Authorization: Bearer ${gh_token}"\
 					-H "X-GitHub-Api-Version: 2022-11-28" \
-					https://api.github.com/${prefix}/${registration_url}/actions/runners/${RUNNER_ID}
+					-o "${resp_body}" -w '%{http_code}' \
+					https://api.github.com/${prefix}/${registration_url}/actions/runners/${RUNNER_ID})
+					if [[ "$http_code" != "204" ]]; then
+						echo "  ! DELETE ${RUNNER_NAME} returned HTTP ${http_code}:" >&2
+						cat "${resp_body}" >&2
+						echo >&2
+						delete_failed=1
+					fi
+					rm -f "${resp_body}"
 				fi
 			done <<< $RUNNER
 			x=$(( $x + 1 ))
 			done
+			return $delete_failed
 		;;
 		"${commands[3]}")
 			if [[ -z $gh_token ]]; then


### PR DESCRIPTION
## Two fixes in this PR

### 1. Don't reinstall runners currently busy on GitHub

A reinstall hit this on every runner mid-job:

```
Removing runner 23 on GitHub
Delete existing: minisforum-23
{
  "message": "Bad request - Runner minisforum-23 is currently running a job and cannot be deleted.",
  "status": "422"
}
Removing runner 23 locally
Removed "/etc/systemd/system/multi-user.target.wants/actions.runner.armbian.minisforum-23.service".
A runner exists with the same name minisforum-22.
```

The DELETE was sent without checking the response. GitHub returned 422 → script silently swallowed → proceeded with `svc.sh uninstall` + `userdel -r` → end state: GitHub still has the runner, host has nothing for it, subsequent `config.sh --name minisforum-N` errors with "A runner exists with the same name".

Three propagation hops in [`module_armbian_runners.sh`](tools/modules/system/module_armbian_runners.sh):

- **`remove_online`** — capture `%{http_code}` on each DELETE via `curl -w`. Print response body to stderr on any non-204. Aggregate into `delete_failed` and `return` it.
- **`remove`** — on non-zero from `remove_online`, skip local cleanup and return 1.
- **install loop** — on non-zero from `remove`, `continue` to the next index. The busy runner keeps running its job; next install pass picks it up once idle.

Behavior matrix:

| Pre-existing runner state | Result |
|---|---|
| Not present on GitHub | `remove_online` doesn't match the name, returns 0, install proceeds. Unchanged. |
| Present, idle | DELETE → 204 → local cleanup → fresh install. Unchanged. |
| Present, busy (was broken) | DELETE → 422 → `Skipping install of runner N — currently busy on GitHub` → continue. Existing runner keeps running its job. |
| Present, other failure (5xx, scope) | Loud failure to stderr → skip, continue. |

### 2. Ship `runner-cleanup/` assets via .deb so the helper install actually finds them

The original install path computed the assets directory as `$(dirname "${BASH_SOURCE[0]}")/runner-cleanup`. Works in a source checkout. In the installed .deb the modules live inside the aggregated `/usr/lib/armbian-config/config.system.sh` → `BASH_SOURCE` resolves to `/usr/lib/armbian-config/` and the folder isn't shipped there:

```
Warning: runner-cleanup assets not found at /usr/bin/../lib/armbian-config/runner-cleanup; skipping maintenance helper install
```

Fix mirrors the existing `desktops_dir` pattern in [`bin/armbian-config`](bin/armbian-config):

- **`debian.conf`** — add `tools/modules/system/runner-cleanup:/usr/share/armbian-config/`. Same shape as the existing `tools/modules/desktops:/usr/share/armbian-config/` rule.
- **module install code** — try BASH_SOURCE-relative first (dev), fall back to `/usr/share/armbian-config/runner-cleanup` (.deb).

End state:
- Source checkout: assets resolved next to module — unchanged.
- .deb install: assets resolved under `/usr/share/armbian-config/` — helper installs normally, warning gone.

## Test plan
- [ ] Fresh `module_armbian_runners install` on a host with no pre-existing runners → all indices register; runner-cleanup.timer enables.
- [ ] Reinstall on a host where one runner is mid-job → that index skipped with the new message; the other indices reinstall cleanly; busy runner finishes its job uninterrupted.
- [ ] Reinstall a few minutes after the previously-busy runner finishes → next pass picks it up.
- [ ] Install from a .deb (not source) → no `runner-cleanup assets not found` warning; `/usr/local/sbin/runner-cleanup` exists; timer enabled.