### PR TITLE
software: tune redis as in-memory LRU cache with RDB-on-shutdown

### DIFF
--- a/tools/include/markdown/REDIS1-header.md
+++ b/tools/include/markdown/REDIS1-header.md
@@ -1,11 +1,11 @@
 Redis is an open-source, in-memory data structure store, used as a database, cache, and message broker.  
-It supports a variety of data structures such as strings, hashes, lists, sets, and sorted sets.
+This module deploys it as an **in-memory LRU cache with RDB persistence** — an RDB snapshot is written on graceful shutdown and reloaded on start, so planned restarts keep the data.
 
 **Key Features:**
 - Extremely fast performance with in-memory storage
-- Persistence options (snapshotting and AOF)
-- Pub/Sub messaging capabilities
-- Built-in replication and high availability
+- RDB snapshot on shutdown (AOF disabled) — survives planned restarts with minimal runtime I/O
+- Bounded memory with `allkeys-lru` eviction (default `maxmemory` 64 GB)
+- Raised open-files limit for many concurrent connections
 - Simple API and wide client support
 
-Redis is widely used for real-time applications, caching layers, session stores, and lightweight queues across industries and platforms.
+Ideal as a caching layer or shared remote cache (for example, a ccache/build cache backend) where data should survive restarts but a hard crash losing the last snapshot is acceptable.

--- a/tools/include/markdown/REDIS1-header.md
+++ b/tools/include/markdown/REDIS1-header.md
@@ -5,6 +5,7 @@ This module deploys it as an **in-memory LRU cache with RDB persistence** — an
 - Extremely fast performance with in-memory storage
 - RDB snapshot on shutdown (AOF disabled) — survives planned restarts with minimal runtime I/O
 - Bounded memory with `allkeys-lru` eviction (default `maxmemory` 64 GB)
+- Throughput-tuned for high concurrency: threaded network I/O, background (lazyfree) eviction, active defragmentation
 - Raised open-files limit for many concurrent connections
 - Simple API and wide client support
 

--- a/tools/modules/software/module_redis.sh
+++ b/tools/modules/software/module_redis.sh
@@ -13,7 +13,9 @@ module_options+=(
 	["module_redis,dockername"]="redis"
 	["module_redis,maxmemory"]="64gb"
 	["module_redis,maxmemory_policy"]="allkeys-lru"
+	["module_redis,maxmemory_samples"]="10"
 	["module_redis,nofile"]="100000"
+	["module_redis,io_threads"]="4"
 	["module_redis,save"]="86400 1"
 	["module_redis,stop_timeout"]="300"
 )
@@ -27,7 +29,9 @@ function module_redis () {
 	local port="${module_options["module_redis,port"]}"
 	local maxmemory="${module_options["module_redis,maxmemory"]}"
 	local maxmemory_policy="${module_options["module_redis,maxmemory_policy"]}"
+	local maxmemory_samples="${module_options["module_redis,maxmemory_samples"]}"
 	local nofile="${module_options["module_redis,nofile"]}"
+	local io_threads="${module_options["module_redis,io_threads"]}"
 	local save="${module_options["module_redis,save"]}"
 	local stop_timeout="${module_options["module_redis,stop_timeout"]}"
 
@@ -54,6 +58,15 @@ function module_redis () {
 			# `docker stop` keeps the data. --stop-timeout raises Docker's 10s
 			# SIGTERM grace period so a large snapshot can finish before SIGKILL.
 			# Eviction keeps memory bounded at maxmemory.
+			#
+			# Throughput tuning for the ccache remote-storage workload (many
+			# runners pushing/pulling large object blobs over a fast link):
+			#   - io-threads (+do-reads): parallelize network read/write, the
+			#     real bottleneck for big payloads over a fat pipe
+			#   - lazyfree-*: evict/free large values on a background thread so
+			#     eviction under allkeys-lru never stalls the event loop
+			#   - maxmemory-samples: more accurate LRU so hot objects survive
+			#   - activedefrag: reclaim fragmentation in a long-running cache
 			docker_operation_progress run "$dockername" \
 				-d \
 				--name="$dockername" \
@@ -67,6 +80,13 @@ function module_redis () {
 				redis-server \
 				--maxmemory "$maxmemory" \
 				--maxmemory-policy "$maxmemory_policy" \
+				--maxmemory-samples "$maxmemory_samples" \
+				--io-threads "$io_threads" \
+				--io-threads-do-reads yes \
+				--lazyfree-lazy-eviction yes \
+				--lazyfree-lazy-expire yes \
+				--lazyfree-lazy-server-del yes \
+				--activedefrag yes \
 				--appendonly no \
 				--save "$save"
 		;;
@@ -89,7 +109,7 @@ function module_redis () {
 		;;
 		"${commands[4]}") # help
 			show_module_help "module_redis" "$title" \
-				"In-memory LRU cache with RDB persistence — an RDB snapshot is written on graceful shutdown and reloaded on start, so planned restarts keep the data (a hard crash may lose writes since the last snapshot).\n\nPort: ${port}\nDocker Image: ${dockerimage}\nMax memory: ${maxmemory}\nEviction policy: ${maxmemory_policy}\nOpen files limit: ${nofile}\nSave points: ${save}\nStop timeout: ${stop_timeout}s\nData directory: ${base_dir}/data"
+				"In-memory LRU cache with RDB persistence — an RDB snapshot is written on graceful shutdown and reloaded on start, so planned restarts keep the data (a hard crash may lose writes since the last snapshot). Tuned for the ccache remote-storage workload: threaded network I/O, background (lazyfree) eviction and active defragmentation.\n\nPort: ${port}\nDocker Image: ${dockerimage}\nMax memory: ${maxmemory}\nEviction policy: ${maxmemory_policy} (samples ${maxmemory_samples})\nIO threads: ${io_threads}\nOpen files limit: ${nofile}\nSave points: ${save}\nStop timeout: ${stop_timeout}s\nData directory: ${base_dir}/data"
 		;;
 		*)
 			${module_options["module_redis,feature"]} ${commands[4]}

--- a/tools/modules/software/module_redis.sh
+++ b/tools/modules/software/module_redis.sh
@@ -3,14 +3,19 @@ module_options+=(
 	["module_redis,maintainer"]="@igorpecovnik"
 	["module_redis,feature"]="module_redis"
 	["module_redis,example"]="install remove purge status help"
-	["module_redis,desc"]="Install Redis in a container (In-Memory Data Store)"
+	["module_redis,desc"]="Install Redis in a container (in-memory LRU cache)"
 	["module_redis,status"]="Active"
 	["module_redis,doc_link"]="https://redis.io/docs/"
 	["module_redis,group"]="Database"
 	["module_redis,port"]="6379"
 	["module_redis,arch"]="x86-64 arm64"
-	["module_redis,dockerimage"]="redis:alpine"
+	["module_redis,dockerimage"]="redis:latest"
 	["module_redis,dockername"]="redis"
+	["module_redis,maxmemory"]="64gb"
+	["module_redis,maxmemory_policy"]="allkeys-lru"
+	["module_redis,nofile"]="100000"
+	["module_redis,save"]="86400 1"
+	["module_redis,stop_timeout"]="300"
 )
 #
 # Module Redis
@@ -20,10 +25,18 @@ function module_redis () {
 	local dockerimage="${module_options["module_redis,dockerimage"]}"
 	local dockername="${module_options["module_redis,dockername"]}"
 	local port="${module_options["module_redis,port"]}"
+	local maxmemory="${module_options["module_redis,maxmemory"]}"
+	local maxmemory_policy="${module_options["module_redis,maxmemory_policy"]}"
+	local nofile="${module_options["module_redis,nofile"]}"
+	local save="${module_options["module_redis,save"]}"
+	local stop_timeout="${module_options["module_redis,stop_timeout"]}"
 
 	local commands
 	IFS=' ' read -r -a commands <<< "${module_options["module_redis,example"]}"
 
+	# RDB snapshot is written to /data inside the container (the official
+	# image's working dir), persisted to the host through this bind-mount so
+	# the cache survives restarts.
 	local base_dir="${SOFTWARE_FOLDER}/redis"
 
 	case "$1" in
@@ -31,17 +44,31 @@ function module_redis () {
 			# Pull image (handles Docker installation and already-installed check)
 			docker_operation_progress pull "$dockerimage"
 
-			# Create base directory
+			# Create base directory for the RDB bind-mount
 			docker_manage_base_dir create "$base_dir" || return 1
 
+			# Run as an in-memory LRU cache with RDB persistence: AOF stays off
+			# to avoid continuous disk I/O, while a single infrequent save point
+			# (module_redis,save) keeps runtime snapshotting minimal. Redis also
+			# writes an RDB snapshot on graceful shutdown, so a planned restart /
+			# `docker stop` keeps the data. --stop-timeout raises Docker's 10s
+			# SIGTERM grace period so a large snapshot can finish before SIGKILL.
+			# Eviction keeps memory bounded at maxmemory.
 			docker_operation_progress run "$dockername" \
 				-d \
 				--name="$dockername" \
 				--net=lsio \
 				--restart=always \
 				-p "${port}:6379" \
+				--ulimit "nofile=${nofile}:${nofile}" \
+				--stop-timeout "$stop_timeout" \
 				-v "${base_dir}/data:/data" \
-				"$dockerimage"
+				"$dockerimage" \
+				redis-server \
+				--maxmemory "$maxmemory" \
+				--maxmemory-policy "$maxmemory_policy" \
+				--appendonly no \
+				--save "$save"
 		;;
 		"${commands[1]}") # remove
 			# Remove container and image (functions handle existence checks)
@@ -62,7 +89,7 @@ function module_redis () {
 		;;
 		"${commands[4]}") # help
 			show_module_help "module_redis" "$title" \
-				"Port: ${port}\nDocker Image: $dockerimage"
+				"In-memory LRU cache with RDB persistence — an RDB snapshot is written on graceful shutdown and reloaded on start, so planned restarts keep the data (a hard crash may lose writes since the last snapshot).\n\nPort: ${port}\nDocker Image: ${dockerimage}\nMax memory: ${maxmemory}\nEviction policy: ${maxmemory_policy}\nOpen files limit: ${nofile}\nSave points: ${save}\nStop timeout: ${stop_timeout}s\nData directory: ${base_dir}/data"
 		;;
 		*)
 			${module_options["module_redis,feature"]} ${commands[4]}


### PR DESCRIPTION
Reconfigures `module_redis` for use as the **ccache remote-storage backend** (`CCACHE_REMOTE_STORAGE`): many build runners moving large object blobs over a fast link, with `allkeys-lru` evicting old objects.

### Base config
```
docker run -d --name redis --net=lsio --restart=always \
  -p 6379:6379 --ulimit nofile=100000:100000 \
  --stop-timeout 300 -v /armbian/redis/data:/data \
  redis:latest redis-server \
    --maxmemory 64gb --maxmemory-policy allkeys-lru --maxmemory-samples 10 \
    --io-threads 4 --io-threads-do-reads yes \
    --lazyfree-lazy-eviction yes --lazyfree-lazy-expire yes --lazyfree-lazy-server-del yes \
    --activedefrag yes \
    --appendonly no --save "86400 1"
```

### Cache behavior
- Image `redis:alpine` → `redis:latest`; `maxmemory 64gb` + `allkeys-lru` (bounded, leaves headroom for RDB-fork COW and OS page cache on a 128 GB host)
- Persistence: AOF off, RDB via an infrequent save point (`86400 1`) → snapshot on graceful shutdown, reloaded on start; `/data` volume; `--stop-timeout 300` so a large snapshot finishes before SIGKILL

### Throughput tuning (ccache workload)
- `io-threads 4` + `io-threads-do-reads` — parallelize network read/write (the bottleneck for big blobs over a fat pipe; reads matter since cache hits pull objects)
- `lazyfree-lazy-{eviction,expire,server-del}` — free large evicted values on a background thread so the event loop never stalls when full
- `maxmemory-samples 10` — more accurate LRU
- `activedefrag yes` — reclaim fragmentation in a long-running cache

Tunables (`maxmemory`, `io_threads`, `maxmemory_samples`, `save`, `stop_timeout`, `nofile`) are exposed as `module_options`. Kept `--net=lsio`, `-p 6379:6379`, `--restart=always` as-is.

**Note:** `--stop-timeout` covers `docker stop`; a host **reboot** instead uses the Docker service's systemd `TimeoutStopSec`.