### PR TITLE
runner-cleanup: drop redundant age-based _diag prune

### DIFF
--- a/tools/modules/system/runner-cleanup/runner-cleanup
+++ b/tools/modules/system/runner-cleanup/runner-cleanup
@@ -394,21 +394,7 @@ if command -v journalctl > /dev/null 2>&1; then
 	run journalctl --vacuum-size="$jmax" > /dev/null 2>&1 || true
 fi
 
-# 4c. Runner _diag log prune. The Listener writes per-job
-# Runner_*.log / Worker_*.log into ~/_diag — useful for troubleshoot,
-# but accumulates indefinitely. Keep the last DIAG_LOG_KEEP_DAYS of
-# them; runner's own rotation is too lazy.
-diag_days="${DIAG_LOG_KEEP_DAYS:-14}"
-for user in "${runner_users[@]}"; do
-	home=$(getent passwd "$user" | cut -d: -f6)
-	[[ -d "${home}/_diag" ]] || continue
-	log "prune ${user}/_diag (older than ${diag_days}d)"
-	run find "${home}/_diag" -type f \
-		\( -name 'Runner_*.log' -o -name 'Worker_*.log' -o -name '*.log.gz' \) \
-		-mtime "+${diag_days}" -delete
-done
-
-# 4d. Docker container log truncation. /var/lib/docker/containers/<id>/<id>-json.log
+# 4c. Docker container log truncation. /var/lib/docker/containers/<id>/<id>-json.log
 # grows unbounded for long-running containers (SWAG, openssh-server,
 # anything with a chatty stdout). Truncating mid-flight is safe — the
 # kernel keeps the existing fd open and the daemon resumes writing


### PR DESCRIPTION
Cleanup of dead code surfaced by [this verbose run](https://github.com/armbian/configng) of \`runner-cleanup --verbose\` after #920 merged.

## What was happening

Output showed 16 \`_diag\`-related lines per pass:

\`\`\`
wipe actions-runner-01/_diag        ← from section 2b (PR #920)
wipe actions-runner-02/_diag
...
wipe actions-runner-08/_diag
... (docker / apt / journal) ...
prune actions-runner-01/_diag (older than 14d)   ← from section 4c (PR #919)
prune actions-runner-02/_diag (older than 14d)
...
prune actions-runner-08/_diag (older than 14d)
\`\`\`

Section 2b (merged in #920) already wipes \`~/_diag/\` unconditionally with \`find -mindepth 1 -delete\`. By the time section 4c runs in the housekeeping pass, \`~/_diag/\` is empty — 4c's \`find -mtime +14 -delete\` finds nothing to delete and just emits a misleading log line.

## Change

Drop section 4c entirely; renumber the following docker container-log section from 4d to 4c.

Net effect: same behaviour, half the lines of \`_diag\` log spam, no dead code.