### PR TITLE
software: add git_cdn module (GitHub caching git+http proxy)

### DIFF
--- a/tools/json/config.software.json
+++ b/tools/json/config.software.json
@@ -1457,7 +1457,7 @@
                             "description": "git_cdn GitHub caching proxy install",
                             "short": "git_cdn",
                             "module": "module_git_cdn",
-                            "about": "This operation will install git_cdn, a caching git+http proxy that mirrors GitHub near your CI workers (x86-64 only)",
+                            "about": "This operation will install git_cdn, a caching git+http proxy that mirrors GitHub near your CI workers",
                             "command": [
                                 "module_git_cdn install"
                             ],
@@ -1465,7 +1465,7 @@
                             "author": "@igorpecovnik",
                             "condition": "! module_git_cdn status",
                             "container_type": "docker",
-                            "help": "git_cdn is a git+http(s) proxy that mirrors an upstream git server (GitHub) on your LAN, so repeated clones/fetches of the same repo across multiple hosts only pull new objects from upstream once. The upstream Docker image is x86-64 only."
+                            "help": "git_cdn is a git+http(s) proxy that mirrors an upstream git server (GitHub) on your LAN, so repeated clones/fetches of the same repo across multiple hosts only pull new objects from upstream once."
                         },
                         {
                             "id": "GCDN002",

--- a/tools/json/config.software.json
+++ b/tools/json/config.software.json
@@ -1453,6 +1453,45 @@
                             "help": "apt-cacher-ng purge with cache folder"
                         },
                         {
+                            "id": "GCDN001",
+                            "description": "git_cdn GitHub caching proxy install",
+                            "short": "git_cdn",
+                            "module": "module_git_cdn",
+                            "about": "This operation will install git_cdn, a caching git+http proxy that mirrors GitHub near your CI workers (x86-64 only)",
+                            "command": [
+                                "module_git_cdn install"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "! module_git_cdn status",
+                            "container_type": "docker",
+                            "help": "git_cdn is a git+http(s) proxy that mirrors an upstream git server (GitHub) on your LAN, so repeated clones/fetches of the same repo across multiple hosts only pull new objects from upstream once. The upstream Docker image is x86-64 only."
+                        },
+                        {
+                            "id": "GCDN002",
+                            "description": "git_cdn remove",
+                            "about": "This operation will remove the git_cdn container",
+                            "command": [
+                                "module_git_cdn remove"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_git_cdn status",
+                            "help": "git_cdn remove"
+                        },
+                        {
+                            "id": "GCDN003",
+                            "description": "git_cdn purge with cache folder",
+                            "about": "This operation will purge git_cdn cache data and remove the container",
+                            "command": [
+                                "module_git_cdn purge"
+                            ],
+                            "status": "Stable",
+                            "author": "@igorpecovnik",
+                            "condition": "module_git_cdn status",
+                            "help": "git_cdn purge with cache folder"
+                        },
+                        {
                             "id": "SMB001",
                             "description": "SAMBA Remote File share",
                             "short": "Samba",

--- a/tools/modules/software/module_git_cdn.sh
+++ b/tools/modules/software/module_git_cdn.sh
@@ -1,0 +1,86 @@
+module_options+=(
+	["module_git_cdn,author"]="@igorpecovnik"
+	["module_git_cdn,maintainer"]="@igorpecovnik"
+	["module_git_cdn,feature"]="module_git_cdn"
+	["module_git_cdn,example"]="install remove purge status help"
+	["module_git_cdn,desc"]="Install git_cdn container (caching git+http proxy for GitHub clones)"
+	["module_git_cdn,status"]="Active"
+	["module_git_cdn,doc_link"]="https://gitlab.com/grouperenault/git_cdn"
+	["module_git_cdn,group"]="Utilities"
+	["module_git_cdn,port"]="8000"
+	["module_git_cdn,arch"]="x86-64"
+	["module_git_cdn,dockerimage"]="registry.gitlab.com/grouperenault/git_cdn:latest"
+	["module_git_cdn,dockername"]="git_cdn"
+	["module_git_cdn,upstream"]="https://github.com/"
+)
+#
+# Module git_cdn — git+http(s) caching proxy / CDN (Groupe Renault)
+#
+function module_git_cdn () {
+	local title="git_cdn"
+	local dockerimage="${module_options["module_git_cdn,dockerimage"]}"
+	local dockername="${module_options["module_git_cdn,dockername"]}"
+	local port="${module_options["module_git_cdn,port"]}"
+	local upstream="${module_options["module_git_cdn,upstream"]}"
+
+	local commands
+	IFS=' ' read -r -a commands <<< "${module_options["module_git_cdn,example"]}"
+
+	local base_dir="${SOFTWARE_FOLDER}/${dockername}"
+
+	case "$1" in
+		"${commands[0]}") # install
+			# Pull image (handles Docker installation and already-installed check)
+			docker_operation_progress pull "$dockerimage"
+
+			# Create base directory for the cache bind-mount
+			docker_manage_base_dir create "$base_dir" || return 1
+
+			# git_cdn mirrors a single upstream git server (GITSERVER_UPSTREAM)
+			# and caches it under WORKING_DIRECTORY, served over http on :8000.
+			docker_operation_progress run "$dockername" \
+				-d \
+				--name="$dockername" \
+				--init \
+				--net=lsio \
+				--restart=always \
+				--publish "${port}:8000" \
+				--env GITSERVER_UPSTREAM="$upstream" \
+				--env WORKING_DIRECTORY="/git-data" \
+				--volume "${base_dir}/cache:/git-data" \
+				"$dockerimage"
+
+			local install_msg="git_cdn is proxying ${upstream} on port ${port}\n\nPoint git at this server on each consumer host:\n\n  git config --global url.\"http://${LOCALIPADD}:${port}/\".insteadOf ${upstream}\n\nThen clone GitHub repos as usual — fetches are served from the local cache:\n\n  git clone ${upstream}<owner>/<repo>.git"
+
+			if [[ -t 1 ]]; then
+				dialog_msgbox "git_cdn installed" "$install_msg" 16 70
+			else
+				echo -e "\n${install_msg}\n"
+			fi
+		;;
+		"${commands[1]}") # remove
+			# Remove container and image (functions handle existence checks)
+			docker_operation_progress rm "$dockername"
+			docker_operation_progress rmi "$dockerimage"
+		;;
+		"${commands[2]}") # purge
+			# Remove container and image first
+			if ! ${module_options["module_git_cdn,feature"]} ${commands[1]}; then
+				return 1
+			fi
+			# Only remove cache directory if container/image removal succeeded
+			docker_manage_base_dir remove "$base_dir"
+		;;
+		"${commands[3]}") # status
+			# Return 0 if installed, 1 if not (used by menu system)
+			docker_is_installed "$dockername" "$dockerimage"
+		;;
+		"${commands[4]}") # help
+			show_module_help "module_git_cdn" "$title" \
+				"Caching git+http(s) proxy / CDN that mirrors one upstream git server near your CI workers, reducing WAN usage on repeated clones.\n\nUpstream: ${upstream}\nProxy port: ${port}\nDocker Image: ${dockerimage}\nCache directory: ${base_dir}/cache\n\nNote: the upstream image is x86-64 only.\n\nClient configuration — on each git host:\n  git config --global url.\"http://<server>:${port}/\".insteadOf ${upstream}\n\nThen clone normally:\n  git clone ${upstream}<owner>/<repo>.git"
+		;;
+		*)
+			${module_options["module_git_cdn,feature"]} ${commands[4]}
+		;;
+	esac
+}

--- a/tools/modules/software/module_git_cdn.sh
+++ b/tools/modules/software/module_git_cdn.sh
@@ -8,8 +8,8 @@ module_options+=(
 	["module_git_cdn,doc_link"]="https://gitlab.com/grouperenault/git_cdn"
 	["module_git_cdn,group"]="Utilities"
 	["module_git_cdn,port"]="8000"
-	["module_git_cdn,arch"]="x86-64"
-	["module_git_cdn,dockerimage"]="registry.gitlab.com/grouperenault/git_cdn:latest"
+	["module_git_cdn,arch"]="x86-64 arm64"
+	["module_git_cdn,dockerimage"]="ghcr.io/armbian/git_cdn:latest"
 	["module_git_cdn,dockername"]="git_cdn"
 	["module_git_cdn,upstream"]="https://github.com/"
 )
@@ -77,7 +77,7 @@ function module_git_cdn () {
 		;;
 		"${commands[4]}") # help
 			show_module_help "module_git_cdn" "$title" \
-				"Caching git+http(s) proxy / CDN that mirrors one upstream git server near your CI workers, reducing WAN usage on repeated clones.\n\nUpstream: ${upstream}\nProxy port: ${port}\nDocker Image: ${dockerimage}\nCache directory: ${base_dir}/cache\n\nNote: the upstream image is x86-64 only.\n\nClient configuration — on each git host:\n  git config --global url.\"http://<server>:${port}/\".insteadOf ${upstream}\n\nThen clone normally:\n  git clone ${upstream}<owner>/<repo>.git"
+				"Caching git+http(s) proxy / CDN that mirrors one upstream git server near your CI workers, reducing WAN usage on repeated clones.\n\nUpstream: ${upstream}\nProxy port: ${port}\nDocker Image: ${dockerimage}\nCache directory: ${base_dir}/cache\n\nClient configuration — on each git host:\n  git config --global url.\"http://<server>:${port}/\".insteadOf ${upstream}\n\nThen clone normally:\n  git clone ${upstream}<owner>/<repo>.git"
 		;;
 		*)
 			${module_options["module_git_cdn,feature"]} ${commands[4]}

--- a/tools/modules/software/module_git_cdn.sh
+++ b/tools/modules/software/module_git_cdn.sh
@@ -12,6 +12,8 @@ module_options+=(
 	["module_git_cdn,dockerimage"]="ghcr.io/armbian/git_cdn:latest"
 	["module_git_cdn,dockername"]="git_cdn"
 	["module_git_cdn,upstream"]="https://github.com/"
+	["module_git_cdn,cache_size_gb"]="500"
+	["module_git_cdn,workers"]="12"
 )
 #
 # Module git_cdn — git+http(s) caching proxy / CDN (Groupe Renault)
@@ -22,6 +24,8 @@ function module_git_cdn () {
 	local dockername="${module_options["module_git_cdn,dockername"]}"
 	local port="${module_options["module_git_cdn,port"]}"
 	local upstream="${module_options["module_git_cdn,upstream"]}"
+	local cache_size_gb="${module_options["module_git_cdn,cache_size_gb"]}"
+	local workers="${module_options["module_git_cdn,workers"]}"
 
 	local commands
 	IFS=' ' read -r -a commands <<< "${module_options["module_git_cdn,example"]}"
@@ -47,6 +51,10 @@ function module_git_cdn () {
 				--publish "${port}:8000" \
 				--env GITSERVER_UPSTREAM="$upstream" \
 				--env WORKING_DIRECTORY="/git-data" \
+				--env GUNICORN_WORKER="$workers" \
+				--env PACK_CACHE_SIZE_GB="$cache_size_gb" \
+				--env PACK_CACHE_DEPTH="true" \
+				--env CDN_BUNDLE_URL="" \
 				--volume "${base_dir}/cache:/git-data" \
 				"$dockerimage"; then
 				echo -e "\nFailed to start ${dockername} (${dockerimage})\n" >&2
@@ -80,7 +88,7 @@ function module_git_cdn () {
 		;;
 		"${commands[4]}") # help
 			show_module_help "module_git_cdn" "$title" \
-				"Caching git+http(s) proxy / CDN that mirrors one upstream git server near your CI workers, reducing WAN usage on repeated clones.\n\nUpstream: ${upstream}\nProxy port: ${port}\nDocker Image: ${dockerimage}\nCache directory: ${base_dir}/cache\n\nClient configuration — on each git host:\n  git config --global url.\"http://<server>:${port}/\".insteadOf ${upstream}\n\nThen clone normally:\n  git clone ${upstream}<owner>/<repo>.git"
+				"Caching git+http(s) proxy / CDN that mirrors one upstream git server near your CI workers, reducing WAN usage on repeated clones.\n\nUpstream: ${upstream}\nProxy port: ${port}\nDocker Image: ${dockerimage}\nCache directory: ${base_dir}/cache\nPack cache size: ${cache_size_gb} GB\nWorkers: ${workers}\n\nClient configuration — on each git host:\n  git config --global url.\"http://<server>:${port}/\".insteadOf ${upstream}\n\nThen clone normally:\n  git clone ${upstream}<owner>/<repo>.git"
 		;;
 		*)
 			${module_options["module_git_cdn,feature"]} ${commands[4]}

--- a/tools/modules/software/module_git_cdn.sh
+++ b/tools/modules/software/module_git_cdn.sh
@@ -38,7 +38,7 @@ function module_git_cdn () {
 
 			# git_cdn mirrors a single upstream git server (GITSERVER_UPSTREAM)
 			# and caches it under WORKING_DIRECTORY, served over http on :8000.
-			docker_operation_progress run "$dockername" \
+			if ! docker_operation_progress run "$dockername" \
 				-d \
 				--name="$dockername" \
 				--init \
@@ -48,7 +48,10 @@ function module_git_cdn () {
 				--env GITSERVER_UPSTREAM="$upstream" \
 				--env WORKING_DIRECTORY="/git-data" \
 				--volume "${base_dir}/cache:/git-data" \
-				"$dockerimage"
+				"$dockerimage"; then
+				echo -e "\nFailed to start ${dockername} (${dockerimage})\n" >&2
+				return 1
+			fi
 
 			local install_msg="git_cdn is proxying ${upstream} on port ${port}\n\nPoint git at this server on each consumer host:\n\n  git config --global url.\"http://${LOCALIPADD}:${port}/\".insteadOf ${upstream}\n\nThen clone GitHub repos as usual — fetches are served from the local cache:\n\n  git clone ${upstream}<owner>/<repo>.git"
 


### PR DESCRIPTION
## What

Adds **`module_git_cdn`** — a Docker-based caching git+http(s) proxy that mirrors GitHub near CI workers / LAN hosts, so repeated clones and fetches of the same repo only pull new objects from upstream once. ([git_cdn](https://gitlab.com/grouperenault/git_cdn) by Groupe Renault.)

Modeled on the existing `module_aptcacherng`: `install / remove / purge / status / help` via the same `docker_operation_progress` / `docker_manage_base_dir` helpers.

## Details

- **Image:** `ghcr.io/armbian/git_cdn:latest` — multi-arch (amd64 + arm64), built by armbian/docker-armbian-build#29 (upstream only ships an x86-64 image)
- **Port:** 8000
- **Upstream:** `GITSERVER_UPSTREAM=https://github.com/` → acts as a GitHub proxy
- **Cache:** `WORKING_DIRECTORY=/git-data`, bind-mounted from the software folder
- **Arch:** `x86-64 arm64`
- **Client config** (emitted on install):
  ```
  git config --global url."http://<server>:8000/".insteadOf https://github.com/
  ```
  then clone GitHub repos normally — served from the local cache.

### Runtime tuning (every env name/value verified against git_cdn source)

| env | value | why |
|---|---|---|
| `GUNICORN_WORKER` | `12` (option `workers`) | otherwise defaults to host `cpu_count()` |
| `PACK_CACHE_SIZE_GB` | `500` (option `cache_size_gb`) | pack cache budget (default 20) |
| `PACK_CACHE_DEPTH` | `true` | cache shallow clones |
| `CDN_BUNDLE_URL` | `""` | disable the upstream Android/AOSP clone-bundle default — irrelevant for GitHub |

`workers` and `cache_size_gb` are exposed as `module_options` and shown in `help`.

### Robustness

- `install` checks the exit status of `docker_operation_progress run` and aborts with an error instead of printing the success message if the container fails to start.

Registers menu entries `GCDN001`–`GCDN003` in `config.software.json`.

## Dependency

Needs the image from **armbian/docker-armbian-build#29** to be merged and built first, otherwise `install` fails at `docker pull ghcr.io/armbian/git_cdn:latest`.

## Validation

- `bash -n` on the module: OK
- `jq empty` on `config.software.json`: valid, no duplicate menu IDs
- Image validated locally: builds, container boots gunicorn on :8000, git `info/refs` through the proxy returns a live response