### PR TITLE
fix(runners): trixie curl flag, help indexing, and status check

### DIFF
--- a/tools/modules/system/module_armbian_runners.sh
+++ b/tools/modules/system/module_armbian_runners.sh
@@ -68,7 +68,7 @@ function module_armbian_runners () {
 
 			if [[ -z $gh_token ]]; then
 				echo "Error: Github token is mandatory"
-				${module_options["module_armbian_runners,feature"]} ${commands[6]}
+				${module_options["module_armbian_runners,feature"]} ${commands[5]}
 				exit 1
 			fi
 
@@ -296,7 +296,7 @@ function module_armbian_runners () {
 		"${commands[3]}")
 			if [[ -z $gh_token ]]; then
 				echo "Error: Github token is mandatory"
-				${module_options["module_armbian_runners,feature"]} ${commands[6]}
+				${module_options["module_armbian_runners,feature"]} ${commands[5]}
 				exit 1
 			fi
 			for i in $(seq -w $start $stop); do
@@ -304,19 +304,22 @@ function module_armbian_runners () {
 			done
 		;;
 		"${commands[4]}")
-			if [[ $(systemctl list-units --type=service 2>/dev/null | grep actions.runner) -gt 0 ]]; then
+			if [[ $(systemctl list-units --type=service --no-legend 2>/dev/null | grep -c actions.runner) -gt 0 ]]; then
 				return 0
 			else
 				return 1
 			fi
 		;;
-		"${commands[6]}")
+		"${commands[5]}")
 			echo -e "\nUsage: ${module_options["module_armbian_runners,feature"]} <command> [switches]"
-			echo -e "Commands:  install purge"
+			echo -e "Commands:  install remove remove_online purge status help"
 			echo -e "Available commands:\n"
 			echo -e "\tinstall\t\t- Install or reinstall $title."
+			echo -e "\tremove\t\t- Remove a single runner (locally and on GitHub)."
+			echo -e "\tremove_online\t- Remove matching runners on GitHub only."
 			echo -e "\tpurge\t\t- Purge $title."
 			echo -e "\tstatus\t\t- Status of $title."
+			echo -e "\thelp\t\t- Show this help."
 			echo -e "\nAvailable switches:\n"
 			echo -e "\tgh_token\t- token with rights to admin runners."
 			echo -e "\trunner_name\t- name of the runner (series)."
@@ -330,7 +333,7 @@ function module_armbian_runners () {
 			echo ""
 		;;
 		*)
-			${module_options["module_armbian_runners,feature"]} ${commands[6]}
+			${module_options["module_armbian_runners,feature"]} ${commands[5]}
 		;;
 	esac
 }

--- a/tools/modules/system/module_armbian_runners.sh
+++ b/tools/modules/system/module_armbian_runners.sh
@@ -105,7 +105,7 @@ function module_armbian_runners () {
 			trap '{ rm -rf -- "$temp_dir"; }' EXIT
 			[[ "$ARCH" == "x86_64" ]] && local arch=x64 || local arch=arm64
 			local LATEST=$(curl -sL https://api.github.com/repos/actions/runner/tags | jq -r '.[0].zipball_url' | rev | cut -d"/" -f1 | rev | sed "s/v//g")
-			curl --progress-bar --create-dir --output-dir ${temp_dir} -o \
+			curl --progress-bar --create-dirs --output-dir ${temp_dir} -o \
 			actions-runner-linux-${ARCH}-${LATEST}.tar.gz -L \
 			https://github.com/actions/runner/releases/download/v${LATEST}/actions-runner-linux-${arch}-${LATEST}.tar.gz
 


### PR DESCRIPTION
## Summary

Fixes several bugs in `module_armbian_runners` (`tools/modules/system/module_armbian_runners.sh`), including a hard failure seen on Debian trixie.

### Fixes

1. **Invalid curl option (`--create-dir`) breaks install on trixie.** curl has no `--create-dir` flag; the correct long form is `--create-dirs`. Newer curl (trixie, 8.x) rejects the unknown option and aborts the runner tarball download, leaving the install with no tarball to unpack. Older curl builds tolerated it, so this only surfaced on trixie.

2. **Help command index off by one.** The code referenced `commands[6]`, but `help` is index 5 in the example list (`install remove remove_online purge status help`). Index 6 was undefined, so `help` and the missing-token error paths only worked by accident via the `*)` fallthrough. Now dispatches correctly.

3. **Broken `status` check.** `[[ $(systemctl ... | grep actions.runner) -gt 0 ]]` fed matched *lines* (a string) into a numeric `-gt` test, erroring with "integer expression expected". Now counts units with `grep -c ... --no-legend`.

4. **Help text out of sync.** `remove` and `remove_online` were undocumented; the help output and `Commands:` summary now list the full command set.

## Testing

Syntax checked with `bash -n`. Runtime install/remove on trixie to be verified.

Signed-off-by: Igor Pecovnik <igor@armbian.com>