### PR TITLE
desktops: run DE postinst scripts in build chroot (fix missing wallpaper)

### DIFF
--- a/tools/modules/desktops/module_desktop_branding.sh
+++ b/tools/modules/desktops/module_desktop_branding.sh
@@ -131,14 +131,25 @@ function module_desktop_branding() {
 				cp -R "$desktop_dir/greeters/sddm/themes/"* /usr/share/sddm/themes/ 2>/dev/null || true
 			fi
 
-			# DE-specific postinst script (skip inside containers / CI)
+			# DE-specific postinst script. Runs unconditionally — including
+			# inside the build chroot. The skip-in-container guard that used
+			# to wrap this block silently dropped wallpaper / dconf / theme
+			# setup on GHA rootfs builds: the postinst scripts here are
+			# almost entirely file writes (dconf overrides, sed-edits of
+			# /etc/*.conf, schema recompiles) — chroot-safe by design and
+			# precisely what we want baked into the rootfs cache.
+			#
+			# Anything that genuinely needs a live system (systemctl,
+			# gsettings against a running dbus, netplan apply) is handled
+			# in module_desktops.sh under explicit _desktop_in_container
+			# guards; this code path never touched runtime services to
+			# begin with. The dialog_infobox call is the one user-facing
+			# bit, so keep it gated on "not inside container" so CI
+			# doesn't try to render an ncurses dialog.
 			if [[ -f "$desktop_dir/postinst/${de}.sh" ]]; then
-				if _desktop_in_container 2>/dev/null; then
-					echo "Skipping ${de} postinst (running inside container/CI)" >&2
-				else
+				_desktop_in_container 2>/dev/null || \
 					dialog_infobox "Desktop" "Running ${de} post-install configuration..."
-					bash "$desktop_dir/postinst/${de}.sh" || true
-				fi
+				bash "$desktop_dir/postinst/${de}.sh" || true
 			fi
 		;;
 	esac


### PR DESCRIPTION
## Summary
- `module_desktop_branding.sh` was skipping the entire DE postinst script when running inside a container/CI (`_desktop_in_container` guard). The build framework runs inside Docker by default, so on GHA every rootfs build silently dropped postinst — visible as missing wallpaper, missing Armbian favorites in the GNOME dash, missing touchpad defaults, etc., on every freshly-cached image.
- Postinst scripts (`gnome.sh`, `xfce.sh`, `mate.sh`, `budgie.sh`) are almost entirely file writes — `/etc/dconf/db/local.d/00-bg`, `dconf update`, sed-edits to `/etc/skel` XML, `glib-compile-schemas`. All chroot-safe.
- Run postinst unconditionally. Keep `dialog_infobox` gated on "not inside container" so CI doesn't try to render an ncurses dialog.

Real runtime-sensitive operations (DM start, `netplan apply`, `gsettings` against a running dbus) live in `module_desktops.sh` and keep their own `_desktop_in_container` guards — those are correctly gated and unaffected here.

## Test plan
- [ ] Build a GNOME resolute image on a fresh rootfs (invalidate cache or `CLEAN=cache`). Verify `/etc/dconf/db/local.d/00-bg` exists and contains the `picture-uri` lines pointing at `/usr/share/backgrounds/armbian/armbian*.jpg`.
- [ ] Boot the image and confirm the Armbian wallpaper is applied to the desktop on first login.
- [ ] Confirm armbian-imager (where present) shows up in the GNOME favorites bar.
- [ ] Spot-check XFCE / MATE / Budgie images haven't regressed.