### PR TITLE
module_cockpit: drop qemu-kvm (no riscv64 build; qemu-system covers it)

### DIFF
--- a/tools/modules/software/module_cockpit.sh
+++ b/tools/modules/software/module_cockpit.sh
@@ -32,7 +32,15 @@ function module_cockpit() {
 
 			## install cockpit
 			pkg_update
-			pkg_install cockpit cockpit-ws cockpit-system cockpit-storaged cockpit-machines dnsmasq virtinst qemu-kvm qemu-utils qemu-system
+			# qemu-kvm is a legacy meta that's only published for amd64
+			# and arm64 (and Ubuntu carries it as a x86-leaning shim
+			# pulling qemu-system-x86). It has no installation
+			# candidate on riscv64, causing the cockpit install to
+			# fail with "Package 'qemu-kvm' has no installation
+			# candidate". qemu-system below is the modern arch-agnostic
+			# meta - on each host it pulls qemu-system-<host-arch>,
+			# which is what libvirt + cockpit-machines actually need.
+			pkg_install cockpit cockpit-ws cockpit-system cockpit-storaged cockpit-machines dnsmasq virtinst qemu-utils qemu-system
 
 			usermod -a -G libvirt libvirtdbus
 			usermod -a -G libvirt libvirt-qemu
@@ -67,7 +75,7 @@ function module_cockpit() {
 				virsh net-destroy ${bridge}
 				virsh net-undefine ${bridge}
 			done
-			pkg_remove cockpit cockpit-ws cockpit-system cockpit-storaged cockpit-machines dnsmasq virtinst qemu-kvm qemu-utils qemu-system
+			pkg_remove cockpit cockpit-ws cockpit-system cockpit-storaged cockpit-machines dnsmasq virtinst qemu-utils qemu-system
 
 		;;
 		"${commands[2]}")


### PR DESCRIPTION
## The bug

\`armbian-config module_cockpit install\` failed on riscv64 with:

\`\`\`
Package qemu-kvm is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  cpu-checker

E: Package 'qemu-kvm' has no installation candidate
\`\`\`

## Why

\`qemu-kvm\` is a legacy x86-leaning meta package. Debian / Ubuntu only publish it for amd64 (and historically arm64). On riscv64 it doesn't exist; apt's "However the following packages replace it: cpu-checker" hint is misleading — \`cpu-checker\` is a tiny KVM-presence-probe tool, not a hypervisor.

## Fix

Drop \`qemu-kvm\` from \`module_cockpit\`'s install + remove lists. The neighboring \`qemu-system\` is the modern arch-agnostic meta that pulls in \`qemu-system-<host-arch>\` (\`qemu-system-riscv64\` on riscv64, \`qemu-system-x86\` on amd64, etc.) — exactly what \`libvirt\` + \`cockpit-machines\` need under the hood.

Functionality unchanged on amd64 / arm64 (qemu-kvm was already a redundant alias for what qemu-system pulls in); install now succeeds on riscv64.

## Test plan

- [ ] \`armbian-config\` cockpit install on riscv64 — completes without "no installation candidate"
- [ ] Same on amd64 / arm64 — KVM-backed VMs still launch via cockpit-machines (libvirt + qemu-system-<arch>)
- [ ] Cockpit remove path also runs clean