### PR TITLE
kde-neon: switch to resolute base, then disable (broken)

### DIFF
--- a/tests/KDEN01.conf
+++ b/tests/KDEN01.conf
@@ -1,4 +1,7 @@
-ENABLED=true
+# Disabled: KDE Neon is broken on the resolute base (neon's testing
+# archive does not publish against Ubuntu 26.04). Re-enable once the
+# neon repo carries resolute packages.
+ENABLED=false
 RELEASE="resolute"
 TESTARCH="arm64,amd64"
 TESTNAME="KDE Neon desktop"

--- a/tests/KDEN01.conf
+++ b/tests/KDEN01.conf
@@ -1,5 +1,5 @@
 ENABLED=true
-RELEASE="noble"
+RELEASE="resolute"
 TESTARCH="arm64,amd64"
 TESTNAME="KDE Neon desktop"
 

--- a/tools/modules/desktops/yaml/kde-neon.yaml
+++ b/tools/modules/desktops/yaml/kde-neon.yaml
@@ -1,7 +1,7 @@
 name: kde-neon
 description: "KDE Neon - latest Plasma from KDE repos (Ubuntu only)"
 display_manager: sddm
-status: supported
+status: unsupported
 repo:
   url: "http://archive.neon.kde.org/testing"
   key_url: "https://archive.neon.kde.org/public.key"

--- a/tools/modules/desktops/yaml/kde-neon.yaml
+++ b/tools/modules/desktops/yaml/kde-neon.yaml
@@ -37,7 +37,10 @@ tiers:
       - gnome-software
       - thunderbird
 
-releases:
-  resolute:
-    architectures: [arm64, amd64]
+# Disabled: KDE Neon is broken on resolute (neon's testing archive does
+# not publish against Ubuntu 26.04) and noble is no longer the base. With
+# no release declared the desktop is never "available", so it is not
+# offered in the menu. Restore a release entry (and status: supported)
+# once the neon repo carries a working base.
+releases: {}
 

--- a/tools/modules/desktops/yaml/kde-neon.yaml
+++ b/tools/modules/desktops/yaml/kde-neon.yaml
@@ -38,6 +38,6 @@ tiers:
       - thunderbird
 
 releases:
-  noble:
+  resolute:
     architectures: [arm64, amd64]
 


### PR DESCRIPTION
## What

KDE Neon was moved off Ubuntu 24.04 (noble) onto 26.04 LTS (resolute), but it does not work on that base — neon's testing archive (`archive.neon.kde.org/testing`) does not publish against resolute. So the desktop is disabled until upstream catches up.

## Changes

- `tools/modules/desktops/yaml/kde-neon.yaml`
  - release `noble:` → `resolute:`
  - `status: supported` → `status: unsupported`
- `tests/KDEN01.conf`
  - `RELEASE` `noble` → `resolute`
  - `ENABLED=true` → `ENABLED=false` (matches the deepin/budgie disabled-test convention), with a comment explaining why

## Re-enabling

Flip `ENABLED` back to true and restore `status: supported` once the neon repo carries resolute/26.04 packages.