### PR TITLE
docs(git_cdn): add GCDN001 help header/footer markdown

### DIFF
--- a/tools/include/markdown/GCDN001-footer.md
+++ b/tools/include/markdown/GCDN001-footer.md
@@ -1,0 +1,30 @@
+=== "Access to the service"
+
+    The proxy listens on port **8000**:
+
+    - URL: `http://<your.IP>:8000`
+
+=== "Client configuration"
+
+    On each git host on the LAN, redirect GitHub through the proxy:
+
+    ```sh
+    git config --global \
+      url."http://<your.IP>:8000/".insteadOf https://github.com/
+    ```
+
+    Then clone normally — fetches are served from the local cache:
+
+    ```sh
+    git clone https://github.com/<owner>/<repo>.git
+    ```
+
+=== "Directories"
+
+    - Cache: `/armbian/git_cdn/cache/`
+
+=== "View logs"
+
+    ```sh
+    docker logs -f git_cdn
+    ```

--- a/tools/include/markdown/GCDN001-header.md
+++ b/tools/include/markdown/GCDN001-header.md
@@ -1,0 +1,8 @@
+**git_cdn** is a caching git+HTTP(s) proxy that mirrors an upstream git server (GitHub) close to your build/CI hosts. The first clone or fetch of a repository populates the cache; every subsequent clone/fetch of the same repo from any host on the LAN pulls only new objects from upstream — saving WAN bandwidth and speeding up repeated GitHub clones.
+
+**Key Features**
+
+- git+http(s) proxy in front of `https://github.com`
+- Single-port (`8000`), single-container deployment
+- Pack-level object cache, configurable size (default 500 GB)
+- Survives container restart — cache lives on a host bind-mount


### PR DESCRIPTION
`module_git_cdn` (id `GCDN001` in config.software.json) had no help header/footer markdown in `tools/include/markdown/`, unlike the sibling apt-cacher-ng module (`APT001`).

Adds:
- `GCDN001-header.md` — overview + key features
- `GCDN001-footer.md` — tabbed access / client configuration / directories / logs

Styled to match the existing `APT001` files.