### PR TITLE
desktops: install libcamera/v4l userspace at minimal tier

### DIFF
--- a/tools/modules/desktops/yaml/common.yaml
+++ b/tools/modules/desktops/yaml/common.yaml
@@ -46,6 +46,16 @@ tiers:
       # in the GTK applet for nothing.
       - network-manager
       - netplan.io
+      # Camera userspace: PipeWire + GStreamer libcamera shims so apps
+      # (GNOME Snapshot / Cheese / Firefox / Chrome) can see V4L2 /
+      # libcamera devices end-to-end. v4l-utils ships `v4l2-ctl` for
+      # troubleshooting. Kernel-side enumeration of /dev/video* is not
+      # enough on modern laptops with complex ISPs (Intel IPU3/6/7,
+      # Qualcomm Snapdragon X) - apps need the userspace pipeline.
+      # Inert on machines without a camera (small daemons only).
+      - pipewire-libcamera
+      - gstreamer1.0-libcamera
+      - v4l-utils
 
   mid:
     packages:


### PR DESCRIPTION
Companion to the alsa-ucm-conf PR (#923) — same shape, different stack.

## Summary

Modern laptops enumerate \`/dev/video*\` at the kernel level but apps need a userspace pipeline (\`libcamera\` + the PipeWire camera shim + GStreamer libcamera plugin) to actually show a live image. Without these, GNOME Snapshot / Cheese / Firefox / Chrome can't find a camera even when one is physically present and the kernel module is bound.

Adds at minimal tier:

| Package | Role |
|---|---|
| \`pipewire-libcamera\` | PipeWire camera node integration |
| \`gstreamer1.0-libcamera\` | GStreamer plugin used by GNOME Snapshot et al. |
| \`v4l-utils\` | \`v4l2-ctl\` for troubleshooting |

## Verified across releases

\`\`\`
noble:    gstreamer1.0-libcamera pipewire-libcamera v4l-utils
resolute: gstreamer1.0-libcamera pipewire-libcamera v4l-utils
trixie:   gstreamer1.0-libcamera pipewire-libcamera v4l-utils
bookworm: gstreamer1.0-libcamera pipewire-libcamera v4l-utils
\`\`\`

## Honest caveat

On bleeding-edge SKUs (ThinkPad X9-15 Gen 1, Lunar Lake IPU7), this PR alone won't make the camera work — upstream libcamera 0.7 doesn't have an IPU7 pipeline handler yet. Intel/Canonical ship those out of tree (libcamera 0.2-fakesync on noble). When IPU7 support lands in mainline libcamera and propagates to Debian/Ubuntu, every Armbian desktop install on these laptops will work on the next apt upgrade. This PR is the cheap pre-stage so the userspace is already in place.

## Test plan

- [ ] Install GNOME minimal on noble — \`dpkg -l\` shows the three packages
- [ ] On a host with a USB UVC camera (IPU3 / supported chain) — GNOME Snapshot shows live preview
- [ ] On a host without a camera — no regression, daemons stay idle