### PR TITLE
maintenance-watchdog: target the workflow that actually exists

### DIFF
--- a/.github/workflows/maintenance-watchdog.yml
+++ b/.github/workflows/maintenance-watchdog.yml
@@ -22,8 +22,11 @@ jobs:
       max-parallel: 8
       matrix:
 
-        # list scripts you want to watch and execute failed jobs x-times
-        script: ["unit-tests"]
+        # list scripts you want to watch and execute failed jobs x-times.
+        # Bare filename (without .yml) of the workflow file under
+        # .github/workflows/ — this gets composed into the jq path
+        # filter below.
+        script: ["maintenance-unit-tests"]
 
     name: rerun
     runs-on: ubuntu-latest
@@ -40,7 +43,7 @@ jobs:
           WORKFLOW=$(gh api "/repos/${OWNER_REPO}/actions/workflows" | jq '.workflows[] | select(.path==".github/workflows/'${{ matrix.script }}'.yml")' | jq -r '.id')
           read ID STATUS ATTEMPT <<< $(gh api "/repos/${OWNER_REPO}/actions/workflows/${WORKFLOW}/runs" | jq '.workflow_runs[]' | jq -r '.id,.conclusion,.run_attempt' | head -3 | xargs -n3 -d'\n')
 
-          # if attempt is lower then X and status is "cancelled" or "failed", rerun failed jobs
-          if [ "${ATTEMPT}" -lt "${ATTEMPTS}" ] && ([ "$STATUS" == "failure" ] || [ "$STATUS" == "failure" ]); then
+          # if attempt is lower then X and status is "cancelled" or "failure", rerun failed jobs
+          if [ "${ATTEMPT}" -lt "${ATTEMPTS}" ] && ([ "$STATUS" == "failure" ] || [ "$STATUS" == "cancelled" ]); then
           gh api --method POST -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/${OWNER_REPO}/actions/runs/${ID}/rerun-failed-jobs
           fi


### PR DESCRIPTION
## The bug

[\`.github/workflows/maintenance-watchdog.yml\`](.github/workflows/maintenance-watchdog.yml) was silently no-op'ing on every 15-min cron tick. Two issues:

### 1. Wrong filename in the matrix

\`\`\`yaml
script: [\"unit-tests\"]
\`\`\`

The inner step composes this into the jq filter:

\`\`\`bash
jq '.workflows[] | select(.path==\".github/workflows/unit-tests.yml\")'
\`\`\`

There's no \`.github/workflows/unit-tests.yml\` — the workflow it was meant to watch is [\`.github/workflows/maintenance-unit-tests.yml\`](.github/workflows/maintenance-unit-tests.yml). The filter returned nothing, \`WORKFLOW\` resolved to empty, and the subsequent \`gh api /repos/.../actions/workflows//runs\` was malformed. No rerun ever fired.

### 2. Failure check repeated against itself

\`\`\`bash
# Comment one line above says: \"cancelled or failed\"
if [ \"${ATTEMPT}\" -lt \"${ATTEMPTS}\" ] && ([ \"$STATUS\" == \"failure\" ] || [ \"$STATUS\" == \"failure\" ]); then
\`\`\`

Both arms test \"failure\". Cancelled runs were never picked up despite the comment.

## Fix

\`\`\`diff
-        script: [\"unit-tests\"]
+        script: [\"maintenance-unit-tests\"]
\`\`\`
\`\`\`diff
-          if [ \"${ATTEMPT}\" -lt \"${ATTEMPTS}\" ] && ([ \"$STATUS\" == \"failure\" ] || [ \"$STATUS\" == \"failure\" ]); then
+          if [ \"${ATTEMPT}\" -lt \"${ATTEMPTS}\" ] && ([ \"$STATUS\" == \"failure\" ] || [ \"$STATUS\" == \"cancelled\" ]); then
\`\`\`

Plus a clarifying comment on the matrix entry so the file-name vs script-name relationship is obvious to a future reviewer.

## Test plan
- [ ] Merge to main; trigger \`workflow_dispatch\` of \`Watchdog (cronjob)\` manually.
- [ ] Confirm the inner step's first \`gh api\` call now returns a non-empty workflow ID.
- [ ] Confirm if the latest \`maintenance-unit-tests.yml\` run is \`failure\` or \`cancelled\` and below 2 attempts, the watchdog issues a rerun.
- [ ] Confirm if the latest run is \`success\`, the watchdog no-ops cleanly.