### PR TITLE
module_aptcacherng: use current ghcr.io/armbian image

### DIFF
--- a/tools/modules/software/module_aptcacherng.sh
+++ b/tools/modules/software/module_aptcacherng.sh
@@ -1,5 +1,5 @@
 module_options+=(
-	["module_aptcacherng,author"]="@sameersbn"
+	["module_aptcacherng,author"]="@igorpecovnik"
 	["module_aptcacherng,maintainer"]="@igorpecovnik"
 	["module_aptcacherng,feature"]="module_aptcacherng"
 	["module_aptcacherng,example"]="install remove purge status help"
@@ -9,7 +9,7 @@ module_options+=(
 	["module_aptcacherng,group"]="Utilities"
 	["module_aptcacherng,port"]="3142"
 	["module_aptcacherng,arch"]="x86-64 arm64"
-	["module_aptcacherng,dockerimage"]="sameersbn/apt-cacher-ng:3.3-20200524"
+	["module_aptcacherng,dockerimage"]="ghcr.io/armbian/apt-cacher-ng:latest"
 	["module_aptcacherng,dockername"]="apt-cacher-ng"
 )
 #


### PR DESCRIPTION
## Summary

Swaps the apt-cacher-ng module off the **abandoned** `sameersbn/apt-cacher-ng:3.3-20200524` image (version 3.3, last updated 2020) onto `ghcr.io/armbian/apt-cacher-ng:latest`, which is built from `debian:trixie-slim` (apt-cacher-ng **3.7.x**) by armbian/docker-armbian-build#28.

## Why

The old image is the root of the reliability problems in the build farm: stale/corrupt `Release`/`Packages` index files (random `apt update` failures), 503s under concurrent runner load, and broken HTTPS repos. apt-cacher-ng 3.7.x has ~4 years of fixes for exactly these, and the new image is tuned for a LAN cache (HTTPS pass-through, no package expiration).

## Notes

- Cache path (`/var/cache/apt-cacher-ng`) and foreground run are unchanged — `install` / `remove` / `purge` / `status` behave exactly as before.
- The proxy model, port `3142`, status page, and client `APT_PROXY_ADDR` wiring are all unchanged. Pure image swap.
- **Depends on** armbian/docker-armbian-build#28 — the `ghcr.io/armbian/apt-cacher-ng` package must be published (and public) before this is usable. Merge/run that first.