### PR TITLE
runner-cleanup: wipe _diag/pages/ alongside _work/

### DIFF
--- a/tools/modules/system/runner-cleanup/runner-cleanup
+++ b/tools/modules/system/runner-cleanup/runner-cleanup
@@ -249,6 +249,17 @@ for user in "${idle[@]}"; do
 		continue
 	fi
 
+	# Stale diagnostic pages under _diag/pages/ accumulate when the
+	# runner is killed mid-job (OOM, hard reboot, ...). The agent uses
+	# a deterministic page ID derived from the parent run + step UUID,
+	# so on the next pull-request a workflow that hashes to the same ID
+	# tries to create a log file at a path that already exists and
+	# crashes in the "Initialize containers" step with:
+	#   The file '/home/actions-runner-NN/_diag/pages/<uuid>.log' already exists.
+	# Wiping _diag/pages/ when the runner is idle is safe — the agent
+	# regenerates a fresh page directory on its next start.
+	diag_pages="${home}/_diag/pages"
+
 	unit=$(find_runner_unit "$user")
 	if [[ -z "$unit" ]]; then
 		# No svc.sh-installed unit found — fall back to wipe without
@@ -256,15 +267,17 @@ for user in "${idle[@]}"; do
 		# or under a different supervisor.
 		log "wipe ${work}/ (no systemd unit for ${user}, no stop/start)"
 		run find "$work" -mindepth 1 -delete
+		[[ -d "$diag_pages" ]] && run find "$diag_pages" -mindepth 1 -delete
 		continue
 	fi
 
-	log "stop ${unit} → wipe ${work}/ → start ${unit}"
+	log "stop ${unit} → wipe ${work}/ + ${diag_pages}/ → start ${unit}"
 	if run systemctl stop "${unit}.service"; then
 		# Record in the trap-tracked set BEFORE the wipe — if we
 		# get killed during wipe, the EXIT trap will restart it.
 		[[ $DRY_RUN -eq 0 ]] && stopped_unit_for["$unit"]=1
 		run find "$work" -mindepth 1 -delete
+		[[ -d "$diag_pages" ]] && run find "$diag_pages" -mindepth 1 -delete
 		if run systemctl start "${unit}.service"; then
 			[[ $DRY_RUN -eq 0 ]] && unset 'stopped_unit_for[$unit]'
 		else


### PR DESCRIPTION
## Summary

The GitHub Actions runner agent writes diagnostic page logs to \`~/_diag/pages/<uuid>.log\`. When the runner is killed mid-job (OOM, hard reboot, watchdog reap from runner-cleanup's stuck-Worker hunter), partial page files stay on disk.

On the next run that hashes to the same page UUID, the agent dies in "Initialize containers" with:

\`\`\`
The file '/home/actions-runner-NN/_diag/pages/<uuid>.log' already exists.
\`\`\`

Seen on \`actions-runner-05\` in PR #918's CI ([run 26001247231](https://github.com/armbian/configng/actions/runs/26001247231/job/76424857696)). The \`_work\` wipe we already do has nothing to say about \`_diag/pages/\`, so the collision survives every cleanup pass.

## Change

When the runner is idle and we've stopped its systemd unit, also \`find $home/_diag/pages -mindepth 1 -delete\`. The agent regenerates a fresh page directory on its next start.

Mirrored in the no-systemd-unit fallback path so it works for runners under tmux / foreground / non-svc.sh supervision.

## Test plan

- [ ] On a host with stale \`_diag/pages/*.log\` files, run \`runner-cleanup --dry-run\` and confirm the new find delete is logged
- [ ] Run for real, confirm the pages files are gone and the runner systemd unit comes back up clean
- [ ] Re-run the failing CI job (#76424857696) to confirm "Initialize containers" gets past the page-file step