### PR TITLE
desktops: install alsa-ucm-conf at minimal tier

### DIFF
--- a/tools/modules/desktops/yaml/common.yaml
+++ b/tools/modules/desktops/yaml/common.yaml
@@ -46,6 +46,16 @@ tiers:
       # in the GTK applet for nothing.
       - network-manager
       - netplan.io
+      # ALSA Use Case Manager profiles. Without this package, PipeWire /
+      # wireplumber see a complex sound card (Intel SOF on Lunar/Meteor/
+      # Panther Lake laptops, Qualcomm Snapdragon X, AMD ACP DSP, …)
+      # but have no per-machine recipe for which PCM device is the speaker
+      # output, which controls to unmute, or how to route on jack-insert.
+      # Result: ALSA-level audio works (`speaker-test -D plughw:0,2`
+      # plays), but GNOME / KDE Sound shows "Dummy Output" only.
+      # Architecture: all package, ~1 MB on disk, inert on simpler audio
+      # chains (HDMI-only SBCs, USB DAC, etc.), so safe at minimal tier.
+      - alsa-ucm-conf
 
   mid:
     packages:


### PR DESCRIPTION
## Summary

Without \`alsa-ucm-conf\` installed, PipeWire / wireplumber see complex sound cards (Intel SOF on Lunar/Meteor/Panther Lake laptops, Qualcomm Snapdragon X, AMD ACP DSP, …) but have no per-machine recipe for which PCM device is the speaker output, which controls to unmute, or how to route on jack-insert.

Result: kernel-level audio is fully alive (\`aplay -l\` shows the Speaker pcm; \`speaker-test -D plughw:0,2\` plays), but GNOME / KDE Sound shows only "Dummy Output" and the speakers stay silent.

## Verified

ThinkPad X9-15 Gen 1 (LNL, CS42L43 SoundWire jack + CS35L56 SPI amps, DMI \`21Q6001MGE\`). Same kernel + same SOF firmware + same Cirrus blobs + same topology as a working Ubuntu OEM 6.17 boot of the same machine. The **only** difference between "silent" and "working" was this package.

## Scope

- **minimal tier** of common.yaml — every desktop / release / arch / DE combo picks it up.
- Architecture: all package, ~1 MB on disk.
- Inert on simpler audio chains (HDMI-only SBCs, USB DAC, basic codec setups).

## Pairs with

[armbian/build#9858](https://github.com/armbian/build/pull/9858) — adds the same package to UEFI image builds via \`uefi_common.inc\`, so image-built rootfs gets it from the build side. This PR ensures the runtime \`armbian-config module_desktops install\` path also gets it on every desktop.

## Verified across releases / tiers

\`\`\`
noble/minimal:  alsa-ucm-conf
noble/mid:      alsa-ucm-conf
resolute/minimal: alsa-ucm-conf
resolute/mid:     alsa-ucm-conf
trixie/minimal:   alsa-ucm-conf
trixie/mid:       alsa-ucm-conf
bookworm/minimal: alsa-ucm-conf
bookworm/mid:     alsa-ucm-conf
\`\`\`

## Test plan

- [ ] Install GNOME minimal on noble — \`dpkg -l alsa-ucm-conf\` shows installed
- [ ] Boot on an SOF-equipped laptop — Sound panel shows real Speaker sink (not Dummy Output)
- [ ] Boot on a non-laptop SBC — no regression, package is inert