### PR TITLE
Add module_aptcacherng: apt-cacher-ng caching proxy

### DIFF
--- a/tools/include/markdown/APT001-footer.md
+++ b/tools/include/markdown/APT001-footer.md
@@ -1,0 +1,25 @@
+=== "Access to the service"
+
+    The proxy listens on port **3142**:
+
+    - URL: `http://<your.IP>:3142`
+    - Hit-rate report: `http://<your.IP>:3142/acng-report.html`
+
+=== "Client configuration"
+
+    On each apt host on the LAN:
+
+    ```sh
+    echo 'Acquire::http::Proxy "http://<your.IP>:3142";' \
+      | sudo tee /etc/apt/apt.conf.d/00aptproxy
+    ```
+
+=== "Directories"
+
+    - Cache: `/armbian/apt-cacher-ng/cache/`
+
+=== "View logs"
+
+    ```sh
+    docker logs -f apt-cacher-ng
+    ```

--- a/tools/include/markdown/APT001-header.md
+++ b/tools/include/markdown/APT001-header.md
@@ -1,0 +1,8 @@
+**apt-cacher-ng** is a caching HTTP proxy for Debian and Ubuntu apt repositories. The first host on the LAN to fetch a `.deb` populates the cache; every subsequent `apt-get install` / `apt-get dist-upgrade` on any other host serves the same package from local disk — saving WAN bandwidth and turning multi-minute upgrades into seconds.
+
+**Key Features**
+
+- Transparent HTTP proxy in front of `deb.debian.org` / `archive.ubuntu.com` / vendor mirrors
+- Single-port (`3142`), single-container deployment
+- Per-package hit-rate report at `/acng-report.html`
+- Survives container restart — cache lives on a host bind-mount

--- a/tools/json/config.software.json
+++ b/tools/json/config.software.json
@@ -1414,6 +1414,45 @@
                             "help": "NetBox purge with data folder"
                         },
                         {
+                            "id": "APT001",
+                            "description": "apt-cacher-ng caching proxy install",
+                            "short": "apt-cacher-ng",
+                            "module": "module_aptcacherng",
+                            "about": "This operation will install apt-cacher-ng, a caching proxy for Debian/Ubuntu apt repositories",
+                            "command": [
+                                "module_aptcacherng install"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "! module_aptcacherng status",
+                            "container_type": "docker",
+                            "help": "apt-cacher-ng caches .deb files on your LAN so each apt-get install / dist-upgrade across multiple hosts only downloads each package once from the upstream mirror."
+                        },
+                        {
+                            "id": "APT002",
+                            "description": "apt-cacher-ng remove",
+                            "about": "This operation will remove the apt-cacher-ng container",
+                            "command": [
+                                "module_aptcacherng remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_aptcacherng status",
+                            "help": "apt-cacher-ng remove"
+                        },
+                        {
+                            "id": "APT003",
+                            "description": "apt-cacher-ng purge with cache folder",
+                            "about": "This operation will purge apt-cacher-ng cache data and remove the container",
+                            "command": [
+                                "module_aptcacherng purge"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_aptcacherng status",
+                            "help": "apt-cacher-ng purge with cache folder"
+                        },
+                        {
                             "id": "SMB001",
                             "description": "SAMBA Remote File share",
                             "short": "Samba",

--- a/tools/modules/runtime/config.runtime.sh
+++ b/tools/modules/runtime/config.runtime.sh
@@ -155,6 +155,7 @@ update_sub_submenu_data "Software" "Monitoring" "PRO002" "http://$LOCALIPADD:${m
 update_sub_submenu_data "Software" "Management" "CPT002" "https://$LOCALIPADD:${module_options["module_cockpit,port"]}"
 update_sub_submenu_data "Software" "Management" "HPG002" "http://$LOCALIPADD:${module_options["module_homepage,port"]}"
 update_sub_submenu_data "Software" "Management" "NBOX02" "http://$LOCALIPADD:${module_options["module_netbox,port"]}"
+update_sub_submenu_data "Software" "Management" "APT002" "http://$LOCALIPADD:${module_options["module_aptcacherng,port"]}/acng-report.html"
 
 # Downloaders
 update_sub_submenu_data "Software" "Downloaders" "DOW002" "http://$LOCALIPADD:${module_options["module_qbittorrent,port"]%% *}" # removing second port from url

--- a/tools/modules/software/module_aptcacherng.sh
+++ b/tools/modules/software/module_aptcacherng.sh
@@ -1,0 +1,80 @@
+module_options+=(
+	["module_aptcacherng,author"]="@sameersbn"
+	["module_aptcacherng,maintainer"]="@igorpecovnik"
+	["module_aptcacherng,feature"]="module_aptcacherng"
+	["module_aptcacherng,example"]="install remove purge status help"
+	["module_aptcacherng,desc"]="Install apt-cacher-ng container (caching proxy for Debian/Ubuntu apt repos)"
+	["module_aptcacherng,status"]="Active"
+	["module_aptcacherng,doc_link"]="https://www.unix-ag.uni-kl.de/~bloch/acng/"
+	["module_aptcacherng,group"]="Utilities"
+	["module_aptcacherng,port"]="3142"
+	["module_aptcacherng,arch"]="x86-64 arm64"
+	["module_aptcacherng,dockerimage"]="sameersbn/apt-cacher-ng:3.3-20200524"
+	["module_aptcacherng,dockername"]="apt-cacher-ng"
+)
+#
+# Module apt-cacher-ng
+#
+function module_aptcacherng () {
+	local title="apt-cacher-ng"
+	local dockerimage="${module_options["module_aptcacherng,dockerimage"]}"
+	local dockername="${module_options["module_aptcacherng,dockername"]}"
+	local port="${module_options["module_aptcacherng,port"]}"
+
+	local commands
+	IFS=' ' read -r -a commands <<< "${module_options["module_aptcacherng,example"]}"
+
+	local base_dir="${SOFTWARE_FOLDER}/${dockername}"
+
+	case "$1" in
+		"${commands[0]}") # install
+			# Pull image (handles Docker installation and already-installed check)
+			docker_operation_progress pull "$dockerimage"
+
+			# Create base directory for the cache bind-mount
+			docker_manage_base_dir create "$base_dir" || return 1
+
+			docker_operation_progress run "$dockername" \
+				-d \
+				--name="$dockername" \
+				--init \
+				--net=lsio \
+				--restart=always \
+				--publish "${port}:3142" \
+				--volume "${base_dir}/cache:/var/cache/apt-cacher-ng" \
+				"$dockerimage"
+
+			local install_msg="apt-cacher-ng is listening on port ${port}\n\nPoint clients at this server by adding the following line to\n/etc/apt/apt.conf.d/00aptproxy on each consumer host:\n\n  Acquire::http::Proxy \"http://${LOCALIPADD}:${port}\";\n\nStatus page: http://${LOCALIPADD}:${port}/acng-report.html"
+
+			if [[ -t 1 ]]; then
+				dialog_msgbox "apt-cacher-ng installed" "$install_msg" 16 70
+			else
+				echo -e "\n${install_msg}\n"
+			fi
+		;;
+		"${commands[1]}") # remove
+			# Remove container and image (functions handle existence checks)
+			docker_operation_progress rm "$dockername"
+			docker_operation_progress rmi "$dockerimage"
+		;;
+		"${commands[2]}") # purge
+			# Remove container and image first
+			if ! ${module_options["module_aptcacherng,feature"]} ${commands[1]}; then
+				return 1
+			fi
+			# Only remove cache directory if container/image removal succeeded
+			docker_manage_base_dir remove "$base_dir"
+		;;
+		"${commands[3]}") # status
+			# Return 0 if installed, 1 if not (used by menu system)
+			docker_is_installed "$dockername" "$dockerimage"
+		;;
+		"${commands[4]}") # help
+			show_module_help "module_aptcacherng" "$title" \
+				"Caching proxy for Debian / Ubuntu apt repositories.\n\nProxy port: ${port}\nDocker Image: ${dockerimage}\nCache directory: ${base_dir}/cache\nStatus page: http://localhost:${port}/acng-report.html\n\nClient configuration — on each apt host:\n  echo 'Acquire::http::Proxy \"http://<server>:${port}\";' \\\\\n    | sudo tee /etc/apt/apt.conf.d/00aptproxy"
+		;;
+		*)
+			${module_options["module_aptcacherng,feature"]} ${commands[4]}
+		;;
+	esac
+}


### PR DESCRIPTION
## Summary

Adds a single-container module wrapping [`sameersbn/apt-cacher-ng:3.3-20200524`](https://hub.docker.com/r/sameersbn/apt-cacher-ng). Once installed, every `apt-get install` / `apt-get dist-upgrade` on a LAN client only hits the upstream mirror the first time — subsequent fetches of the same `.deb` are served from local disk.

## Files

| File | Purpose |
|------|---------|
| [`tools/modules/software/module_aptcacherng.sh`](tools/modules/software/module_aptcacherng.sh) | Module (install / remove / purge / status / help) — same shape as `module_qbittorrent` / `module_netbox`. Cache lives at `${SOFTWARE_FOLDER}/apt-cacher-ng/cache` so `purge` cleans it up correctly. |
| [`tools/json/config.software.json`](tools/json/config.software.json) | `APT001`/`APT002`/`APT003` triplet under **Software → Management** (next to NetBox), with `container_type: docker`. |
| [`tools/modules/runtime/config.runtime.sh`](tools/modules/runtime/config.runtime.sh) | Runtime URL hook so the Management menu links straight to the `acng-report.html` hit-rate page once installed. |
| [`tools/include/markdown/APT001-header.md`](tools/include/markdown/APT001-header.md) | Per-menu-ID docs header (same convention as `NBOX01` / `FIL001`). |
| [`tools/include/markdown/APT001-footer.md`](tools/include/markdown/APT001-footer.md) | Docs footer with access URL, client `Acquire::http::Proxy` snippet, cache path, log viewing. |

## Underlying docker run equivalent

```bash
docker run --name apt-cacher-ng --init -d --restart=always \
  --publish 3142:3142 \
  --volume ${SOFTWARE_FOLDER}/apt-cacher-ng/cache:/var/cache/apt-cacher-ng \
  sameersbn/apt-cacher-ng:3.3-20200524
```

## Test plan

- [x] `sudo armbian-config` → Software → Management → "apt-cacher-ng caching proxy install" runs to completion
- [x] Container starts: `docker ps --filter name=apt-cacher-ng` shows `Up`
- [x] Status page reachable: `curl -sf http://localhost:3142/acng-report.html`
- [x] Client config (`Acquire::http::Proxy "http://<server>:3142";`) causes `apt-get update` traffic to traverse the proxy (verify with `apt-get -o Debug::Acquire::http=true install <pkg>`)
- [x] Second install of the same package on the same / a different client is visibly faster (cache hit)
- [x] `purge` removes the container, image, and cache directory; `remove` keeps the cache