### PR TITLE
postinst/gnome: enable tap-to-click + clickpad right-click out of the box

### DIFF
--- a/tools/modules/desktops/postinst/gnome.sh
+++ b/tools/modules/desktops/postinst/gnome.sh
@@ -36,6 +36,26 @@ cat >> "$keys" <<- EOF
 	[org/gnome/settings-daemon/plugins/power]
 	sleep-inactive-ac-timeout='0'
 
+	# Clickpad right-click. Modern Lenovo / Dell / HP laptops use
+	# clickpads (no separate physical buttons under the touchpad), and
+	# GNOME's per-arch defaults sometimes leave new users without a
+	# working right-click out of the box.
+	#
+	# tap-to-click=true: single-finger tap → left click.
+	# click-method='areas': physical press in the bottom-right corner
+	#                       of the touchpad → right-click. Verified
+	#                       working on a current-gen Lenovo where the
+	#                       'fingers' (two-finger tap) default did not
+	#                       reliably trigger BTN_RIGHT.
+	#
+	# Alternative (single-valued, so only one of the two): swap the
+	# line below to click-method='fingers' if you prefer two-finger
+	# tap. The system-wide default here is just a default — users can
+	# override per-account via 'gsettings set …' or GNOME Settings.
+	[org/gnome/desktop/peripherals/touchpad]
+	tap-to-click=true
+	click-method='areas'
+
 	[org/gnome/desktop/background]
 	picture-uri='file:///usr/share/backgrounds/armbian/armbian18-Dre0x-Minum-light-3840x2160.jpg'
 	picture-uri-dark='file:///usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-3840x2160.jpg'


### PR DESCRIPTION
## Problem
Modern Lenovo / Dell / HP laptops use clickpads — touchpads with no separate physical buttons. Out of the box GNOME's per-arch defaults sometimes leave new users without a working right-click. Reproduced on a current-gen Lenovo where the upstream default \`click-method='fingers'\` (two-finger tap) did not reliably emit \`BTN_RIGHT\` despite \`tap-to-click\` being enabled.

## Fix
Extend the existing system-wide dconf override that the GNOME postinst writes to \`/etc/dconf/db/local.d/00-bg\` with explicit touchpad defaults:

\`\`\`ini
[org/gnome/desktop/peripherals/touchpad]
tap-to-click=true
click-method='areas'
\`\`\`

- \`tap-to-click=true\` — single-finger tap → left-click.
- \`click-method='areas'\` — physical press in the bottom-right corner → right-click. Verified working on the hardware that motivated this.

## Alternative noted in comment
\`click-method\` is single-valued, so it's areas-OR-fingers. If a future fleet decides to prefer two-finger-tap right-click, the inline comment documents swapping that single line to \`click-method='fingers'\`. System-wide only — users always keep per-account precedence via \`gsettings set …\` or GNOME Settings.

## Test plan
- [ ] Build a GNOME image; on first boot, confirm \`gsettings get org.gnome.desktop.peripherals.touchpad tap-to-click\` returns \`true\` and \`click-method\` returns \`'areas'\`.
- [ ] Bottom-right corner press on the touchpad → right-click menu appears.
- [ ] User can still override: \`gsettings set org.gnome.desktop.peripherals.touchpad click-method 'fingers'\` should switch to two-finger tap and persist.