### PR TITLE
runner-cleanup: event-driven _diag/pages wipe via systemd hooks

### DIFF
--- a/tools/modules/system/module_armbian_runners.sh
+++ b/tools/modules/system/module_armbian_runners.sh
@@ -187,6 +187,14 @@ function module_armbian_runners () {
 					install -m 0644 "${cleanup_src}/runner-cleanup.conf" /etc/armbian/runner-cleanup.conf
 				fi
 				install -m 0644 "${cleanup_src}/runner-cleanup.conf" /etc/armbian/runner-cleanup.conf.dist
+				# Event-driven per-runner _diag/pages cleanup. The hourly
+				# runner-cleanup timer is the catch-all; this layer fires
+				# on every runner unit start/stop so collisions never
+				# survive a quick restart cycle. install-runner-hooks
+				# scans every actions.runner.*.service installed by the
+				# svc.sh step above and drops in ExecStartPre/StopPost
+				# wired to /usr/local/sbin/runner-clean-pages.
+				install -m 0755 "${cleanup_src}/runner-clean-pages"     /usr/local/sbin/runner-clean-pages
 				systemctl daemon-reload
 				# Don't silence errors here — a failed timer install
 				# means the cleanup never fires and the host quietly
@@ -199,6 +207,15 @@ function module_armbian_runners () {
 						echo "Error: 'systemctl enable runner-cleanup.timer' failed" >&2
 					systemctl start  runner-cleanup.timer || \
 						echo "Error: 'systemctl start runner-cleanup.timer' failed" >&2
+				fi
+				# Wire up the systemd drop-ins for every runner unit
+				# that the svc.sh loop above just installed. Runs after
+				# daemon-reload so the new drop-ins take effect on the
+				# next runner restart cycle. Non-fatal — runner units
+				# already started above keep working without hooks
+				# until the operator restarts them.
+				if ! bash "${cleanup_src}/install-runner-hooks"; then
+					echo "Warning: install-runner-hooks failed; runner-clean-pages systemd hooks not in place" >&2
 				fi
 			else
 				echo "Warning: runner-cleanup assets not found in source tree next to module or at /usr/share/armbian-config/runner-cleanup; skipping maintenance helper install" >&2

--- a/tools/modules/system/runner-cleanup/install-runner-hooks
+++ b/tools/modules/system/runner-cleanup/install-runner-hooks
@@ -1,0 +1,63 @@
+#!/bin/bash
+# install-runner-hooks — wire ExecStartPre + ExecStopPost into every
+# actions.runner.*.service so each runner self-cleans its _diag/pages/
+# on start AND on stop (including SIGKILL / OOM / hard reboot).
+#
+# Idempotent: re-running just rewrites the drop-in files.
+#
+# Run once on the runner host as root after the runner-cleanup
+# scripts are deployed. Hourly runner-cleanup keeps running in
+# parallel; this is the event-driven layer on top.
+
+set -e
+
+if [[ "$EUID" -ne 0 ]]; then
+	echo "install-runner-hooks: must run as root" >&2
+	exit 1
+fi
+
+# Locate ourselves so the drop-in can point at the right runner-clean-pages
+# path. Default to /usr/local/bin which is where the cleanup helper
+# ends up if the operator copies things by hand; override via env.
+HELPER_PATH="${RUNNER_CLEAN_PAGES_PATH:-/usr/local/bin/runner-clean-pages}"
+
+if [[ ! -x "$HELPER_PATH" ]]; then
+	echo "install-runner-hooks: ${HELPER_PATH} not found or not executable" >&2
+	echo "  copy this directory's runner-clean-pages there first, or set" >&2
+	echo "  RUNNER_CLEAN_PAGES_PATH=/path/to/runner-clean-pages" >&2
+	exit 1
+fi
+
+shopt -s nullglob
+declare -a units=( /etc/systemd/system/actions.runner.*.service )
+shopt -u nullglob
+
+if (( ${#units[@]} == 0 )); then
+	echo "install-runner-hooks: no actions.runner.*.service units found on this host"
+	exit 0
+fi
+
+declare -i installed=0
+for unit_path in "${units[@]}"; do
+	unit_name="${unit_path##*/}"
+	unit_name="${unit_name%.service}"
+	drop_dir="/etc/systemd/system/${unit_name}.service.d"
+	mkdir -p "$drop_dir"
+
+	cat > "${drop_dir}/10-clean-pages.conf" <<- EOF
+		# Installed by runner-cleanup/install-runner-hooks.
+		# Wipes ~/_diag/pages/ on every start AND every stop so the
+		# next job never collides on a stale page UUID. Both hooks
+		# are prefixed with '-' so any failure is non-fatal (the
+		# runner unit must still start / stop even if cleanup fails).
+		[Service]
+		ExecStartPre=-${HELPER_PATH}
+		ExecStopPost=-${HELPER_PATH}
+	EOF
+
+	echo "install-runner-hooks: ${drop_dir}/10-clean-pages.conf"
+	installed=$(( installed + 1 ))
+done
+
+systemctl daemon-reload
+echo "install-runner-hooks: ${installed} unit(s) updated; daemon-reload done"

--- a/tools/modules/system/runner-cleanup/install-runner-hooks
+++ b/tools/modules/system/runner-cleanup/install-runner-hooks
@@ -19,7 +19,7 @@ fi
 # Locate ourselves so the drop-in can point at the right runner-clean-pages
 # path. Default to /usr/local/bin which is where the cleanup helper
 # ends up if the operator copies things by hand; override via env.
-HELPER_PATH="${RUNNER_CLEAN_PAGES_PATH:-/usr/local/bin/runner-clean-pages}"
+HELPER_PATH="${RUNNER_CLEAN_PAGES_PATH:-/usr/local/sbin/runner-clean-pages}"
 
 if [[ ! -x "$HELPER_PATH" ]]; then
 	echo "install-runner-hooks: ${HELPER_PATH} not found or not executable" >&2

--- a/tools/modules/system/runner-cleanup/runner-clean-pages
+++ b/tools/modules/system/runner-cleanup/runner-clean-pages
@@ -1,0 +1,28 @@
+#!/bin/bash
+# runner-clean-pages — wipe ~/_diag/pages/ for the runner user that
+# systemd invoked us as. Designed to be wired in as ExecStartPre
+# + ExecStopPost on every actions.runner.*.service unit via a
+# drop-in (see install-runner-hooks).
+#
+# Why: stale per-job page files cause "Initialize containers" to die
+# on the next job with:
+#   The file '/home/actions-runner-NN/_diag/pages/<uuid>.log' already exists.
+# The hourly runner-cleanup timer eventually clears it, but a runner
+# that restarts within the hour hits the collision. systemd hooks
+# clear it event-driven instead.
+#
+# Idempotent. Logs to journald (systemd-cat) for visibility.
+
+set -e
+
+home="${HOME:?HOME is not set; runner-clean-pages must run as the runner user}"
+diag_pages="${home}/_diag/pages"
+
+[ -d "$diag_pages" ] || exit 0
+
+if find "$diag_pages" -mindepth 1 -delete 2>/dev/null; then
+	echo "runner-clean-pages: wiped ${diag_pages}/" | \
+		systemd-cat -t runner-clean-pages -p info 2>/dev/null || true
+fi
+
+exit 0


### PR DESCRIPTION
## The bug, again

Even with hourly \`runner-cleanup\` (PRs #919/#920), \`actions-runner-01\` keeps hitting:

\`\`\`
Error: The file '/home/actions-runner-01/_diag/pages/<uuid>.log' already exists.
\`\`\`

The hourly timer eventually clears it, but a runner that restarts within that hour still collides on a stale page UUID. We need event-driven cleanup.

## What this adds

Two tiny pieces in \`tools/modules/system/runner-cleanup/\`:

| File | Role |
|---|---|
| \`runner-clean-pages\` | One-liner: wipes \`$HOME/_diag/pages/\` for whatever runner user systemd invoked it as. Logs to journald. |
| \`install-runner-hooks\` | One-shot installer: finds every \`actions.runner.*.service\` and drops in a \`10-clean-pages.conf\` override adding \`ExecStartPre=-<helper>\` + \`ExecStopPost=-<helper>\`. |

The \`-\` prefix means cleanup failures never block the runner unit itself.

## Why systemd hooks, not a daemon

\`ExecStopPost\` fires on every stop reason — graceful exit, SIGTERM, SIGKILL, OOM, machine reboot. \`ExecStartPre\` covers the case where systemd was bypassed (hard power-cut). Together they form an event-driven cleanup chain with zero long-lived daemon process — systemd's own supervision IS the daemon.

The hourly \`runner-cleanup\` timer continues to run as the catch-all fallback for whatever the hooks miss.

## Deployment

On each runner host, after pulling the updated configng:

\`\`\`bash
sudo install -m 0755 tools/modules/system/runner-cleanup/runner-clean-pages /usr/local/bin/
sudo bash tools/modules/system/runner-cleanup/install-runner-hooks
\`\`\`

(or just copy both files to /usr/local/bin and run the installer)

## Test plan

- [ ] After install, \`systemctl cat actions.runner.<unit>\` shows the new \`ExecStartPre\` / \`ExecStopPost\` lines from the drop-in
- [ ] \`systemctl stop actions.runner.<unit>\` then \`ls /home/actions-runner-NN/_diag/pages/\` is empty
- [ ] \`systemctl start actions.runner.<unit>\` runs ExecStartPre cleanly (journalctl shows \`runner-clean-pages: wiped\`)
- [ ] \`actions-runner-01\` no longer hits "Initialize containers" UUID collisions on quick-restart workloads