### PR TITLE
runner-cleanup: wipe ~/_diag/ on every runner each pass

### DIFF
--- a/tools/modules/system/runner-cleanup/runner-cleanup
+++ b/tools/modules/system/runner-cleanup/runner-cleanup
@@ -249,17 +249,6 @@ for user in "${idle[@]}"; do
 		continue
 	fi
 
-	# Stale diagnostic pages under _diag/pages/ accumulate when the
-	# runner is killed mid-job (OOM, hard reboot, ...). The agent uses
-	# a deterministic page ID derived from the parent run + step UUID,
-	# so on the next pull-request a workflow that hashes to the same ID
-	# tries to create a log file at a path that already exists and
-	# crashes in the "Initialize containers" step with:
-	#   The file '/home/actions-runner-NN/_diag/pages/<uuid>.log' already exists.
-	# Wiping _diag/pages/ when the runner is idle is safe — the agent
-	# regenerates a fresh page directory on its next start.
-	diag_pages="${home}/_diag/pages"
-
 	unit=$(find_runner_unit "$user")
 	if [[ -z "$unit" ]]; then
 		# No svc.sh-installed unit found — fall back to wipe without
@@ -267,17 +256,15 @@ for user in "${idle[@]}"; do
 		# or under a different supervisor.
 		log "wipe ${work}/ (no systemd unit for ${user}, no stop/start)"
 		run find "$work" -mindepth 1 -delete
-		[[ -d "$diag_pages" ]] && run find "$diag_pages" -mindepth 1 -delete
 		continue
 	fi
 
-	log "stop ${unit} → wipe ${work}/ + ${diag_pages}/ → start ${unit}"
+	log "stop ${unit} → wipe ${work}/ → start ${unit}"
 	if run systemctl stop "${unit}.service"; then
 		# Record in the trap-tracked set BEFORE the wipe — if we
 		# get killed during wipe, the EXIT trap will restart it.
 		[[ $DRY_RUN -eq 0 ]] && stopped_unit_for["$unit"]=1
 		run find "$work" -mindepth 1 -delete
-		[[ -d "$diag_pages" ]] && run find "$diag_pages" -mindepth 1 -delete
 		if run systemctl start "${unit}.service"; then
 			[[ $DRY_RUN -eq 0 ]] && unset 'stopped_unit_for[$unit]'
 		else
@@ -286,6 +273,31 @@ for user in "${idle[@]}"; do
 	else
 		note "WARNING: could not stop ${unit}.service for ${user}; skipping wipe to avoid mid-job damage"
 	fi
+done
+
+# -------------------------------------------------------------------
+# 2b. Wipe ~/_diag/ on every runner, regardless of busy/idle state
+#     and regardless of KEEP_RUNNERS_WORK.
+#
+# The agent writes Runner_*.log / Worker_*.log under ~/_diag/ and
+# per-job page files under ~/_diag/pages/*.log. They accumulate
+# indefinitely - a runner host grows tens of GB of these over a few
+# months - and stale page-UUID files break "Initialize containers"
+# when the agent reuses a UUID that already exists on disk.
+#
+# Safe to wipe even while a job is running. Linux keeps the inode
+# alive as long as Runner.Listener / Runner.Worker hold the file
+# open; the agent keeps writing to its existing fd, and new jobs
+# create fresh files. Recent logs are reachable via the GitHub
+# Actions UI (workflow logs retained 90 days) anyway - the on-disk
+# copies are duplicative.
+# -------------------------------------------------------------------
+for user in "${runner_users[@]}"; do
+	home=$(getent passwd "$user" | cut -d: -f6)
+	diag="${home}/_diag"
+	[[ -d "$diag" ]] || continue
+	note "wipe ${user}/_diag"
+	run find "$diag" -mindepth 1 -delete
 done
 
 # -------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #919. That PR wiped \`_diag/pages/\` only on idle runners, gated on \`KEEP_RUNNERS_WORK\`. Two problems:

- Tied to the whitelist — \`actions-runner-01\` is in \`KEEP_RUNNERS_WORK\`, so its \`_diag/pages/\` never got cleared. Exactly that runner kept breaking with "Initialize containers" UUID collisions.
- Limited to \`pages/\` — the agent also accumulates \`Runner_*.log\` / \`Worker_*.log\` directly under \`~/_diag/\`. A long-lived runner host grows tens of GB of these.

## Change

\`find ~/_diag -mindepth 1 -delete\` on every runner each pass — regardless of busy/idle state and regardless of any whitelist.

## Why wipe-all is safe

- Linux keeps the inode alive while \`Runner.Listener\` / \`Runner.Worker\` hold the file open. The agent keeps writing to its existing fd; new jobs create fresh files.
- Recent logs are reachable via the GitHub Actions UI (workflow logs retained 90 days). The on-disk copies in \`~/_diag/\` are duplicative for triage purposes.
- Stale page-UUID files — the original trigger for #919 — are cleared on the next hourly tick.

## Expected output

\`\`\`
wipe actions-runner-01/_diag
wipe actions-runner-02/_diag
...
wipe actions-runner-08/_diag
\`\`\`

## Test plan

- [ ] \`runner-cleanup --dry-run\` prints \`wipe actions-runner-NN/_diag\` for each runner + the \`[dry-run] find …\` command
- [ ] Real run wipes the directory contents, busy runners' jobs keep running, fresh log files appear on next job
- [ ] No more "Initialize containers" UUID collisions