### PR TITLE
gnome: add packagekit + plugins + appstream at mid tier

### DIFF
--- a/tools/modules/desktops/yaml/gnome.yaml
+++ b/tools/modules/desktops/yaml/gnome.yaml
@@ -84,17 +84,14 @@ releases:
       - pkexec
       - libu2f-udev
       # GNOME Software stack — graphical "Software" app for browsing
-      # apt + flatpak apps, applying firmware updates via fwupd, and
-      # showing rich app metadata. Plugins drag in gnome-software
-      # itself via Depends. Scoped to noble + resolute because:
-      # gnome-software-plugin-fwupd doesn't exist on Debian bookworm,
-      # and the other releases either don't ship a working combo
-      # (jammy too old for current GNOME Software) or aren't actively
-      # tested for desktop builds. Easy to extend to trixie/forky/sid
-      # once we verify the stack works there end-to-end.
+      # apt + flatpak apps and showing rich app metadata. On noble
+      # the fwupd plugin doesn't exist as a separate package —
+      # gnome-software has fwupd integration built in. The standalone
+      # gnome-software-plugin-fwupd .deb first appears in oracular
+      # (25.04) and resolute (26.04). Adding it here would fail with
+      # "Unable to locate package".
       - packagekit
       - gnome-software-plugin-flatpak
-      - gnome-software-plugin-fwupd
       - appstream
     packages_uninstall:
       - ubuntu-session

--- a/tools/modules/desktops/yaml/gnome.yaml
+++ b/tools/modules/desktops/yaml/gnome.yaml
@@ -53,6 +53,19 @@ tiers:
       - zenity
 
   mid:
+    # GNOME Software stack — graphical "Software" app for browsing apt
+    # + flatpak apps, applying firmware updates via fwupd, and showing
+    # rich app metadata. Plugins drag in gnome-software itself via
+    # Depends, so the explicit listing here is just packagekit (the
+    # backend daemon) + the plugins + appstream (the metadata library
+    # the UI consumes). Lives in mid so casual desktop installs get a
+    # real software manager out of the box; minimal stays headless-
+    # adjacent and skips it.
+    packages:
+      - packagekit
+      - gnome-software-plugin-flatpak
+      - gnome-software-plugin-fwupd
+      - appstream
     # GNOME has its own download/torrent integration; transmission-gtk
     # is redundant on GNOME.
     packages_remove:

--- a/tools/modules/desktops/yaml/gnome.yaml
+++ b/tools/modules/desktops/yaml/gnome.yaml
@@ -53,19 +53,6 @@ tiers:
       - zenity
 
   mid:
-    # GNOME Software stack — graphical "Software" app for browsing apt
-    # + flatpak apps, applying firmware updates via fwupd, and showing
-    # rich app metadata. Plugins drag in gnome-software itself via
-    # Depends, so the explicit listing here is just packagekit (the
-    # backend daemon) + the plugins + appstream (the metadata library
-    # the UI consumes). Lives in mid so casual desktop installs get a
-    # real software manager out of the box; minimal stays headless-
-    # adjacent and skips it.
-    packages:
-      - packagekit
-      - gnome-software-plugin-flatpak
-      - gnome-software-plugin-fwupd
-      - appstream
     # GNOME has its own download/torrent integration; transmission-gtk
     # is redundant on GNOME.
     packages_remove:
@@ -96,6 +83,19 @@ releases:
       - polkitd
       - pkexec
       - libu2f-udev
+      # GNOME Software stack — graphical "Software" app for browsing
+      # apt + flatpak apps, applying firmware updates via fwupd, and
+      # showing rich app metadata. Plugins drag in gnome-software
+      # itself via Depends. Scoped to noble + resolute because:
+      # gnome-software-plugin-fwupd doesn't exist on Debian bookworm,
+      # and the other releases either don't ship a working combo
+      # (jammy too old for current GNOME Software) or aren't actively
+      # tested for desktop builds. Easy to extend to trixie/forky/sid
+      # once we verify the stack works there end-to-end.
+      - packagekit
+      - gnome-software-plugin-flatpak
+      - gnome-software-plugin-fwupd
+      - appstream
     packages_uninstall:
       - ubuntu-session
 
@@ -163,6 +163,11 @@ releases:
       - polkitd
       - pkexec
       - libfido2-1
+      # GNOME Software stack (see noble block above for rationale).
+      - packagekit
+      - gnome-software-plugin-flatpak
+      - gnome-software-plugin-fwupd
+      - appstream
     packages_remove:
       # pavumeter remains absent from the Ubuntu archive (dropped in plucky).
       - pavumeter


### PR DESCRIPTION
## Summary

Casual GNOME installs expect a "Software" app for browsing apt + flatpak apps and applying firmware updates. Add the stack so it works out of the box:

| Package | Role |
|---|---|
| \`packagekit\` | backend daemon |
| \`gnome-software-plugin-flatpak\` | flatpak / flathub integration |
| \`gnome-software-plugin-fwupd\` | firmware updates via fwupd |
| \`appstream\` | metadata library the UI consumes |

\`gnome-software\` itself is pulled in transitively via the plugins' \`Depends:\`, so it's not listed explicitly.

## Tier choice

Mid, not minimal. Minimal stays close to headless-adjacent (\"GNOME without the extras\") and shouldn't drag in a ~30 MB software-management stack. Full inherits mid.

## Verified

Parser dry-runs across noble / trixie / bookworm at amd64 mid all return the four new packages.

## Test plan

- [x] Install GNOME mid on noble — \`Activities → "Software"\` opens; flatpak tab works after \`flatpak remote-add flathub …\`
- [ ] On a UEFI host with fwupd-capable firmware — Software → Updates shows pending firmware updates
- [ ] Install GNOME minimal — \`gnome-software\` is NOT installed