### PR TITLE
desktops: add libspa-0.2-bluetooth for OOB Bluetooth headphone audio

### DIFF
--- a/tools/modules/desktops/yaml/common.yaml
+++ b/tools/modules/desktops/yaml/common.yaml
@@ -66,6 +66,13 @@ tiers:
       # Architecture: all package, ~1 MB on disk, inert on simpler audio
       # chains (HDMI-only SBCs, USB DAC, etc.), so safe at minimal tier.
       - alsa-ucm-conf
+      # PipeWire Bluetooth SPA plugin. PipeWire pulls in the core media
+      # session, but A2DP/HSP/HFP audio routing to Bluetooth headsets
+      # lives in this separate SPA plugin. Without it PipeWire enumerates
+      # the paired BT device but Sound settings offer no audio profile,
+      # so headphones pair yet play nothing. Small plugin, inert when no
+      # BT adapter is present, so safe out-of-the-box at minimal tier.
+      - libspa-0.2-bluetooth
 
   mid:
     packages:


### PR DESCRIPTION
## Problem

On a fresh desktop install, Bluetooth headphones pair but play no audio. PipeWire enumerates the paired device, but Sound settings offer no audio profile.

## Cause

PipeWire pulls in the core media session, but A2DP/HSP/HFP routing to Bluetooth headsets lives in the separate `libspa-0.2-bluetooth` SPA plugin, which was not installed.

## Fix

Add `libspa-0.2-bluetooth` to the `minimal` tier in `common.yaml`, next to the existing audio packages (`alsa-ucm-conf`). It is a small plugin and inert when no BT adapter is present, so it is safe out-of-the-box at the base tier every desktop install gets.

Package is present on Debian bookworm/trixie/forky/sid and Ubuntu jammy/noble/resolute.