### PR TITLE
desktops: ship fprintd userspace at mid tier

### DIFF
--- a/tools/modules/desktops/module_desktops.sh
+++ b/tools/modules/desktops/module_desktops.sh
@@ -341,6 +341,39 @@ function _module_desktops_rockchip_multimedia() {
 # Arguments: none. Uses SRC path via $desktops_dir for asset
 # resolution, same as module_desktop_branding.
 #
+#
+# Wire fprintd into PAM so fingerprint login / sudo / screen-unlock
+# works as soon as the user enrols a finger. libpam-fprintd installs
+# the PAM module but does NOT enable it by default - pam-auth-update
+# is the standard Debian/Ubuntu way to flip it on idempotently.
+#
+# Safe to call unconditionally: pam-auth-update is a no-op when the
+# fprintd module is already enabled, and libpam-fprintd's PAM
+# fragment falls back to password auth when no finger is enrolled,
+# so machines without a reader still log in normally.
+#
+# Skipped in build mode (no real users yet) and on hosts where the
+# fprintd userspace didn't actually install (older releases / arches
+# stripped via tier_overrides).
+#
+function _module_desktops_configure_fprintd() {
+	local mode="${1:-}"
+	if [[ "$mode" == "build" ]]; then
+		debug_log "_module_desktops_configure_fprintd: mode=build, skipping pam-auth-update"
+		return 0
+	fi
+	if ! command -v fprintd-enroll > /dev/null 2>&1; then
+		debug_log "_module_desktops_configure_fprintd: fprintd not installed, skipping"
+		return 0
+	fi
+	if ! command -v pam-auth-update > /dev/null 2>&1; then
+		debug_log "_module_desktops_configure_fprintd: pam-auth-update missing, skipping"
+		return 0
+	fi
+	debug_log "_module_desktops_configure_fprintd: enabling fprintd PAM module"
+	DEBIAN_FRONTEND=noninteractive pam-auth-update --enable fprintd 2> /dev/null || true
+}
+
 function _module_desktops_configure_networking() {
 	local src_dir="${desktops_dir}/networking"
 	if [[ ! -d "$src_dir" ]]; then
@@ -668,6 +701,12 @@ function module_desktops() {
 			# otherwise the UI shows an always-disconnected state
 			# even though the machine is online.
 			_module_desktops_configure_networking
+
+			# Enable fprintd in PAM so fingerprint login works once
+			# the user enrols a finger via `fprintd-enroll`. Inert on
+			# hosts without a reader (libpam-fprintd falls back to
+			# password) and on tiers/arches that stripped fprintd.
+			_module_desktops_configure_fprintd "$mode"
 
 			# Wire up the Rockchip 3D + multimedia stack on
 			# rk3588-family / vendor-kernel boards: panthor-gpu DT

--- a/tools/modules/desktops/scripts/parse_desktop_yaml.py
+++ b/tools/modules/desktops/scripts/parse_desktop_yaml.py
@@ -275,6 +275,18 @@ def parse_desktop(yaml_dir, de_name, release, arch, tier):
 
     # 4. Apply the orthogonal release block — packages_remove + packages
     #    declared per release. The release block is independent of tier.
+    #    Common.yaml goes first so a per-DE release block can still
+    #    remove what common added (symmetric with how tier_overrides
+    #    works above).
+    common_releases = _as_dict(common.get("releases"))
+    common_release_data = _as_dict(common_releases.get(release))
+    for pkg in _as_list(common_release_data.get("packages_remove")):
+        if pkg in packages:
+            packages.remove(pkg)
+    for pkg in _as_list(common_release_data.get("packages")):
+        if pkg not in packages:
+            packages.append(pkg)
+
     releases = _as_dict(de_data.get("releases"))
     release_data = _as_dict(releases.get(release))
     supported_archs = _as_list(release_data.get("architectures"))

--- a/tools/modules/desktops/yaml/common.yaml
+++ b/tools/modules/desktops/yaml/common.yaml
@@ -90,13 +90,14 @@ tiers:
       # mid-tier install; machines without a reader pay ~5 MB of
       # idle daemons.
       #
-      # libfprint-2-tod1 hosts vendor "Touch OEM Driver" plugins -
-      # required for several Goodix/Synaptics sensors where no
-      # open-source driver exists. The host alone is a no-op until
-      # a TOD plugin gets installed alongside it.
+      # The TOD plugin host (libfprint-2-tod1) is Ubuntu-only and
+      # mostly only useful when the user also installs a vendor TOD
+      # blob - keep it out of the default set so Debian installs
+      # don't fail with "Unable to locate package". Ubuntu users who
+      # need it can `apt install libfprint-2-tod1` plus the matching
+      # vendor plugin manually.
       - fprintd
       - libfprint-2-2
-      - libfprint-2-tod1
       - libpam-fprintd
 
   full:
@@ -252,10 +253,38 @@ tier_overrides:
       bookworm:
         # loupe is GNOME 46+; bookworm shipped with GNOME 43 era and
         # has no loupe package on any arch.
+        # libfprint-2-tod1 is Ubuntu-only (the TOD framework was added
+        # via a Lenovo/Ubuntu patch that Debian never picked up). Strip
+        # it on every Debian release; fprintd / libpam-fprintd /
+        # libfprint-2-2 stay in place and work fine with the in-tree
+        # libfprint drivers - users just lose access to closed-source
+        # vendor TOD plugins.
         architectures:
-          amd64:  { packages_remove: [loupe] }
-          arm64:  { packages_remove: [loupe] }
-          armhf:  { packages_remove: [loupe] }
+          amd64:  { packages_remove: [loupe, libfprint-2-tod1] }
+          arm64:  { packages_remove: [loupe, libfprint-2-tod1] }
+          armhf:  { packages_remove: [loupe, libfprint-2-tod1] }
+      trixie:
+        # libfprint-2-tod1: Ubuntu-only (see bookworm note).
+        architectures:
+          amd64:    { packages_remove: [libfprint-2-tod1] }
+          arm64:    { packages_remove: [libfprint-2-tod1] }
+          armhf:    { packages_remove: [libfprint-2-tod1] }
+          riscv64:  { packages_remove: [libfprint-2-tod1] }
+      forky:
+        # libfprint-2-tod1: Ubuntu-only (see bookworm note).
+        architectures:
+          amd64:    { packages_remove: [libfprint-2-tod1] }
+          arm64:    { packages_remove: [libfprint-2-tod1] }
+          armhf:    { packages_remove: [libfprint-2-tod1] }
+          riscv64:  { packages_remove: [libfprint-2-tod1] }
+      sid:
+        # libfprint-2-tod1: Ubuntu-only (see bookworm note).
+        architectures:
+          amd64:    { packages_remove: [libfprint-2-tod1] }
+          arm64:    { packages_remove: [libfprint-2-tod1] }
+          armhf:    { packages_remove: [libfprint-2-tod1] }
+          riscv64:  { packages_remove: [libfprint-2-tod1] }
+          loong64:  { packages_remove: [libfprint-2-tod1] }
       jammy:
         # loupe was introduced with GNOME 44/45; Ubuntu 22.04 (jammy)
         # shipped GNOME 42 and has no loupe package on any arch.

--- a/tools/modules/desktops/yaml/common.yaml
+++ b/tools/modules/desktops/yaml/common.yaml
@@ -81,6 +81,23 @@ tiers:
       - glmark2-es2-wayland   # GLES2 benchmark — Wayland backend
       - glmark2-x11           # GL benchmark — X11 backend
       - glmark2-es2-x11       # GLES2 benchmark — X11 backend
+      # Fingerprint reader stack. Standard on every modern business
+      # laptop (ThinkPad / Latitude / EliteBook / ...). Installing
+      # the packages doesn't auto-enable fingerprint auth - PAM
+      # only starts using it once the user runs
+      # `pam-auth-update --enable fprintd` and enrols a finger via
+      # `fprintd-enroll`. So this is safe to ship to every desktop
+      # mid-tier install; machines without a reader pay ~5 MB of
+      # idle daemons.
+      #
+      # libfprint-2-tod1 hosts vendor "Touch OEM Driver" plugins -
+      # required for several Goodix/Synaptics sensors where no
+      # open-source driver exists. The host alone is a no-op until
+      # a TOD plugin gets installed alongside it.
+      - fprintd
+      - libfprint-2-2
+      - libfprint-2-tod1
+      - libpam-fprintd
 
   full:
     packages:

--- a/tools/modules/desktops/yaml/common.yaml
+++ b/tools/modules/desktops/yaml/common.yaml
@@ -253,38 +253,10 @@ tier_overrides:
       bookworm:
         # loupe is GNOME 46+; bookworm shipped with GNOME 43 era and
         # has no loupe package on any arch.
-        # libfprint-2-tod1 is Ubuntu-only (the TOD framework was added
-        # via a Lenovo/Ubuntu patch that Debian never picked up). Strip
-        # it on every Debian release; fprintd / libpam-fprintd /
-        # libfprint-2-2 stay in place and work fine with the in-tree
-        # libfprint drivers - users just lose access to closed-source
-        # vendor TOD plugins.
         architectures:
-          amd64:  { packages_remove: [loupe, libfprint-2-tod1] }
-          arm64:  { packages_remove: [loupe, libfprint-2-tod1] }
-          armhf:  { packages_remove: [loupe, libfprint-2-tod1] }
-      trixie:
-        # libfprint-2-tod1: Ubuntu-only (see bookworm note).
-        architectures:
-          amd64:    { packages_remove: [libfprint-2-tod1] }
-          arm64:    { packages_remove: [libfprint-2-tod1] }
-          armhf:    { packages_remove: [libfprint-2-tod1] }
-          riscv64:  { packages_remove: [libfprint-2-tod1] }
-      forky:
-        # libfprint-2-tod1: Ubuntu-only (see bookworm note).
-        architectures:
-          amd64:    { packages_remove: [libfprint-2-tod1] }
-          arm64:    { packages_remove: [libfprint-2-tod1] }
-          armhf:    { packages_remove: [libfprint-2-tod1] }
-          riscv64:  { packages_remove: [libfprint-2-tod1] }
-      sid:
-        # libfprint-2-tod1: Ubuntu-only (see bookworm note).
-        architectures:
-          amd64:    { packages_remove: [libfprint-2-tod1] }
-          arm64:    { packages_remove: [libfprint-2-tod1] }
-          armhf:    { packages_remove: [libfprint-2-tod1] }
-          riscv64:  { packages_remove: [libfprint-2-tod1] }
-          loong64:  { packages_remove: [libfprint-2-tod1] }
+          amd64:  { packages_remove: [loupe] }
+          arm64:  { packages_remove: [loupe] }
+          armhf:  { packages_remove: [loupe] }
       jammy:
         # loupe was introduced with GNOME 44/45; Ubuntu 22.04 (jammy)
         # shipped GNOME 42 and has no loupe package on any arch.

--- a/tools/modules/desktops/yaml/common.yaml
+++ b/tools/modules/desktops/yaml/common.yaml
@@ -198,6 +198,30 @@ browser:
 # Verified against packages.debian.org (madison) and
 # packages.ubuntu.com / launchpad as of 2026-04. Update when releases
 # move forward or when arch dependencies change.
+
+# Cross-DE per-release additions/removals, applied AFTER tiers + the
+# `browser` substitution + tier_overrides. Mirrors the per-DE
+# `releases:` block in yaml/<de>.yaml but applies to every desktop.
+#
+# Use this for packages that:
+#   - only exist on a subset of releases, AND
+#   - we want on every desktop where they DO exist
+#
+# Cheaper than enumerating Debian strips when the package is Ubuntu-only,
+# and avoids touching each per-DE yaml.
+releases:
+  noble:
+    # libfprint-2-tod1 is Ubuntu-only - hosts vendor "Touch OEM Driver"
+    # plugins for several Goodix / Synaptics fingerprint sensors with
+    # no open-source path. Inert on its own; pairs with whichever
+    # vendor TOD .deb a user installs for their reader (e.g.
+    # libfprint-2-tod1-goodix-550a).
+    packages:
+      - libfprint-2-tod1
+  resolute:
+    packages:
+      - libfprint-2-tod1
+
 tier_overrides:
   minimal:
     releases:


### PR DESCRIPTION
## Summary

Ship the fingerprint userspace stack to every desktop install so machines with a reader (current-gen ThinkPads, Latitudes, EliteBooks, …) work out of the box once the user runs `fprintd-enroll`. No reader → no impact (libpam-fprintd falls back to password).

## What's installed, where

| Release | Packages |
|---|---|
| Debian: bookworm / trixie / forky / sid | `fprintd`, `libfprint-2-2`, `libpam-fprintd` |
| Ubuntu: jammy | `fprintd`, `libfprint-2-2`, `libpam-fprintd` |
| Ubuntu: **noble / resolute** | + `libfprint-2-tod1` |

`libfprint-2-tod1` is the "Touch OEM Driver" plugin host. It's Ubuntu-only (Debian never picked up the Lenovo/Ubuntu patch that adds the TOD framework) — so shipping it cross-distro breaks Debian installs with `Unable to locate package`. Adding it via a new per-release block, only on the releases that have it. Older Ubuntu (jammy) excluded for now — its 1.94 version is materially older; can re-add if anyone needs it.

## Commits

1. `0f9ed1f3` — add `fprintd` + `libfprint-2-2` + `libpam-fprintd` to common.yaml mid tier
2. `377089ff` — drop dead-code Debian-side strips
3. `d203263d` — extend parse_desktop_yaml.py to honour `common.releases.<release>.packages` (additive, mirrors the per-DE shape that already worked); use it to add `libfprint-2-tod1` only on noble/resolute
4. `9a181d64` — auto-enable fprintd in PAM via `pam-auth-update --enable fprintd` in the cross-DE postinst path; inert in build mode / without fprintd / without pam-auth-update

## Parser change (commit 3)

The Python parser already walked `de_data.releases.<release>.packages` for additive per-release entries. It did NOT walk the same shape on `common.yaml`. One small block added that mirrors the existing per-DE handling — common runs first so per-DE release blocks can still remove what common added (symmetric with how `tier_overrides` works above).

Verified:

```
$ parse_desktop_yaml.py … gnome noble    amd64 --tier mid
  ... fprintd libfprint-2-2 libpam-fprintd libfprint-2-tod1 ...
$ parse_desktop_yaml.py … gnome resolute amd64 --tier mid
  ... fprintd libfprint-2-2 libpam-fprintd libfprint-2-tod1 ...
$ parse_desktop_yaml.py … gnome trixie   amd64 --tier mid
  ... fprintd libfprint-2-2 libpam-fprintd ...                  (no tod1)
$ parse_desktop_yaml.py … gnome bookworm amd64 --tier mid
  ... fprintd libfprint-2-2 libpam-fprintd ...                  (no tod1)
```

## Sensor caveat

Several recent Goodix / Synaptics sensors (e.g. ThinkPad X9-14 Aura Edition Gen 1's Goodix `27c6:659c`) need a closed-source TOD plugin riding on top of `libfprint-2-tod1`. There's no `libfprint-2-tod1-goodix-*` for `659c` in noble / resolute / Launchpad / public Lenovo PPAs yet — when one appears, it's a manual `apt install <plugin>` on that machine. This PR puts the host + PAM wiring in place; it doesn't (and can't) bundle plugins that don't exist publicly.

## Test plan

- [ ] `parse_desktop_yaml.py … <de> <release> <arch> --tier mid` returns the table above on each release
- [ ] Install a desktop on Debian trixie — apt succeeds (no "Unable to locate package libfprint-2-tod1")
- [ ] Install a desktop on Ubuntu noble — `dpkg -l | grep fprint` shows all four packages
- [ ] After install on a host with a supported reader: `fprintd-enroll` works, and `grep fprintd /etc/pam.d/common-auth` is non-empty (PAM is wired)
- [ ] On a host without a reader, login still works normally