### PR TITLE
runner-cleanup: chown workspace after each job via JOB_COMPLETED hook

### DIFF
--- a/tools/modules/system/module_armbian_runners.sh
+++ b/tools/modules/system/module_armbian_runners.sh
@@ -198,6 +198,12 @@ function module_armbian_runners () {
 				# svc.sh step above and drops in ExecStartPre/StopPost
 				# wired to /usr/local/sbin/runner-clean-pages.
 				install -m 0755 "${cleanup_src}/runner-clean-pages"     /usr/local/sbin/runner-clean-pages
+				# Per-job workspace chown. Docker builds leave root-owned
+				# files under _work that break the next job's checkout
+				# cleanup. The runner runs this after every job via
+				# ACTIONS_RUNNER_HOOK_JOB_COMPLETED (wired into each
+				# runner's .env below).
+				install -m 0755 "${cleanup_src}/runner-job-completed"   /usr/local/sbin/runner-job-completed
 				systemctl daemon-reload
 				# Don't silence errors here — a failed timer install
 				# means the cleanup never fires and the host quietly
@@ -220,6 +226,27 @@ function module_armbian_runners () {
 				if ! bash "${cleanup_src}/install-runner-hooks"; then
 					echo "Warning: install-runner-hooks failed; runner-clean-pages systemd hooks not in place" >&2
 				fi
+
+				# Wire the post-job chown hook into every runner's .env. The
+				# runner loads ACTIONS_RUNNER_HOOK_JOB_COMPLETED from .env at
+				# service start and runs it (as the runner user, which has
+				# passwordless sudo) after each job. Idempotent; covers
+				# already-installed runners too. Takes effect on each runner's
+				# next (re)start, so we don't force-restart busy ones here.
+				local job_hook_path="/usr/local/sbin/runner-job-completed"
+				local runner_home runner_owner env_file
+				for runner_home in /home/actions-runner-*; do
+					[[ -d "$runner_home" ]] || continue
+					runner_owner="$(stat -c '%U' "$runner_home")"
+					env_file="${runner_home}/.env"
+					touch "$env_file"
+					if grep -q '^ACTIONS_RUNNER_HOOK_JOB_COMPLETED=' "$env_file"; then
+						sed -i "s#^ACTIONS_RUNNER_HOOK_JOB_COMPLETED=.*#ACTIONS_RUNNER_HOOK_JOB_COMPLETED=${job_hook_path}#" "$env_file"
+					else
+						echo "ACTIONS_RUNNER_HOOK_JOB_COMPLETED=${job_hook_path}" >> "$env_file"
+					fi
+					chown "${runner_owner}:${runner_owner}" "$env_file"
+				done
 			else
 				echo "Warning: runner-cleanup assets not found in source tree next to module or at /usr/share/armbian-config/runner-cleanup; skipping maintenance helper install" >&2
 			fi

--- a/tools/modules/system/runner-cleanup/runner-job-completed
+++ b/tools/modules/system/runner-cleanup/runner-job-completed
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# runner-job-completed — GitHub Actions ACTIONS_RUNNER_HOOK_JOB_COMPLETED hook.
+#
+# Armbian builds run inside Docker as root and bind-mount the runner's
+# workspace, so they leave files under _work owned by root (cache/sources,
+# cache/aptcache, rootfs, …). The *next* job's actions/checkout runs as the
+# runner user (no sudo) and then fails to clean the workspace with:
+#   EACCES: permission denied, rmdir '.../cache/aptcache/lists'
+#
+# The GitHub runner process runs continuously and does NOT restart between
+# jobs, so systemd start/stop hooks can't fire per-job — but the runner DOES
+# invoke ACTIONS_RUNNER_HOOK_JOB_COMPLETED after every job, as the runner
+# user. We use that to hand ownership of the root-owned leftovers back to the
+# runner user, so the next checkout can clean them.
+#
+# Wired per runner via ACTIONS_RUNNER_HOOK_JOB_COMPLETED in each runner's
+# .env (see module_armbian_runners). Runs as the runner user, which has
+# passwordless sudo — required because only root can chown root-owned files.
+#
+# Selective by design: chown only files NOT already owned by the runner user
+# or group, so we touch just the handful of root-owned paths instead of a
+# full recursive chown of a multi-GB workspace after every job.
+
+set -u
+
+me_u="$(id -un)"
+me_g="$(id -gn)"
+
+# Work-folder root to fix. Prefer the parent of this job's workspace
+# (RUNNER_WORKSPACE is .../_work/<repo>), fall back to ~/_work.
+work_root=""
+if [[ -n "${RUNNER_WORKSPACE:-}" ]]; then
+	work_root="$(dirname "${RUNNER_WORKSPACE}")"
+fi
+[[ -d "${work_root}" ]] || work_root="${HOME}/_work"
+[[ -d "${work_root}" ]] || exit 0
+
+# Only chown what isn't already ours. Non-fatal: a hook that exits non-zero
+# is just logged by the runner, and the job has already finished anyway.
+sudo find "${work_root}" \( ! -user "${me_u}" -o ! -group "${me_g}" \) \
+	-exec chown "${me_u}:${me_g}" {} + 2> /dev/null || true
+
+exit 0


### PR DESCRIPTION
## Problem

Armbian builds run in Docker **as root** and bind-mount the runner's workspace, so they leave files under `_work` owned by root (`cache/sources`, `cache/aptcache`, rootfs, …). The **next** job's `actions/checkout` runs as the runner user (no sudo) and dies cleaning the workspace:

```
EACCES: permission denied, rmdir '.../cache/aptcache/lists'
```

## Why a job hook (and not systemd)

The GitHub runner process runs **continuously** and does **not** restart between jobs — jobs come and go inside one long-lived process. So the existing systemd `ExecStartPre`/`ExecStopPost` hooks can't fire per-job. GitHub's **`ACTIONS_RUNNER_HOOK_JOB_COMPLETED`** does: the runner invokes it after every job, as the runner user (which has passwordless sudo).

## Change

- **`runner-job-completed`** — new hook script. Selectively chowns the runner's `_work` tree back to the runner user (`find ( ! -user .. -o ! -group .. ) -exec chown +`), touching only the root-owned leftovers, not the whole multi-GB tree. Targets `dirname $RUNNER_WORKSPACE` (the `_work` root), falls back to `~/_work`. Non-fatal (`exit 0`).
- **`module_armbian_runners`** — installs it to `/usr/local/sbin/runner-job-completed` and writes `ACTIONS_RUNNER_HOOK_JOB_COMPLETED=...` into every `/home/actions-runner-*/.env`, idempotently (covers already-installed runners). Takes effect on each runner's next (re)start, so busy runners aren't force-restarted.

Tested: module parses, hook parses, `.env` wiring verified idempotent (single line, replace-not-append).

## Relationship to the other PRs
- Complements **armbian/actions#23** (start-of-job selective chown). This one runs at *job completion*, is **workspace-agnostic** (covers any job on the runner, not only workflows that use the `runner-clean` action), and cleans up right after the build that made the mess.
- Independent of **configng#943** (keep build images) — different files.

## Operational note
Existing runners pick up the new `.env` var only after a restart. New installs start fresh and get it immediately.