### PR TITLE
module_qbittorrent: poll for temporary password before showing dialog

### DIFF
--- a/tools/modules/software/module_qbittorrent.sh
+++ b/tools/modules/software/module_qbittorrent.sh
@@ -51,15 +51,41 @@ function module_qbittorrent () {
 				--restart=always \
 				"$dockerimage"
 
-			# Get temporary password from logs
-			local temp_password
-			temp_password=$(docker logs "$dockername" 2>&1 | grep password | grep session | cut -d":" -f2 | xargs)
+			# Wait for the LSIO image to actually bootstrap qBittorrent
+			# and emit the per-session temporary password. The previous
+			# code read 'docker logs' the instant after 'docker run'
+			# returned — long before s6-overlay had spawned qbittorrent
+			# and printed the password line — so the dialog usually
+			# rendered with an empty password.
+			#
+			# Step 1: wait for the container to be 'running' (~1 s).
+			# Step 2: poll the log for the password marker, up to ~30 s.
+			wait_for_container_ready "$dockername" 10 1 "running" >/dev/null 2>&1 || true
+
+			local temp_password=""
+			local attempt
+			for ((attempt = 1; attempt <= 30; attempt++)); do
+				# 'A temporary password is provided for this session: <pw>'
+				# Last whitespace-separated field of the matching line.
+				temp_password=$(docker logs "$dockername" 2>&1 \
+					| awk '/temporary password is provided for this session:/ {print $NF; exit}')
+				[[ -n "$temp_password" ]] && break
+				sleep 1
+			done
+
+			local install_msg="qBittorrent is listening at http://$LOCALIPADD:${port}\n\nLogin as: admin"
+			if [[ -n "$temp_password" ]]; then
+				install_msg+="\n\nTemporary password: ${temp_password}"
+			else
+				# Don't lie to the user with a blank field — point them
+				# at where the password will appear once bootstrap finishes.
+				install_msg+="\n\nTemporary password was not in the logs yet.\nRun:\n  docker logs ${dockername} 2>&1 | grep 'temporary password'\nin a few seconds to retrieve it."
+			fi
 
 			if [[ -t 1 ]]; then
-				dialog_msgbox "qBittorrent installed" \
-					"qBittorrent is listening at http://$LOCALIPADD:${port}\n\nLogin as: admin\n\nTemporary password: ${temp_password}" 10 70
+				dialog_msgbox "qBittorrent installed" "$install_msg" 14 70
 			else
-				echo -e "\nqBittorrent is listening at http://$LOCALIPADD:${port}\nLogin as: admin\nTemporary password: ${temp_password}\n"
+				echo -e "\n${install_msg}\n"
 			fi
 		;;
 		"${commands[1]}") # remove


### PR DESCRIPTION
## The bug

Install on noble → dialog comes up with an empty 'Temporary password:' field:

```
qBittorrent is listening at http://10.0.10.71:8090

Login as: admin

Temporary password:
```

## Why

The install path was:

```bash
docker_operation_progress run ...                        # returns the instant docker creates the container
temp_password=$(docker logs "$dockername" 2>&1 \
    | grep password | grep session | cut -d":" -f2 | xargs)
dialog_msgbox ...
```

The LSIO `linuxserver/qbittorrent` image needs 5-15 s of s6-overlay bootstrap to spawn qBittorrent and print the per-session password line. The script tailed `docker logs` *before* that line existed, so the awk/grep returned empty, the dialog rendered with the field blank.

## Fix

Three changes in the install branch:

1. Call `wait_for_container_ready` (the existing helper from `module_dialog_ui.sh`) so we don't tail logs of a container that isn't even running yet.
2. Replace the one-shot grep with a poll loop — up to 30 × 1 s — exit early on the first hit. awk on the marker `'temporary password is provided for this session:'`, take the last whitespace-separated field. Robust against timestamps, surrounding `****` decoration, and multi-colon prefixes.
3. If the line still doesn't show up in 30 s, the dialog shows a fallback message pointing the operator at `docker logs ${dockername} | grep 'temporary password'` rather than the misleading empty field.

## Out of scope
The `unbuffer: command not found` error from `config.functions.sh:1905` that the user also saw is a global `docker_operation_progress` issue (missing `expect-dev` runtime dep) — different fix in a different file.

## Test plan
- [x] Fresh install on noble; dialog renders with the password populated.
- [ ] Manually delay the LSIO bootstrap (e.g. heavy host load) and confirm the poll loop still picks the password up before 30 s.
- [ ] Worst case: stop the container mid-bootstrap so the password never appears; dialog should fall back to the 'check docker logs later' message instead of going blank.