### PR TITLE
armbian-install: redesign as a tested armbian-config module

### DIFF
--- a/.github/workflows/maintenance-bats.yml
+++ b/.github/workflows/maintenance-bats.yml
@@ -18,10 +18,14 @@ jobs:
     name: "Installer engine bats"
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'Armbian' }}
+    permissions:
+      contents: read
     steps:
 
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install bats and helpers
         run: sudo apt-get update -qq && sudo apt-get install -y -qq bats jq parted dosfstools ntfs-3g

--- a/.github/workflows/maintenance-bats.yml
+++ b/.github/workflows/maintenance-bats.yml
@@ -27,7 +27,7 @@ jobs:
         run: sudo apt-get update -qq && sudo apt-get install -y -qq bats jq parted dosfstools ntfs-3g
 
       - name: Unit tests (pure functions, no privileges)
-        run: bats tests/bats/plan.bats tests/bats/detect.bats tests/bats/bootconfig.bats tests/bats/dualboot.bats
+        run: bats tests/bats/plan.bats tests/bats/detect.bats tests/bats/bootconfig.bats tests/bats/dualboot.bats tests/bats/transfer.bats
 
       - name: Integration tests (loopback block device + Windows dual-boot, needs root)
         run: sudo bats tests/bats/integration_loopback.bats tests/bats/integration_dualboot.bats

--- a/.github/workflows/maintenance-bats.yml
+++ b/.github/workflows/maintenance-bats.yml
@@ -24,10 +24,10 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install bats and helpers
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq bats jq parted dosfstools
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq bats jq parted dosfstools ntfs-3g
 
       - name: Unit tests (pure functions, no privileges)
-        run: bats tests/bats/plan.bats tests/bats/detect.bats tests/bats/bootconfig.bats
+        run: bats tests/bats/plan.bats tests/bats/detect.bats tests/bats/bootconfig.bats tests/bats/dualboot.bats
 
-      - name: Integration tests (loopback block device, needs root)
-        run: sudo bats tests/bats/integration_loopback.bats
+      - name: Integration tests (loopback block device + Windows dual-boot, needs root)
+        run: sudo bats tests/bats/integration_loopback.bats tests/bats/integration_dualboot.bats

--- a/.github/workflows/maintenance-bats.yml
+++ b/.github/workflows/maintenance-bats.yml
@@ -27,7 +27,7 @@ jobs:
         run: sudo apt-get update -qq && sudo apt-get install -y -qq bats jq parted dosfstools ntfs-3g
 
       - name: Unit tests (pure functions, no privileges)
-        run: bats tests/bats/plan.bats tests/bats/detect.bats tests/bats/bootconfig.bats tests/bats/dualboot.bats tests/bats/transfer.bats
+        run: bats tests/bats/plan.bats tests/bats/detect.bats tests/bats/detect_windows.bats tests/bats/bootconfig.bats tests/bats/dualboot.bats tests/bats/transfer.bats
 
       - name: Integration tests (loopback block device + Windows dual-boot, needs root)
         run: sudo bats tests/bats/integration_loopback.bats tests/bats/integration_dualboot.bats

--- a/.github/workflows/maintenance-bats.yml
+++ b/.github/workflows/maintenance-bats.yml
@@ -1,0 +1,33 @@
+name: "Maintenance: Bats unit tests"
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'tools/modules/**'
+      - 'tests/bats/**'
+      - '.github/workflows/maintenance-bats.yml'
+
+concurrency:
+  group: bats-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  bats:
+    name: "Installer engine bats"
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'Armbian' }}
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Install bats and helpers
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq bats jq parted dosfstools
+
+      - name: Unit tests (pure functions, no privileges)
+        run: bats tests/bats/plan.bats tests/bats/detect.bats tests/bats/bootconfig.bats
+
+      - name: Integration tests (loopback block device, needs root)
+        run: sudo bats tests/bats/integration_loopback.bats

--- a/.github/workflows/maintenance-build-debian.yml
+++ b/.github/workflows/maintenance-build-debian.yml
@@ -22,7 +22,7 @@ jobs:
       section: "default"
       priority: "optional"
       compile: "tools/config-assemble.sh -p"
-      depends: "bash, jq, whiptail, sudo, procps, systemd, lsb-release, iproute2, debconf, libtext-iconv-perl, gpg, xz-utils, pv, python3-yaml, expect-dev"
+      depends: "bash, jq, whiptail, sudo, procps, systemd, lsb-release, iproute2, debconf, libtext-iconv-perl, gpg, xz-utils, pv, python3-yaml, expect-dev, rsync, parted, dosfstools, e2fsprogs, btrfs-progs, f2fs-tools, ntfs-3g"
       description: "Armbian config: The Next Generation"
 
     secrets:

--- a/tests/bats/bootconfig.bats
+++ b/tests/bats/bootconfig.bats
@@ -98,6 +98,20 @@ setup() {
 	[ "$status" -eq 0 ]
 }
 
+@test "verify boot dir: uEnv.txt counts as a boot script (k3/BeaglePlay)" {
+	d="$TMP/boot"; mkdir -p "$d"
+	: >"$d/Image"; : >"$d/uEnv.txt"
+	run install_verify_boot_dir "$d"
+	[ "$status" -eq 0 ]
+}
+
+@test "verify boot dir: boot.ini counts as a boot script (amlogic/odroid)" {
+	d="$TMP/boot"; mkdir -p "$d"
+	: >"$d/Image"; : >"$d/boot.ini"
+	run install_verify_boot_dir "$d"
+	[ "$status" -eq 0 ]
+}
+
 # --- populate /boot (synced separately from the main rootfs rsync) -----------
 
 @test "populate_boot: copies the kernel into the target /boot and verifies" {

--- a/tests/bats/bootconfig.bats
+++ b/tests/bats/bootconfig.bats
@@ -130,6 +130,19 @@ setup() {
 	unset -f write_uboot_platform
 }
 
+@test "fs tools: ext4 always available; missing fs reports its package" {
+	# ext4 tools are part of the base system.
+	run install_check_fs_tools ext4
+	[ "$status" -eq 0 ]
+	# For a filesystem whose tool is absent, the package name is reported so the
+	# pre-flight can refuse before wiping (the mkfs.f2fs-missing scenario).
+	if ! command -v mkfs.f2fs >/dev/null 2>&1; then
+		run install_check_fs_tools f2fs
+		[ "$status" -ne 0 ]
+		[ "$output" = "f2fs-tools" ]
+	fi
+}
+
 @test "bootloader available: grub modes depend on grub-install presence" {
 	if command -v grub-install >/dev/null 2>&1; then
 		run install_bootloader_available bios; [ "$status" -eq 0 ]

--- a/tests/bats/bootconfig.bats
+++ b/tests/bats/bootconfig.bats
@@ -203,3 +203,27 @@ setup() {
 		run install_bootloader_available bios; [ "$status" -ne 0 ]
 	fi
 }
+
+# --- sd mode: map current /boot into the target (mount + bind) ---------------
+
+@test "map current boot: dedicated /boot partition mounts straight at /boot" {
+	findmnt() { case "$3" in /boot) case "$2" in SOURCE) echo /dev/mmcblk1p1 ;; FSTYPE) echo vfat ;; esac ;; esac; }
+	install_uuid() { echo "UUID=bootpart"; }
+	f="$TMP/fstab"; : >"$f"; mp="$TMP/target"; mkdir -p "$mp"
+	run install_map_current_boot "$f" "$mp"
+	[ "$status" -eq 0 ]
+	grep -qE '^UUID=bootpart	/boot	vfat	defaults,nofail' "$f"
+	# straight mount, no bind indirection
+	! grep -q 'boot-media' "$f"
+}
+
+@test "map current boot: /boot dir on root partition uses mount + bind" {
+	findmnt() { case "$3" in /boot) return 1 ;; /) case "$2" in SOURCE) echo /dev/mmcblk1p1 ;; FSTYPE) echo ext4 ;; esac ;; esac; }
+	install_uuid() { echo "UUID=rootpart"; }
+	f="$TMP/fstab"; : >"$f"; mp="$TMP/target"; mkdir -p "$mp"
+	run install_map_current_boot "$f" "$mp"
+	[ "$status" -eq 0 ]
+	grep -qE '^UUID=rootpart	/media/boot-media	ext4	defaults,nofail' "$f"
+	grep -qE '^/media/boot-media/boot	/boot	none	bind,nofail' "$f"
+	[ -d "$mp/media/boot-media" ]
+}

--- a/tests/bats/bootconfig.bats
+++ b/tests/bats/bootconfig.bats
@@ -88,6 +88,29 @@ setup() {
 	[ "$status" -eq 0 ]
 }
 
+# --- populate /boot (synced separately from the main rootfs rsync) -----------
+
+@test "populate_boot: copies the kernel into the target /boot and verifies" {
+	src="$TMP/srcboot"; mkdir -p "$src"; : >"$src/vmlinuz-test"; : >"$src/boot.scr"
+	rootfs="$TMP/rootfs"; mkdir -p "$rootfs"
+	run install_populate_boot "$rootfs" 1 "$src"
+	[ "$status" -eq 0 ]
+	[ -f "$rootfs/boot/vmlinuz-test" ]
+	# The populated /boot must pass the bootable check (regression for the empty
+	# /boot that produced verify code 73 on the x86 BIOS install).
+	run install_verify_boot_dir "$rootfs/boot"
+	[ "$status" -eq 0 ]
+}
+
+@test "populate_boot: copy=0 leaves /boot empty (sd mode, boot on removable)" {
+	src="$TMP/srcboot"; mkdir -p "$src"; : >"$src/vmlinuz-test"
+	rootfs="$TMP/rootfs"; mkdir -p "$rootfs"
+	run install_populate_boot "$rootfs" 0 "$src"
+	[ "$status" -eq 0 ]
+	[ -d "$rootfs/boot" ]
+	[ ! -f "$rootfs/boot/vmlinuz-test" ]
+}
+
 # --- bootloader capability pre-flight ----------------------------------------
 
 @test "bootloader available: u-boot modes need write_uboot_platform (x86 has none)" {

--- a/tests/bats/bootconfig.bats
+++ b/tests/bats/bootconfig.bats
@@ -143,6 +143,13 @@ setup() {
 	fi
 }
 
+@test "fs kernel support: ext4 always supported; a bogus fs is not" {
+	run install_fs_kernel_supported ext4
+	[ "$status" -eq 0 ]
+	run install_fs_kernel_supported notafs_zzz
+	[ "$status" -ne 0 ]
+}
+
 @test "bootloader available: grub modes depend on grub-install presence" {
 	if command -v grub-install >/dev/null 2>&1; then
 		run install_bootloader_available bios; [ "$status" -eq 0 ]

--- a/tests/bats/bootconfig.bats
+++ b/tests/bats/bootconfig.bats
@@ -40,6 +40,7 @@ setup() {
 
 @test "fstab: no swap UUID emits no swap entry" {
 	run install_gen_fstab "UUID=root1" ext4
+	[ "$status" -eq 0 ]
 	[[ "$output" != *"	swap	"* ]]
 }
 
@@ -186,6 +187,17 @@ setup() {
 	run install_update_initramfs "$rootfs" ext4
 	[ "$status" -eq 0 ]
 	[ ! -s "$rootfs/etc/initramfs-tools/modules" ]   # ext4 added nothing
+}
+
+@test "update_initramfs: a module fs (f2fs) is added to the module list" {
+	rootfs="$TMP/rootfs-mod"; mkdir -p "$rootfs/etc/initramfs-tools" "$rootfs/usr/sbin"
+	: >"$rootfs/etc/initramfs-tools/modules"
+	printf '#!/bin/sh\nexit 0\n' >"$rootfs/usr/sbin/update-initramfs"; chmod +x "$rootfs/usr/sbin/update-initramfs"
+	# f2fs is a module root fs: it must be added to the initramfs module list.
+	# That add happens before the chroot step, which may fail unprivileged on
+	# the mount --bind, so assert on the module list rather than the exit status.
+	install_update_initramfs "$rootfs" f2fs || true
+	grep -qxF f2fs "$rootfs/etc/initramfs-tools/modules"
 }
 
 @test "fs kernel support: ext4 always supported; a bogus fs is not" {

--- a/tests/bats/bootconfig.bats
+++ b/tests/bats/bootconfig.bats
@@ -23,6 +23,7 @@ setup() {
 
 @test "fstab: separate boot + ESP produce /boot and /boot/efi lines" {
 	run install_gen_fstab "UUID=root1" btrfs "UUID=boot1" ext4 "UUID=efi1"
+	[ "$status" -eq 0 ]
 	[[ "$output" == *"UUID=root1	/	btrfs"* ]]
 	[[ "$output" == *"UUID=boot1	/boot	ext4"* ]]
 	[[ "$output" == *"UUID=efi1	/boot/efi	vfat"* ]]
@@ -30,6 +31,7 @@ setup() {
 
 @test "fstab: btrfs root carries subvol=@ option" {
 	run install_gen_fstab "UUID=root1" btrfs
+	[ "$status" -eq 0 ]
 	[[ "$output" == *"subvol=@"* ]]
 }
 
@@ -61,6 +63,7 @@ setup() {
 	f="$TMP/armbianEnv.txt"
 	printf 'verbosity=1\n' >"$f"
 	run install_rewrite_bootenv "$f" "UUID=new" ext4
+	[ "$status" -eq 0 ]
 	grep -q '^rootdev=UUID=new$' "$f"
 	grep -q '^rootfstype=ext4$' "$f"
 }

--- a/tests/bats/bootconfig.bats
+++ b/tests/bats/bootconfig.bats
@@ -33,6 +33,16 @@ setup() {
 	[[ "$output" == *"subvol=@"* ]]
 }
 
+@test "fstab: a swap partition UUID produces a swap entry" {
+	run install_gen_fstab "UUID=root1" btrfs "UUID=boot1" ext4 "" "UUID=swap1"
+	[[ "$output" == *"UUID=swap1	none	swap	sw"* ]]
+}
+
+@test "fstab: no swap UUID emits no swap entry" {
+	run install_gen_fstab "UUID=root1" ext4
+	[[ "$output" != *"	swap	"* ]]
+}
+
 # --- armbianEnv rewrite ------------------------------------------------------
 
 @test "bootenv: existing rootdev/rootfstype are replaced in place" {

--- a/tests/bats/bootconfig.bats
+++ b/tests/bats/bootconfig.bats
@@ -143,6 +143,18 @@ setup() {
 	fi
 }
 
+@test "update_initramfs: built-in fs is a no-op, module fs gets listed" {
+	rootfs="$TMP/rootfs"; mkdir -p "$rootfs/etc/initramfs-tools" "$rootfs/usr/sbin"
+	: >"$rootfs/etc/initramfs-tools/modules"
+	# Fake update-initramfs so no real chroot/mount happens; ext4 must not even
+	# reach it (built-in), f2fs must add itself to the module list first.
+	printf '#!/bin/sh\nexit 0\n' >"$rootfs/usr/sbin/update-initramfs"; chmod +x "$rootfs/usr/sbin/update-initramfs"
+
+	run install_update_initramfs "$rootfs" ext4
+	[ "$status" -eq 0 ]
+	[ ! -s "$rootfs/etc/initramfs-tools/modules" ]   # ext4 added nothing
+}
+
 @test "fs kernel support: ext4 always supported; a bogus fs is not" {
 	run install_fs_kernel_supported ext4
 	[ "$status" -eq 0 ]

--- a/tests/bats/bootconfig.bats
+++ b/tests/bats/bootconfig.bats
@@ -87,3 +87,31 @@ setup() {
 	run install_verify_boot_dir "$d"
 	[ "$status" -eq 0 ]
 }
+
+# --- bootloader capability pre-flight ----------------------------------------
+
+@test "bootloader available: u-boot modes need write_uboot_platform (x86 has none)" {
+	# No write_uboot_platform defined -> u-boot modes must report unavailable, so
+	# the installer refuses before wiping (the code-72-after-wipe scenario).
+	unset -f write_uboot_platform 2>/dev/null || true
+	run install_bootloader_available sd
+	[ "$status" -ne 0 ]
+	run install_bootloader_available emmc
+	[ "$status" -ne 0 ]
+}
+
+@test "bootloader available: u-boot modes ok once the hook exists" {
+	write_uboot_platform() { :; }
+	run install_bootloader_available sd
+	[ "$status" -eq 0 ]
+	unset -f write_uboot_platform
+}
+
+@test "bootloader available: grub modes depend on grub-install presence" {
+	if command -v grub-install >/dev/null 2>&1; then
+		run install_bootloader_available bios; [ "$status" -eq 0 ]
+		run install_bootloader_available uefi; [ "$status" -eq 0 ]
+	else
+		run install_bootloader_available bios; [ "$status" -ne 0 ]
+	fi
+}

--- a/tests/bats/bootconfig.bats
+++ b/tests/bats/bootconfig.bats
@@ -1,0 +1,89 @@
+#!/usr/bin/env bats
+#
+# Unit tests for boot-config generation and verification: fstab, armbianEnv
+# rewriting, and the empty-/boot guard (build#10099/#10064) plus the
+# not-bootable guard (build#6905).
+
+setup() {
+	declare -A module_options
+	source "${BATS_TEST_DIRNAME}/../../tools/modules/functions/module_install_engine.sh"
+	TMP="$BATS_TEST_TMPDIR"
+	INSTALL_LOG=/dev/null
+}
+
+# --- fstab -------------------------------------------------------------------
+
+@test "fstab: root-only ext4 has tmpfs + root, no boot line" {
+	run install_gen_fstab "UUID=aaaa" ext4
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"tmpfs	/tmp	tmpfs"* ]]
+	[[ "$output" == *"UUID=aaaa	/	ext4"* ]]
+	[[ "$output" != *"	/boot	"* ]]
+}
+
+@test "fstab: separate boot + ESP produce /boot and /boot/efi lines" {
+	run install_gen_fstab "UUID=root1" btrfs "UUID=boot1" ext4 "UUID=efi1"
+	[[ "$output" == *"UUID=root1	/	btrfs"* ]]
+	[[ "$output" == *"UUID=boot1	/boot	ext4"* ]]
+	[[ "$output" == *"UUID=efi1	/boot/efi	vfat"* ]]
+}
+
+@test "fstab: btrfs root carries subvol=@ option" {
+	run install_gen_fstab "UUID=root1" btrfs
+	[[ "$output" == *"subvol=@"* ]]
+}
+
+# --- armbianEnv rewrite ------------------------------------------------------
+
+@test "bootenv: existing rootdev/rootfstype are replaced in place" {
+	f="$TMP/armbianEnv.txt"
+	printf 'verbosity=1\nrootdev=UUID=old\nrootfstype=ext4\n' >"$f"
+	run install_rewrite_bootenv "$f" "UUID=new" btrfs
+	[ "$status" -eq 0 ]
+	grep -q '^rootdev=UUID=new$' "$f"
+	grep -q '^rootfstype=btrfs$' "$f"
+	# no duplicate keys
+	[ "$(grep -c '^rootdev=' "$f")" -eq 1 ]
+}
+
+@test "bootenv: missing keys are appended" {
+	f="$TMP/armbianEnv.txt"
+	printf 'verbosity=1\n' >"$f"
+	run install_rewrite_bootenv "$f" "UUID=new" ext4
+	grep -q '^rootdev=UUID=new$' "$f"
+	grep -q '^rootfstype=ext4$' "$f"
+}
+
+@test "bootenv: missing file returns bootcfg error" {
+	run install_rewrite_bootenv "$TMP/nope.txt" "UUID=new" ext4
+	[ "$status" -eq 71 ]
+}
+
+# --- verify: bootable /boot --------------------------------------------------
+
+@test "verify boot dir: kernel + boot script passes" {
+	d="$TMP/boot"; mkdir -p "$d"
+	: >"$d/vmlinuz-6.6.0"; : >"$d/boot.scr"
+	run install_verify_boot_dir "$d"
+	[ "$status" -eq 0 ]
+}
+
+@test "verify boot dir: empty /boot fails (build#10099)" {
+	d="$TMP/boot"; mkdir -p "$d"
+	run install_verify_boot_dir "$d"
+	[ "$status" -eq 73 ]
+}
+
+@test "verify boot dir: kernel but no boot script fails (build#6905)" {
+	d="$TMP/boot"; mkdir -p "$d"
+	: >"$d/Image"
+	run install_verify_boot_dir "$d"
+	[ "$status" -eq 73 ]
+}
+
+@test "verify boot dir: extlinux config counts as a boot script" {
+	d="$TMP/boot"; mkdir -p "$d/extlinux"
+	: >"$d/Image"; : >"$d/extlinux/extlinux.conf"
+	run install_verify_boot_dir "$d"
+	[ "$status" -eq 0 ]
+}

--- a/tests/bats/bootconfig.bats
+++ b/tests/bats/bootconfig.bats
@@ -121,6 +121,15 @@ setup() {
 	[ ! -f "$rootfs/boot/vmlinuz-test" ]
 }
 
+@test "grub firstboot: installs a self-removing one-shot update-grub unit" {
+	r="$TMP/rootfs"; mkdir -p "$r/etc/systemd/system"
+	install_setup_grub_firstboot "$r"
+	[ -f "$r/etc/systemd/system/armbian-grub-update.service" ]
+	grep -q "update-grub" "$r/etc/systemd/system/armbian-grub-update.service"
+	# enabled via a wants symlink so it runs on first boot
+	[ -L "$r/etc/systemd/system/multi-user.target.wants/armbian-grub-update.service" ]
+}
+
 # --- bootloader capability pre-flight ----------------------------------------
 
 @test "bootloader available: u-boot modes need write_uboot_platform (x86 has none)" {

--- a/tests/bats/detect.bats
+++ b/tests/bats/detect.bats
@@ -12,13 +12,31 @@ setup() {
 @test "detect: one TSV record per disk, no concatenation (build#8738)" {
 	run install_detect_targets "" "$(cat "$FIX/lsblk_multidisk.json")"
 	[ "$status" -eq 0 ]
-	# Three disks in the fixture -> exactly three lines.
+	# Six entries in the fixture, but zram0/zram1/loop0 are filtered out -> three.
 	[ "${#lines[@]}" -eq 3 ]
 	# No line may contain two device names glued together.
 	for line in "${lines[@]}"; do
 		name="${line%%$'\t'*}"
 		[[ "$name" != *" "* ]]
 	done
+}
+
+@test "detect: excludes zram / loop / ram pseudo-devices" {
+	run install_detect_targets "" "$(cat "$FIX/lsblk_multidisk.json")"
+	[ "$status" -eq 0 ]
+	[[ "$output" != *"zram"* ]]
+	[[ "$output" != *"loop"* ]]
+}
+
+@test "detect: emits a '-' placeholder for an absent bus so fields never shift" {
+	# mmcblk0 has tran=null; the bus column must be "-", not empty, and the row
+	# must still parse into 7 tab-separated fields with role=mmc.
+	run install_detect_targets "" "$(cat "$FIX/lsblk_multidisk.json")"
+	local row; row=$(printf '%s\n' "${lines[@]}" | grep '^mmcblk0')
+	IFS=$'\t' read -r n role sz sec bus rota model <<<"$row"
+	[ "$role" = "mmc" ]
+	[ "$bus" = "-" ]
+	[ "$rota" = "false" ]
 }
 
 @test "detect: excludes the running-root disk" {

--- a/tests/bats/detect.bats
+++ b/tests/bats/detect.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+#
+# Unit tests for install_detect_targets - the storage inventory. The headline
+# guarantee is build#8738: one record per device, never space-joined.
+
+setup() {
+	declare -A module_options
+	source "${BATS_TEST_DIRNAME}/../../tools/modules/functions/module_install_engine.sh"
+	FIX="${BATS_TEST_DIRNAME}/fixtures"
+}
+
+@test "detect: one TSV record per disk, no concatenation (build#8738)" {
+	run install_detect_targets "" "$(cat "$FIX/lsblk_multidisk.json")"
+	[ "$status" -eq 0 ]
+	# Three disks in the fixture -> exactly three lines.
+	[ "${#lines[@]}" -eq 3 ]
+	# No line may contain two device names glued together.
+	for line in "${lines[@]}"; do
+		name="${line%%$'\t'*}"
+		[[ "$name" != *" "* ]]
+	done
+}
+
+@test "detect: excludes the running-root disk" {
+	run install_detect_targets "mmcblk0" "$(cat "$FIX/lsblk_multidisk.json")"
+	[ "$status" -eq 0 ]
+	[ "${#lines[@]}" -eq 2 ]
+	[[ "$output" != *"mmcblk0"* ]]
+	[[ "$output" == *"nvme0n1"* ]]
+	[[ "$output" == *"sda"* ]]
+}
+
+@test "detect: classifies roles from name and bus" {
+	run install_detect_targets "" "$(cat "$FIX/lsblk_multidisk.json")"
+	# fields: name role size sector bus rota model
+	echo "$output" | grep -qP '^mmcblk0\tmmc\t'
+	echo "$output" | grep -qP '^nvme0n1\tnvme\t'
+	echo "$output" | grep -qP '^sda\tusb\t'
+}
+
+@test "detect: surfaces sector size and model" {
+	run install_detect_targets "" "$(cat "$FIX/lsblk_4kn_large.json")"
+	# 4Kn NVMe reports phy-sec 4096 in field 4.
+	echo "$output" | grep -qP '^nvme0n1\tnvme\t4000787030016\t4096\t'
+	[[ "$output" == *"WD Black SN850 4TB"* ]]
+}

--- a/tests/bats/detect_windows.bats
+++ b/tests/bats/detect_windows.bats
@@ -35,6 +35,15 @@ setup() {
 	grep -qi "BitLocker" "$BATS_TEST_TMPDIR/log"
 }
 
+@test "has_bitlocker: true when a BitLocker volume is present, false otherwise" {
+	local bl; bl="$(jq '(.blockdevices[0].children[2].fstype)="BitLocker"' "$FIX/lsblk_windows.json")"
+	run install_disk_has_bitlocker /dev/sda "$bl"
+	[ "$status" -eq 0 ]
+	# Plain NTFS Windows -> not BitLocker.
+	run install_disk_has_bitlocker /dev/sda "$(cat "$FIX/lsblk_windows.json")"
+	[ "$status" -ne 0 ]
+}
+
 @test "detect_windows: no NTFS at all is reported as no ESP+NTFS pair" {
 	# No NTFS and no "basic data" partition -> the generic message, not the
 	# BitLocker hint.

--- a/tests/bats/detect_windows.bats
+++ b/tests/bats/detect_windows.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+#
+# Unit tests for Windows dual-boot detection (_install_windows_parts /
+# install_detect_windows). The headline guarantee: pick the Windows *system*
+# NTFS volume (C:), never the tiny WinRE recovery partition, and sort by numeric
+# size (lsblk may emit size as a string).
+
+setup() {
+	declare -A module_options
+	source "${BATS_TEST_DIRNAME}/../../tools/modules/functions/module_install_engine.sh"
+	INSTALL_LOG=/dev/null
+	FIX="${BATS_TEST_DIRNAME}/fixtures"
+}
+
+@test "detect_windows: picks C: (Microsoft basic data), not the WinRE recovery part" {
+	run install_detect_windows /dev/sda "$(cat "$FIX/lsblk_windows.json")"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"esp=/dev/sda1"* ]]
+	[[ "$output" == *"windows=/dev/sda3"* ]]
+	[[ "$output" != *"windows=/dev/sda4"* ]]
+}
+
+@test "detect_windows: numeric size sort (string sort would wrongly pick 781MB WinRE)" {
+	# Only the pure helper, exercising the sort directly.
+	run _install_windows_parts "$(cat "$FIX/lsblk_windows.json")"
+	[[ "$output" == *"windows=/dev/sda3"* ]]
+}
+
+@test "detect_windows: a BitLocker C: yields no target and a clear hint" {
+	# sda3 is Microsoft basic data but NOT ntfs (BitLocker); only WinRE is ntfs.
+	local json; json="$(jq '(.blockdevices[0].children[2].fstype)="BitLocker"' "$FIX/lsblk_windows.json")"
+	INSTALL_LOG="$BATS_TEST_TMPDIR/log"
+	run install_detect_windows /dev/sda "$json"
+	[ "$status" -eq 65 ]                      # INSTALL_EX_NODEV
+	grep -qi "BitLocker" "$BATS_TEST_TMPDIR/log"
+}
+
+@test "detect_windows: no NTFS at all is reported as no ESP+NTFS pair" {
+	# No NTFS and no "basic data" partition -> the generic message, not the
+	# BitLocker hint.
+	local json; json="$(jq '
+		(.blockdevices[0].children[2].fstype)="ext4"
+		| (.blockdevices[0].children[2].parttypename)="Linux filesystem"
+		| (.blockdevices[0].children[3].fstype)="ext4"
+		| (.blockdevices[0].children[3].parttypename)="Linux filesystem"' "$FIX/lsblk_windows.json")"
+	INSTALL_LOG="$BATS_TEST_TMPDIR/log"
+	run install_detect_windows /dev/sda "$json"
+	[ "$status" -eq 65 ]
+	grep -qi "no ESP+NTFS pair" "$BATS_TEST_TMPDIR/log"
+}

--- a/tests/bats/dualboot.bats
+++ b/tests/bats/dualboot.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+#
+# Unit tests for the pure Windows dual-boot planner (install_dualboot_plan):
+# how far Windows must shrink to free the requested space, with a safety margin,
+# and refusal when it will not fit.
+
+setup() {
+	declare -A module_options
+	source "${BATS_TEST_DIRNAME}/../../tools/modules/functions/module_install_engine.sh"
+	INSTALL_LOG=/dev/null
+	GIB=$(( 1024 * 1024 * 1024 ))
+}
+
+@test "dualboot plan: shrinks Windows to free the requested space" {
+	# 500G Windows, 120G used-minimum, no free tail, want 100G for Armbian.
+	run install_dualboot_plan $((500*GIB)) $((120*GIB)) 0 $((100*GIB))
+	[ "$status" -eq 0 ]
+	# Windows should become 500G - 100G = 400G.
+	[ "$output" = "shrink_to=$((400*GIB))" ]
+}
+
+@test "dualboot plan: uses an existing free tail before shrinking Windows" {
+	# 40G free tail already; want 30G -> no shrink needed, Windows unchanged.
+	run install_dualboot_plan $((500*GIB)) $((120*GIB)) $((40*GIB)) $((30*GIB))
+	[ "$status" -eq 0 ]
+	[ "$output" = "shrink_to=$((500*GIB))" ]
+}
+
+@test "dualboot plan: tail partially covers, shrink only the remainder" {
+	# 40G tail, want 100G -> take 60G from Windows.
+	run install_dualboot_plan $((500*GIB)) $((120*GIB)) $((40*GIB)) $((100*GIB))
+	[ "$status" -eq 0 ]
+	[ "$output" = "shrink_to=$((440*GIB))" ]
+}
+
+@test "dualboot plan: refuses when the request exceeds shrinkable space" {
+	# 130G Windows, 120G minimum -> only ~2G shrinkable after the 8G margin,
+	# so a 100G request must fail.
+	run install_dualboot_plan $((130*GIB)) $((120*GIB)) 0 $((100*GIB))
+	[ "$status" -eq 66 ]   # INSTALL_EX_NOSPACE
+}
+
+@test "dualboot plan: keeps an 8GiB margin above the NTFS minimum" {
+	# 200G Windows, 100G minimum. Max Armbian = 200 - (100+8) = 92G.
+	run install_dualboot_plan $((200*GIB)) $((100*GIB)) 0 $((92*GIB))
+	[ "$status" -eq 0 ]
+	run install_dualboot_plan $((200*GIB)) $((100*GIB)) 0 $((93*GIB))
+	[ "$status" -eq 66 ]
+}

--- a/tests/bats/fixtures/lsblk_4kn_large.json
+++ b/tests/bats/fixtures/lsblk_4kn_large.json
@@ -1,0 +1,6 @@
+{
+   "blockdevices": [
+      {"name":"mmcblk1","type":"disk","size":7818182656,"phy-sec":512,"tran":null,"rota":false,"model":null},
+      {"name":"nvme0n1","type":"disk","size":4000787030016,"phy-sec":4096,"tran":"nvme","rota":false,"model":"WD Black SN850 4TB"}
+   ]
+}

--- a/tests/bats/fixtures/lsblk_4kn_large.json
+++ b/tests/bats/fixtures/lsblk_4kn_large.json
@@ -1,6 +1,6 @@
 {
-   "blockdevices": [
-      {"name":"mmcblk1","type":"disk","size":7818182656,"phy-sec":512,"tran":null,"rota":false,"model":null},
-      {"name":"nvme0n1","type":"disk","size":4000787030016,"phy-sec":4096,"tran":"nvme","rota":false,"model":"WD Black SN850 4TB"}
-   ]
+    "blockdevices": [
+        {"name":"mmcblk1","type":"disk","size":7818182656,"phy-sec":512,"tran":null,"rota":false,"model":null},
+        {"name":"nvme0n1","type":"disk","size":4000787030016,"phy-sec":4096,"tran":"nvme","rota":false,"model":"WD Black SN850 4TB"}
+    ]
 }

--- a/tests/bats/fixtures/lsblk_multidisk.json
+++ b/tests/bats/fixtures/lsblk_multidisk.json
@@ -1,0 +1,7 @@
+{
+   "blockdevices": [
+      {"name":"mmcblk0","type":"disk","size":31914983424,"phy-sec":512,"tran":null,"rota":false,"model":null},
+      {"name":"nvme0n1","type":"disk","size":512110190592,"phy-sec":512,"tran":"nvme","rota":false,"model":"Samsung SSD 970 EVO"},
+      {"name":"sda","type":"disk","size":1000204886016,"phy-sec":512,"tran":"usb","rota":true,"model":"Generic USB3.0"}
+   ]
+}

--- a/tests/bats/fixtures/lsblk_multidisk.json
+++ b/tests/bats/fixtures/lsblk_multidisk.json
@@ -1,5 +1,8 @@
 {
    "blockdevices": [
+      {"name":"zram0","type":"disk","size":2147483648,"phy-sec":4096,"tran":null,"rota":false,"model":null},
+      {"name":"zram1","type":"disk","size":52428800,"phy-sec":4096,"tran":null,"rota":false,"model":null},
+      {"name":"loop0","type":"disk","size":134217728,"phy-sec":512,"tran":null,"rota":false,"model":null},
       {"name":"mmcblk0","type":"disk","size":31914983424,"phy-sec":512,"tran":null,"rota":false,"model":null},
       {"name":"nvme0n1","type":"disk","size":512110190592,"phy-sec":512,"tran":"nvme","rota":false,"model":"Samsung SSD 970 EVO"},
       {"name":"sda","type":"disk","size":1000204886016,"phy-sec":512,"tran":"usb","rota":true,"model":"Generic USB3.0"}

--- a/tests/bats/fixtures/lsblk_multidisk.json
+++ b/tests/bats/fixtures/lsblk_multidisk.json
@@ -1,10 +1,10 @@
 {
-   "blockdevices": [
-      {"name":"zram0","type":"disk","size":2147483648,"phy-sec":4096,"tran":null,"rota":false,"model":null},
-      {"name":"zram1","type":"disk","size":52428800,"phy-sec":4096,"tran":null,"rota":false,"model":null},
-      {"name":"loop0","type":"disk","size":134217728,"phy-sec":512,"tran":null,"rota":false,"model":null},
-      {"name":"mmcblk0","type":"disk","size":31914983424,"phy-sec":512,"tran":null,"rota":false,"model":null},
-      {"name":"nvme0n1","type":"disk","size":512110190592,"phy-sec":512,"tran":"nvme","rota":false,"model":"Samsung SSD 970 EVO"},
-      {"name":"sda","type":"disk","size":1000204886016,"phy-sec":512,"tran":"usb","rota":true,"model":"Generic USB3.0"}
-   ]
+    "blockdevices": [
+        {"name":"zram0","type":"disk","size":2147483648,"phy-sec":4096,"tran":null,"rota":false,"model":null},
+        {"name":"zram1","type":"disk","size":52428800,"phy-sec":4096,"tran":null,"rota":false,"model":null},
+        {"name":"loop0","type":"disk","size":134217728,"phy-sec":512,"tran":null,"rota":false,"model":null},
+        {"name":"mmcblk0","type":"disk","size":31914983424,"phy-sec":512,"tran":null,"rota":false,"model":null},
+        {"name":"nvme0n1","type":"disk","size":512110190592,"phy-sec":512,"tran":"nvme","rota":false,"model":"Samsung SSD 970 EVO"},
+        {"name":"sda","type":"disk","size":1000204886016,"phy-sec":512,"tran":"usb","rota":true,"model":"Generic USB3.0"}
+    ]
 }

--- a/tests/bats/fixtures/lsblk_windows.json
+++ b/tests/bats/fixtures/lsblk_windows.json
@@ -1,0 +1,10 @@
+{
+    "blockdevices": [
+        {"name":"/dev/sda","fstype":null,"parttypename":null,"size":68719476736,"children": [
+            {"name":"/dev/sda1","fstype":"vfat","parttypename":"EFI System","size":209715200},
+            {"name":"/dev/sda2","fstype":null,"parttypename":"Microsoft reserved","size":16777216},
+            {"name":"/dev/sda3","fstype":"ntfs","parttypename":"Microsoft basic data","size":67670851584},
+            {"name":"/dev/sda4","fstype":"ntfs","parttypename":"Windows recovery environment","size":818937856}
+        ]}
+    ]
+}

--- a/tests/bats/integration_dualboot.bats
+++ b/tests/bats/integration_dualboot.bats
@@ -36,6 +36,13 @@ setup() {
 	mkfs.vfat -F 32 "${LOOP}p1" >/dev/null 2>&1
 	mkfs.ntfs -Q -F "${LOOP}p2" >/dev/null 2>&1
 	mkfs.ntfs -Q -F "${LOOP}p3" >/dev/null 2>&1
+	# Re-probe the freshly-made filesystems into the udev/blkid db. `udevadm
+	# settle` alone does not re-probe, so lsblk (used by install_detect_windows)
+	# can otherwise report empty FSTYPE for these loop partitions on newer
+	# runner images. blkid warms the cache and `udevadm trigger` re-reads it.
+	blkid "${LOOP}p1" "${LOOP}p2" "${LOOP}p3" >/dev/null 2>&1 || true
+	udevadm trigger --settle "${LOOP}p1" "${LOOP}p2" "${LOOP}p3" >/dev/null 2>&1 \
+		|| udevadm trigger --settle >/dev/null 2>&1 || true
 
 	# Marker files: Windows boot manager in the ESP, payload in C:, marker in the
 	# trailing recovery partition (must survive untouched).

--- a/tests/bats/integration_dualboot.bats
+++ b/tests/bats/integration_dualboot.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+#
+# Integration test for the Windows dual-boot primitives against a real,
+# loop-backed "Windows" disk (GPT + ESP + NTFS). It exercises the risky part -
+# NTFS detection, shrink, and carving an Armbian partition out of the freed tail
+# - and asserts Windows survives intact. Needs root + ntfsprogs; skips otherwise.
+
+setup() {
+	declare -A module_options
+	source "${BATS_TEST_DIRNAME}/../../tools/modules/functions/module_install_engine.sh"
+	INSTALL_LOG=/dev/null
+	export LC_ALL=C LANG=C
+
+	[[ "$(id -u)" -eq 0 ]] || skip "needs root for losetup"
+	command -v mkfs.ntfs  >/dev/null || skip "mkfs.ntfs (ntfs-3g) not available"
+	command -v ntfsresize >/dev/null || skip "ntfsresize not available"
+	command -v parted     >/dev/null || skip "parted not available"
+
+	IMG="$BATS_TEST_TMPDIR/win.img"
+	truncate -s 12G "$IMG"
+	LOOP="$(losetup -f --show -P "$IMG")"
+
+	# Fabricate a Windows/UEFI layout: GPT, ESP (vfat) + one big NTFS volume.
+	parted -s "$LOOP" mklabel gpt
+	parted -s "$LOOP" mkpart primary fat32 1MiB 301MiB
+	parted -s "$LOOP" set 1 esp on
+	parted -s "$LOOP" mkpart primary ntfs 301MiB 100%
+	partprobe "$LOOP"; udevadm settle
+	mkfs.vfat -F 32 "${LOOP}p1" >/dev/null 2>&1
+	mkfs.ntfs -Q -F "${LOOP}p2" >/dev/null 2>&1
+
+	# Drop marker files: a Windows boot manager in the ESP and payload in NTFS.
+	local m="$BATS_TEST_TMPDIR/mnt"; mkdir -p "$m"
+	mount "${LOOP}p1" "$m"; mkdir -p "$m/EFI/Microsoft/Boot"; echo bootmgr >"$m/EFI/Microsoft/Boot/bootmgfw.efi"; umount "$m"
+	mount -t ntfs-3g "${LOOP}p2" "$m"; head -c 5000000 /dev/urandom >"$m/payload.bin"; PAYSUM="$(sha256sum "$m/payload.bin" | cut -d' ' -f1)"; umount "$m"
+	udevadm settle
+}
+
+teardown() {
+	[[ -n "${LOOP:-}" ]] && losetup -d "$LOOP" 2>/dev/null || true
+}
+
+@test "dualboot: detect_windows finds the ESP and the NTFS volume" {
+	run install_detect_windows "$LOOP"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"esp=${LOOP}p1"* ]]
+	[[ "$output" == *"windows=${LOOP}p2"* ]]
+}
+
+@test "dualboot: windows_min_bytes reports a plausible NTFS minimum" {
+	run install_windows_min_bytes "${LOOP}p2"
+	[ "$status" -eq 0 ]
+	[ "$output" -gt 0 ]
+	# Minimum must be smaller than the ~11.7G volume.
+	[ "$output" -lt $((11 * 1024 * 1024 * 1024)) ]
+}
+
+@test "dualboot: shrink Windows, carve Armbian partition, Windows survives" {
+	local win="${LOOP}p2"
+	local before; before="$(blockdev --getsize64 "$win")"
+
+	# Shrink the NTFS volume to 4 GiB.
+	run install_shrink_windows "$LOOP" "$win" $((4 * 1024 * 1024 * 1024))
+	[ "$status" -eq 0 ]
+
+	# The partition actually got smaller...
+	local after; after="$(blockdev --getsize64 "$win")"
+	[ "$after" -lt "$before" ]
+	# ...and there is now free space to carve into.
+	partprobe "$LOOP"; udevadm settle
+
+	# Create + format the Armbian partition in the freed tail.
+	local root; root="$(install_create_free_partition "$LOOP" ext4)"
+	[ -b "$root" ]
+	run install_make_filesystems "root $root ext4"
+	[ "$status" -eq 0 ]
+	[ "$(blkid -s TYPE -o value "$root")" = "ext4" ]
+
+	# Windows is intact: still NTFS, still consistent, payload unchanged, and the
+	# ESP still holds the Windows boot manager.
+	[ "$(blkid -s TYPE -o value "$win")" = "ntfs" ]
+	ntfsresize -f --info "$win" >/dev/null 2>&1
+	local m="$BATS_TEST_TMPDIR/verify"; mkdir -p "$m"
+	mount -t ntfs-3g "$win" "$m"
+	[ "$(sha256sum "$m/payload.bin" | cut -d' ' -f1)" = "$PAYSUM" ]
+	umount "$m"
+	mount "${LOOP}p1" "$m"
+	[ -f "$m/EFI/Microsoft/Boot/bootmgfw.efi" ]
+	umount "$m"
+}

--- a/tests/bats/integration_dualboot.bats
+++ b/tests/bats/integration_dualboot.bats
@@ -66,6 +66,12 @@ teardown() {
 
 @test "dualboot: detect_windows finds the ESP and the NTFS volume" {
 	run install_detect_windows "$LOOP"
+	if [ "$status" -ne 0 ]; then
+		echo "# detect_windows FAILED status=$status output=[$output]" >&3
+		echo "# lsblk: $(lsblk -b -po NAME,FSTYPE,PARTTYPENAME,SIZE --json "$LOOP" 2>&1 | tr '\n' ' ')" >&3
+		echo "# parted: $(parted -sm "$LOOP" print 2>&1 | tr '\n' '|')" >&3
+		echo "# blkid: p1=[$(blkid "${LOOP}p1" 2>&1)] p2=[$(blkid "${LOOP}p2" 2>&1)]" >&3
+	fi
 	[ "$status" -eq 0 ]
 	[[ "$output" == *"esp=${LOOP}p1"* ]]
 	[[ "$output" == *"windows=${LOOP}p2"* ]]

--- a/tests/bats/integration_dualboot.bats
+++ b/tests/bats/integration_dualboot.bats
@@ -23,19 +23,26 @@ setup() {
 	truncate -s 12G "$IMG"
 	LOOP="$(losetup -f --show -P "$IMG")"
 
-	# Fabricate a Windows/UEFI layout: GPT, ESP (vfat) + one big NTFS volume.
+	# Fabricate a real Windows/UEFI layout: GPT, ESP (vfat) + big NTFS (C:) + a
+	# trailing NTFS "recovery" partition at the disk END. The trailing partition
+	# is what tripped up "return the highest-numbered partition" - the free space
+	# after shrinking C: sits BEFORE it.
 	parted -s "$LOOP" mklabel gpt
 	parted -s "$LOOP" mkpart primary fat32 1MiB 301MiB
 	parted -s "$LOOP" set 1 esp on
-	parted -s "$LOOP" mkpart primary ntfs 301MiB 100%
+	parted -s "$LOOP" mkpart primary ntfs 301MiB 10GiB
+	parted -s "$LOOP" mkpart primary ntfs 10GiB 100%
 	partprobe "$LOOP"; udevadm settle
 	mkfs.vfat -F 32 "${LOOP}p1" >/dev/null 2>&1
 	mkfs.ntfs -Q -F "${LOOP}p2" >/dev/null 2>&1
+	mkfs.ntfs -Q -F "${LOOP}p3" >/dev/null 2>&1
 
-	# Drop marker files: a Windows boot manager in the ESP and payload in NTFS.
+	# Marker files: Windows boot manager in the ESP, payload in C:, marker in the
+	# trailing recovery partition (must survive untouched).
 	local m="$BATS_TEST_TMPDIR/mnt"; mkdir -p "$m"
 	mount "${LOOP}p1" "$m"; mkdir -p "$m/EFI/Microsoft/Boot"; echo bootmgr >"$m/EFI/Microsoft/Boot/bootmgfw.efi"; umount "$m"
 	mount -t ntfs-3g "${LOOP}p2" "$m"; head -c 5000000 /dev/urandom >"$m/payload.bin"; PAYSUM="$(sha256sum "$m/payload.bin" | cut -d' ' -f1)"; umount "$m"
+	mount -t ntfs-3g "${LOOP}p3" "$m"; echo winre >"$m/RECOVERY.marker"; RECSUM="$(sha256sum "$m/RECOVERY.marker" | cut -d' ' -f1)"; umount "$m"
 	udevadm settle
 }
 
@@ -44,7 +51,7 @@ teardown() {
 	# partition mounted and the loop device busy. Unmount everything we create
 	# first, then detach - and don't silently swallow a still-busy device.
 	local m
-	for m in "$BATS_TEST_TMPDIR/verify" "$BATS_TEST_TMPDIR/mnt"; do
+	for m in "$BATS_TEST_TMPDIR/verify" "$BATS_TEST_TMPDIR/rec" "$BATS_TEST_TMPDIR/mnt"; do
 		mountpoint -q "$m" && umount "$m"
 	done
 	[[ -n "${LOOP:-}" ]] && losetup -d "$LOOP"
@@ -79,12 +86,21 @@ teardown() {
 	# ...and there is now free space to carve into.
 	partprobe "$LOOP"; udevadm settle
 
-	# Create + format the Armbian partition in the freed tail.
+	# Create + format the Armbian partition in the freed GAP (between C: and the
+	# trailing recovery). It must be the NEW partition, never the recovery one.
 	local root; root="$(install_create_free_partition "$LOOP" ext4)"
 	[ -b "$root" ]
+	[ "$root" != "${LOOP}p3" ]          # regression: not the trailing recovery part
 	run install_make_filesystems "root $root ext4"
 	[ "$status" -eq 0 ]
 	[ "$(blkid -s TYPE -o value "$root")" = "ext4" ]
+
+	# The trailing recovery partition is untouched: still NTFS, marker intact.
+	[ "$(blkid -s TYPE -o value "${LOOP}p3")" = "ntfs" ]
+	local mr="$BATS_TEST_TMPDIR/rec"; mkdir -p "$mr"
+	mount -t ntfs-3g "${LOOP}p3" "$mr"
+	[ "$(sha256sum "$mr/RECOVERY.marker" | cut -d' ' -f1)" = "$RECSUM" ]
+	umount "$mr"
 
 	# Windows is intact: still NTFS, still consistent, payload unchanged, and the
 	# ESP still holds the Windows boot manager.

--- a/tests/bats/integration_dualboot.bats
+++ b/tests/bats/integration_dualboot.bats
@@ -40,7 +40,14 @@ setup() {
 }
 
 teardown() {
-	[[ -n "${LOOP:-}" ]] && losetup -d "$LOOP" 2>/dev/null || true
+	# A failed assertion can abort a test before its own umount runs, leaving a
+	# partition mounted and the loop device busy. Unmount everything we create
+	# first, then detach - and don't silently swallow a still-busy device.
+	local m
+	for m in "$BATS_TEST_TMPDIR/verify" "$BATS_TEST_TMPDIR/mnt"; do
+		mountpoint -q "$m" && umount "$m"
+	done
+	[[ -n "${LOOP:-}" ]] && losetup -d "$LOOP"
 }
 
 @test "dualboot: detect_windows finds the ESP and the NTFS volume" {

--- a/tests/bats/integration_dualboot.bats
+++ b/tests/bats/integration_dualboot.bats
@@ -6,6 +6,9 @@
 # - and asserts Windows survives intact. Needs root + ntfsprogs; skips otherwise.
 
 setup() {
+	# Run under pipefail so a masked-exit-code bug (e.g. `yes | ntfsresize`
+	# reporting failure on SIGPIPE) is caught, mirroring a strict caller.
+	set -o pipefail
 	declare -A module_options
 	source "${BATS_TEST_DIRNAME}/../../tools/modules/functions/module_install_engine.sh"
 	INSTALL_LOG=/dev/null

--- a/tests/bats/integration_loopback.bats
+++ b/tests/bats/integration_loopback.bats
@@ -74,6 +74,27 @@ root ${LOOP}p2 ext4"
 	[ "$status" -eq 0 ]
 }
 
+@test "loopback: bios msdos plan yields a single boot-flagged partition" {
+	local plan; plan="$(install_plan_layout bios ext4 0 $((8*1024*1024*1024)) 512 0)"
+	run install_apply_partitions "$LOOP" "$plan"
+	[ "$status" -eq 0 ]
+	LC_ALL=C parted -sm "$LOOP" print | grep -q '^/dev/.*:msdos:'
+	LC_ALL=C parted -sm "$LOOP" print | grep -q 'boot'
+	[ -b "${LOOP}p1" ]
+	[ ! -b "${LOOP}p2" ]
+}
+
+@test "loopback: bios gpt plan yields a bios_grub-flagged partition + root" {
+	# Force GPT via a >2TiB capacity in the plan (applied to the small loop dev).
+	local plan; plan="$(install_plan_layout bios ext4 0 $((3*1024*1024*1024*1024)) 512 0)"
+	[[ "$plan" == *"table=gpt"* ]]
+	run install_apply_partitions "$LOOP" "$plan"
+	[ "$status" -eq 0 ]
+	LC_ALL=C parted -sm "$LOOP" print | grep -q 'bios_grub'
+	[[ "$output" == *"biosboot ${LOOP}p1"* ]]
+	[[ "$output" == *"root ${LOOP}p2"* ]]
+}
+
 @test "loopback: >2TiB capacity forces GPT even in a non-uefi plan (build#9794)" {
 	# We cannot allocate 2TiB, but the planner decision is capacity-driven, so
 	# feed the large capacity to the plan and apply it to the small loop dev.

--- a/tests/bats/integration_loopback.bats
+++ b/tests/bats/integration_loopback.bats
@@ -1,0 +1,85 @@
+#!/usr/bin/env bats
+#
+# Integration tests for the side-effecting engine primitives against a real
+# (loop-backed) block device: partitioning, mkfs and fstab generation. These
+# need root + losetup, so they run under sudo in CI and skip locally otherwise.
+#
+# They exercise the exact chain the installer uses, minus the rootfs rsync and
+# bootloader write, and assert with parted/blkid/lsblk that the on-disk result
+# matches the plan - proving the GPT/MBR/flag/blocksize fixes end to end.
+
+setup() {
+	declare -A module_options
+	source "${BATS_TEST_DIRNAME}/../../tools/modules/functions/module_install_engine.sh"
+	INSTALL_LOG=/dev/null
+
+	if [[ "$(id -u)" -ne 0 ]]; then skip "needs root for losetup"; fi
+	command -v losetup >/dev/null || skip "losetup not available"
+	command -v parted  >/dev/null || skip "parted not available"
+
+	IMG="$BATS_TEST_TMPDIR/disk.img"
+	truncate -s 8G "$IMG"
+	LOOP="$(losetup -f --show -P "$IMG")"
+}
+
+teardown() {
+	[[ -n "${LOOP:-}" ]] && losetup -d "$LOOP" 2>/dev/null || true
+}
+
+@test "loopback: uefi plan yields GPT with an ESP-flagged first partition" {
+	local plan; plan="$(install_plan_layout uefi ext4 1 $((8*1024*1024*1024)) 512 0)"
+	run install_apply_partitions "$LOOP" "$plan"
+	[ "$status" -eq 0 ]
+	# parted reports the label type and the esp flag (force C locale - parted
+	# translates flag names, e.g. "boot" -> "zagon" under a Slovenian locale).
+	LC_ALL=C parted -sm "$LOOP" print | grep -q '^/dev/.*:gpt:'
+	LC_ALL=C parted -sm "$LOOP" print | head -3 | grep -q 'esp'
+	# Two partition nodes exist.
+	[ -b "${LOOP}p1" ]
+	[ -b "${LOOP}p2" ]
+}
+
+@test "loopback: emmc ext4 plan yields a single MBR boot-flagged partition" {
+	local plan; plan="$(install_plan_layout emmc ext4 0 $((8*1024*1024*1024)) 512 0)"
+	run install_apply_partitions "$LOOP" "$plan"
+	[ "$status" -eq 0 ]
+	LC_ALL=C parted -sm "$LOOP" print | grep -q '^/dev/.*:msdos:'
+	LC_ALL=C parted -sm "$LOOP" print | grep -q 'boot'
+	[ -b "${LOOP}p1" ]
+	[ ! -b "${LOOP}p2" ]
+}
+
+@test "loopback: apply_partitions echoes role->device for each partition" {
+	local plan; plan="$(install_plan_layout uefi ext4 1 $((8*1024*1024*1024)) 512 0)"
+	run install_apply_partitions "$LOOP" "$plan"
+	[[ "$output" == *"esp ${LOOP}p1"* ]]
+	[[ "$output" == *"root ${LOOP}p2"* ]]
+}
+
+@test "loopback: make_filesystems creates the requested filesystems with UUIDs" {
+	local plan map; plan="$(install_plan_layout uefi ext4 1 $((8*1024*1024*1024)) 512 0)"
+	install_apply_partitions "$LOOP" "$plan" >/dev/null
+	# Explicit fs map: esp->vfat, root->ext4 (real newline between rows).
+	map="esp ${LOOP}p1 vfat
+root ${LOOP}p2 ext4"
+	run install_make_filesystems "$map"
+	[ "$status" -eq 0 ]
+	[ "$(blkid -s TYPE -o value "${LOOP}p1")" = "vfat" ]
+	[ "$(blkid -s TYPE -o value "${LOOP}p2")" = "ext4" ]
+	# A generated fstab from these real UUIDs must verify.
+	local ru; ru="$(install_uuid "${LOOP}p2")"
+	local fstab="$BATS_TEST_TMPDIR/fstab"
+	install_gen_fstab "$ru" ext4 >"$fstab"
+	run install_verify_fstab "$fstab"
+	[ "$status" -eq 0 ]
+}
+
+@test "loopback: >2TiB capacity forces GPT even in a non-uefi plan (build#9794)" {
+	# We cannot allocate 2TiB, but the planner decision is capacity-driven, so
+	# feed the large capacity to the plan and apply it to the small loop dev.
+	local plan; plan="$(install_plan_layout sd ext4 0 $((3*1024*1024*1024*1024)) 512 0)"
+	[[ "$plan" == *"table=gpt"* ]]
+	run install_apply_partitions "$LOOP" "$plan"
+	[ "$status" -eq 0 ]
+	LC_ALL=C parted -sm "$LOOP" print | grep -q '^/dev/.*:gpt:'
+}

--- a/tests/bats/plan.bats
+++ b/tests/bats/plan.bats
@@ -48,6 +48,23 @@ setup() {
 	[[ "$output" == *"table=gpt"* ]]
 }
 
+# --- bios (x86 legacy) layout ------------------------------------------------
+
+@test "plan bios: msdos disk -> single boot-flagged root, no bios boot partition" {
+	run install_plan_layout bios ext4 0 $(( 20 * GIB )) 512 0
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"table=msdos"* ]]
+	[[ "$output" == *"part=root:100%:ext4:boot"* ]]
+	[[ "$output" != *"biosboot"* ]]
+}
+
+@test "plan bios: gpt disk (>2TiB) -> 1MiB bios_grub partition + root" {
+	run install_plan_layout bios ext4 0 $(( 4 * TIB )) 512 0
+	[[ "$output" == *"table=gpt"* ]]
+	[[ "$output" == *"part=biosboot:1MiB::bios_grub"* ]]
+	[[ "$output" == *"part=root:100%:ext4:"* ]]
+}
+
 # --- emmc full install -------------------------------------------------------
 
 @test "plan emmc ext4: single boot-flagged root partition" {

--- a/tests/bats/plan.bats
+++ b/tests/bats/plan.bats
@@ -1,0 +1,104 @@
+#!/usr/bin/env bats
+#
+# Unit tests for the pure partition planner. These lock down the partitioning
+# bug classes: MBR-only tables (build#9454), MBR on >2TiB / 4Kn (build#9794),
+# and missing boot/ESP flags (build#6905).
+
+setup() {
+	declare -A module_options
+	source "${BATS_TEST_DIRNAME}/../../tools/modules/functions/module_install_engine.sh"
+	GIB=$(( 1024 * 1024 * 1024 ))
+	TIB=$(( 1024 * GIB ))
+}
+
+# --- table type decision -----------------------------------------------------
+
+@test "table: small 512b non-uefi disk -> msdos" {
+	run install_table_type 0 $(( 32 * GIB )) 512
+	[ "$output" = "msdos" ]
+}
+
+@test "table: uefi always -> gpt" {
+	run install_table_type 1 $(( 32 * GIB )) 512
+	[ "$output" = "gpt" ]
+}
+
+@test "table: >2TiB disk -> gpt even without uefi (build#9794)" {
+	run install_table_type 0 $(( 4 * TIB )) 512
+	[ "$output" = "gpt" ]
+}
+
+@test "table: 4Kn disk -> gpt (build#9454)" {
+	run install_table_type 0 $(( 32 * GIB )) 4096
+	[ "$output" = "gpt" ]
+}
+
+# --- uefi layout -------------------------------------------------------------
+
+@test "plan uefi: gpt, ESP first with esp+boot flags, root fills rest" {
+	run install_plan_layout uefi ext4 1 $(( 256 * GIB )) 512 0
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"table=gpt"* ]]
+	[[ "$output" == *"part=esp:512MiB:vfat:esp,boot"* ]]
+	[[ "$output" == *"part=root:100%:ext4:"* ]]
+}
+
+@test "plan uefi: table stays gpt even for a tiny 512b disk" {
+	run install_plan_layout uefi ext4 1 $(( 8 * GIB )) 512 0
+	[[ "$output" == *"table=gpt"* ]]
+}
+
+# --- emmc full install -------------------------------------------------------
+
+@test "plan emmc ext4: single boot-flagged root partition" {
+	run install_plan_layout emmc ext4 0 $(( 16 * GIB )) 512 0
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"table=msdos"* ]]
+	[[ "$output" == *"part=root:100%:ext4:boot"* ]]
+	# ext4 keeps /boot as a directory: no separate boot partition.
+	[[ "$output" != *"part=boot:"* ]]
+}
+
+@test "plan emmc btrfs: separate ext4 boot + btrfs root (u-boot can't read btrfs)" {
+	run install_plan_layout emmc btrfs 0 $(( 16 * GIB )) 512 0
+	[[ "$output" == *"part=boot:512MiB:ext4:boot"* ]]
+	[[ "$output" == *"part=root:100%:btrfs:"* ]]
+}
+
+@test "plan emmc btrfs with swap: boot + swap + root" {
+	run install_plan_layout emmc btrfs 0 $(( 16 * GIB )) 512 1
+	[[ "$output" == *"part=boot:512MiB:ext4:boot"* ]]
+	[[ "$output" == *"part=swap:256MiB:swap:"* ]]
+	[[ "$output" == *"part=root:100%:btrfs:"* ]]
+}
+
+@test "plan emmc ext4 has no swap partition (swapfile stays on ext4)" {
+	run install_plan_layout emmc ext4 0 $(( 16 * GIB )) 512 1
+	[[ "$output" != *"part=swap:"* ]]
+}
+
+# --- rootfs-only layouts (boot lives elsewhere) ------------------------------
+
+@test "plan sd: single boot-flagged root partition" {
+	run install_plan_layout sd ext4 0 $(( 500 * GIB )) 512 0
+	[[ "$output" == *"part=root:100%:ext4:boot"* ]]
+}
+
+@test "plan sd on >2TiB disk: upgrades to gpt (build#9794)" {
+	run install_plan_layout sd ext4 0 $(( 4 * TIB )) 512 0
+	[[ "$output" == *"table=gpt"* ]]
+}
+
+@test "plan mtd/ufs: rootfs-only, boot flag set" {
+	run install_plan_layout mtd ext4 0 $(( 250 * GIB )) 512 0
+	[[ "$output" == *"part=root:100%:ext4:boot"* ]]
+	run install_plan_layout ufs f2fs 0 $(( 250 * GIB )) 512 0
+	[[ "$output" == *"part=root:100%:f2fs:boot"* ]]
+}
+
+# --- errors ------------------------------------------------------------------
+
+@test "plan: unknown boot mode fails with usage code" {
+	run install_plan_layout bogus ext4 0 $(( 16 * GIB )) 512 0
+	[ "$status" -eq 64 ]
+}

--- a/tests/bats/transfer.bats
+++ b/tests/bats/transfer.bats
@@ -1,0 +1,42 @@
+#!/usr/bin/env bats
+#
+# Tests for install_transfer_rootfs progress reporting. The gauge must track
+# rsync's real byte progress (monotonic 0..100, reaching 100) rather than an
+# out-of-sync line count. No privileges needed - it rsyncs a temp tree.
+
+setup() {
+	declare -A module_options
+	source "${BATS_TEST_DIRNAME}/../../tools/modules/functions/module_install_engine.sh"
+	INSTALL_LOG=/dev/null
+	SRC="$BATS_TEST_TMPDIR/src"; DEST="$BATS_TEST_TMPDIR/dest"
+	EX="$BATS_TEST_TMPDIR/exclude"
+	mkdir -p "$SRC/sub" "$DEST"
+	: >"$EX"
+	local i
+	for i in $(seq 1 24); do head -c 1048576 /dev/urandom >"$SRC/f$i"; done
+	for i in $(seq 1 8);  do head -c 1048576 /dev/urandom >"$SRC/sub/g$i"; done
+}
+
+@test "transfer: progress is monotonic non-decreasing and reaches 100" {
+	install_transfer_rootfs "$DEST" "$EX" 1 "$SRC/" >"$BATS_TEST_TMPDIR/prog"
+	[ -s "$BATS_TEST_TMPDIR/prog" ]
+	# every value is an integer 0..100
+	run awk '$1!~/^[0-9]+$/ || $1<0 || $1>100 {exit 1}' "$BATS_TEST_TMPDIR/prog"
+	[ "$status" -eq 0 ]
+	# non-decreasing
+	run awk 'NR>1 && $1<prev {exit 1} {prev=$1}' "$BATS_TEST_TMPDIR/prog"
+	[ "$status" -eq 0 ]
+	# actually reaches completion
+	grep -qx 100 "$BATS_TEST_TMPDIR/prog"
+}
+
+@test "transfer: actually copies the tree and returns success" {
+	run install_transfer_rootfs "$DEST" "$EX" 1 "$SRC/"
+	[ "$status" -eq 0 ]
+	[ "$(find "$DEST" -type f | wc -l)" -eq 32 ]
+}
+
+@test "transfer: missing destination fails cleanly" {
+	run install_transfer_rootfs "$BATS_TEST_TMPDIR/nope" "$EX" 1 "$SRC/"
+	[ "$status" -eq 70 ]   # INSTALL_EX_TRANSFER
+}

--- a/tests/bats/transfer.bats
+++ b/tests/bats/transfer.bats
@@ -1,8 +1,8 @@
 #!/usr/bin/env bats
 #
-# Tests for install_transfer_rootfs progress reporting. The gauge must track
-# rsync's real byte progress (monotonic 0..100, reaching 100) rather than an
-# out-of-sync line count. No privileges needed - it rsyncs a temp tree.
+# Tests for install_transfer_rootfs progress reporting. The gauge tracks rsync's
+# real file-count progress (to-chk=REMAIN/TOTAL from --info=progress2, monotonic
+# 0..100, reaching 100). No privileges needed - it rsyncs a temp tree.
 
 setup() {
 	declare -A module_options

--- a/tools/json/config.system.json
+++ b/tools/json/config.system.json
@@ -1026,15 +1026,15 @@
                     "sub": [
                         {
                             "id": "STO001",
-                            "description": "Copy the running Armbian system to another device",
+                            "description": "Install the running system to internal media (eMMC/NVMe/SATA/USB/UFS, or Windows dual-boot)",
                             "short": "Install",
-                            "module": "module_generic",
+                            "module": "module_partitioner",
                             "command": [
-                                "armbian-install"
+                                "module_partitioner run"
                             ],
                             "status": "Preview",
                             "author": "@igorpecovnik",
-                            "condition": "[[ -f /sbin/armbian-install || -f /usr/bin/armbian-install ]]",
+                            "condition": "",
                             "help": "Clones your current live OS installation - Keeps your settings, configuration, installed."
                         },
                         {

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -153,6 +153,17 @@ install_plan_layout() {
 			parts+=("esp:512MiB:vfat:esp,boot")
 			parts+=("root:100%:${fs}:")
 			;;
+		bios)
+			# x86 legacy BIOS install with GRUB (grub-pc). On GPT a 1MiB BIOS boot
+			# partition is required for GRUB to embed core.img; on MBR it embeds in
+			# the post-MBR gap, so the root partition just carries the boot flag.
+			if [[ "$table" == "gpt" ]]; then
+				parts+=("biosboot:1MiB::bios_grub")
+				parts+=("root:100%:${fs}:")
+			else
+				parts+=("root:100%:${fs}:boot")
+			fi
+			;;
 		emmc)
 			if [[ "$fs" == "btrfs" || "$fs" == "f2fs" ]]; then
 				# u-boot cannot read btrfs/f2fs -> a dedicated ext4 /boot.
@@ -251,6 +262,10 @@ install_apply_partitions() {
 			else
 				parted -s "$device" set "$idx" boot on >>"$INSTALL_LOG" 2>&1 || true
 			fi
+		fi
+		# BIOS boot partition on GPT: where GRUB embeds core.img (no filesystem).
+		if [[ ",$flags," == *",bios_grub,"* ]]; then
+			parted -s "$device" set "$idx" bios_grub on >>"$INSTALL_LOG" 2>&1 || true
 		fi
 
 		[[ "$size" != "100%" ]] && start_mib=$(( start_mib + ${size%MiB} ))
@@ -454,6 +469,20 @@ install_verify_fstab() {
 
 # ---- bootloader -------------------------------------------------------------
 
+install_bootloader_available() {
+	# install_bootloader_available <boot_mode>
+	# True if the bootloader method for this mode can actually run on this system.
+	# Called BEFORE any destructive step so we never wipe a disk we can't make
+	# bootable (e.g. a u-boot mode on x86, which has no write_uboot_platform).
+	case "$1" in
+		uefi|uefi-dualboot|bios) command -v grub-install >/dev/null 2>&1 ;;
+		emmc|sd) [[ "$(type -t write_uboot_platform)" == function ]] ;;
+		mtd)     [[ "$(type -t write_uboot_platform_mtd)" == function ]] ;;
+		ufs)     [[ "$(type -t write_uboot_platform_ufs)" == function ]] ;;
+		*)       return 1 ;;
+	esac
+}
+
 install_write_bootloader() {
 	# install_write_bootloader <boot_mode> <target_disk> <rootfs_mount> [uboot_dir] [mtd_list] [ufs_boot_lun]
 	# Dispatches to the board-provided u-boot hooks (sourced at runtime from
@@ -462,7 +491,9 @@ install_write_bootloader() {
 	local boot_mode="$1" disk="$2" rootfs="$3" uboot_dir="${4:-${DIR:-}}" mtd_list="${5:-}" ufs_boot="${6:-}"
 	case "$boot_mode" in
 		uefi)
-			install_grub_install "$rootfs" ;;
+			install_grub_install "$rootfs" solo ;;
+		bios)
+			install_grub_install "$rootfs" bios "$disk" ;;
 		mtd)
 			[[ "$(type -t write_uboot_platform_mtd)" == function ]] || { install_log ERR "bootloader: write_uboot_platform_mtd missing"; return "$INSTALL_EX_BOOTLOADER"; }
 			write_uboot_platform_mtd "$uboot_dir" "/dev/${mtd_list%% *}" "$INSTALL_LOG" "$mtd_list" \
@@ -481,30 +512,37 @@ install_write_bootloader() {
 }
 
 install_grub_install() {
-	# install_grub_install <rootfs_mount> [mode]
+	# install_grub_install <rootfs_mount> [mode] [disk]
 	# Bind-mount /dev,/proc,/sys and run grub-install + grub-mkconfig in the
-	# target. The ESP must already be mounted at <rootfs>/boot/efi.
-	#   mode=solo     (default) sole-OS install: --removable, so it boots even
-	#                 without a working NVRAM entry (typical for wiped disks).
+	# target.
+	#   mode=solo     (default) sole-OS UEFI install: --removable, so it boots
+	#                 even without a working NVRAM entry (typical for wiped disks).
+	#                 The ESP must already be mounted at <rootfs>/boot/efi.
 	#   mode=dualboot keep an existing OS (Windows): NO --removable (leave the
 	#                 /EFI/BOOT fallback alone) and turn on os-prober so the
-	#                 GRUB menu offers the other OS.
-	local rootfs="$1" mode="${2:-solo}" arch_target
-	mountpoint -q "$rootfs/boot/efi" || { install_log ERR "grub: ESP not mounted at $rootfs/boot/efi"; return "$INSTALL_EX_BOOTLOADER"; }
+	#                 GRUB menu offers the other OS. ESP mounted at /boot/efi.
+	#   mode=bios     x86 legacy BIOS: grub-pc to <disk>'s MBR, no ESP.
+	local rootfs="$1" mode="${2:-solo}" disk="${3:-}" arch_target grub_cmd
+	if [[ "$mode" == bios ]]; then
+		[[ -b "$disk" ]] || { install_log ERR "grub: bios install needs a disk"; return "$INSTALL_EX_BOOTLOADER"; }
+		grub_cmd="grub-install --target=i386-pc --recheck $disk"
+	else
+		mountpoint -q "$rootfs/boot/efi" || { install_log ERR "grub: ESP not mounted at $rootfs/boot/efi"; return "$INSTALL_EX_BOOTLOADER"; }
+		arch_target=$([[ "$(arch)" == x86_64 ]] && echo "x86_64-efi" || echo "arm64-efi")
+		grub_cmd="grub-install --target=$arch_target --efi-directory=/boot/efi --bootloader-id=Armbian"
+		if [[ "$mode" == dualboot ]]; then
+			install_enable_os_prober "$rootfs"
+		else
+			grub_cmd+=" --removable"
+		fi
+	fi
 	mkdir -p "$rootfs"/{dev,proc,sys}
 	mount --bind /dev "$rootfs/dev"
 	mount --make-rslave --bind /dev/pts "$rootfs/dev/pts"
 	mount --bind /proc "$rootfs/proc"
 	mount --make-rslave --rbind /sys "$rootfs/sys"
-	arch_target=$([[ "$(arch)" == x86_64 ]] && echo "x86_64-efi" || echo "arm64-efi")
-	local grub_opts="--target=$arch_target --efi-directory=/boot/efi --bootloader-id=Armbian"
-	if [[ "$mode" == dualboot ]]; then
-		install_enable_os_prober "$rootfs"
-	else
-		grub_opts+=" --removable"
-	fi
 	local rc=0
-	chroot "$rootfs" /bin/bash -c "grub-install $grub_opts" >>"$INSTALL_LOG" 2>&1 || rc=1
+	chroot "$rootfs" /bin/bash -c "$grub_cmd" >>"$INSTALL_LOG" 2>&1 || rc=1
 	chroot "$rootfs" /bin/bash -c "grub-mkconfig -o /boot/grub/grub.cfg" >>"$INSTALL_LOG" 2>&1 || rc=1
 	# Unwind the API mounts regardless of outcome.
 	awk -v r="$rootfs/sys" '$2 ~ "^"r {print $2}' /proc/mounts | sort -r | xargs -r umount -n 2>/dev/null
@@ -662,6 +700,9 @@ install_run_scenario() {
 	export LC_ALL=C LANG=C
 	[[ -b "$disk" ]] || { install_log ERR "scenario: '$disk' is not a block device"; return "$INSTALL_EX_NODEV"; }
 	[[ -f "$exclude" ]] || { install_log ERR "scenario: exclude file '$exclude' missing"; return "$INSTALL_EX_TRANSFER"; }
+	# Pre-flight: confirm we can make the target bootable BEFORE wiping anything.
+	install_bootloader_available "$boot_mode" \
+		|| { install_log ERR "scenario: no bootloader method for '$boot_mode' on this system (u-boot hooks or grub-install missing) - refusing to modify $disk"; return "$INSTALL_EX_BOOTLOADER"; }
 
 	# Geometry + firmware context feed the pure planner.
 	local cap sec is_uefi=0 has_swap=0

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -705,9 +705,12 @@ install_run_scenario() {
 	export LC_ALL=C LANG=C
 	[[ -b "$disk" ]] || { install_log ERR "scenario: '$disk' is not a block device"; return "$INSTALL_EX_NODEV"; }
 	[[ -f "$exclude" ]] || { install_log ERR "scenario: exclude file '$exclude' missing"; return "$INSTALL_EX_TRANSFER"; }
-	# Pre-flight: confirm we can make the target bootable BEFORE wiping anything.
+	# Pre-flight: confirm we can make the target bootable AND format it BEFORE
+	# wiping anything - never destroy a disk we cannot finish installing to.
 	install_bootloader_available "$boot_mode" \
 		|| { install_log ERR "scenario: no bootloader method for '$boot_mode' on this system (u-boot hooks or grub-install missing) - refusing to modify $disk"; return "$INSTALL_EX_BOOTLOADER"; }
+	install_check_fs_tools "$fs" >/dev/null \
+		|| { install_log ERR "scenario: mkfs.$fs not installed (need $(_install_fs_pkg "$fs")) - refusing to modify $disk"; return "$INSTALL_EX_TOOL"; }
 
 	# Geometry + firmware context feed the pure planner.
 	local cap sec is_uefi=0 has_swap=0
@@ -814,6 +817,8 @@ install_run_dualboot() {
 	[[ -f "$exclude" ]] || { install_log ERR "dualboot: exclude '$exclude' missing"; return "$INSTALL_EX_TRANSFER"; }
 	[[ "$want" =~ ^[0-9]+$ && "$want" -gt 0 ]] || { install_log ERR "dualboot: bad size '$want'"; return "$INSTALL_EX_USAGE"; }
 	command -v ntfsresize >/dev/null 2>&1 || { install_log ERR "dualboot: ntfsresize missing - install the ntfs-3g package"; return "$INSTALL_EX_TOOL"; }
+	install_check_fs_tools "$fs" >/dev/null || { install_log ERR "dualboot: mkfs.$fs not installed (need $(_install_fs_pkg "$fs")) - refusing to modify $disk"; return "$INSTALL_EX_TOOL"; }
+	command -v grub-install >/dev/null 2>&1 || { install_log ERR "dualboot: grub-install missing - refusing to modify $disk"; return "$INSTALL_EX_BOOTLOADER"; }
 
 	# 1) locate the existing Windows ESP + NTFS volume (nothing is touched yet).
 	local wi esp win

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -926,9 +926,24 @@ install_run_scenario() {
 		# Point the board's boot env at the new root (u-boot scenarios only; GRUB
 		# modes are handled by grub-mkconfig).
 		case "$boot_mode" in
-			emmc|sd|mtd|ufs)
+			emmc|mtd|ufs)
 				local env_file="$mp/boot/armbianEnv.txt"
 				[[ -f "$env_file" ]] && install_rewrite_bootenv "$env_file" "$root_uuid" "$fs" ;;
+			sd)
+				# Boot stays on the current media (the SD/eMMC the board booted
+				# from); only the rootfs moved to $disk. Point the CURRENT media's
+				# boot env at the new root so u-boot keeps loading the kernel from it
+				# but mounts rootfs from $disk. The target has no /boot of its own,
+				# so without this the board would keep booting its old rootfs.
+				local env_file="/boot/armbianEnv.txt"
+				if [[ -f "$env_file" ]]; then
+					install_rewrite_bootenv "$env_file" "$root_uuid" "$fs" \
+						|| { install_log ERR "scenario: failed to point current boot env ($env_file) at new root $root_uuid"; rc=$INSTALL_EX_BOOTCFG; break; }
+					install_log INFO "scenario: pointed current boot media ($env_file) at new root $root_uuid ($fs)"
+				else
+					install_log ERR "scenario: sd mode but current boot env ($env_file) is missing; cannot make $disk bootable"
+					rc=$INSTALL_EX_BOOTCFG; break
+				fi ;;
 		esac
 
 		# Rebuild the target initramfs so a module root fs (btrfs/f2fs) boots
@@ -938,8 +953,14 @@ install_run_scenario() {
 		echo 95
 		# ESP must be mounted before GRUB runs.
 		[[ -n "$esp_dev" ]] && { mount "$esp_dev" "$mp/boot/efi" || { rc=$INSTALL_EX_BOOTLOADER; break; }; }
-		install_write_bootloader "$boot_mode" "$disk" "$mp" "$uboot_dir" "${INSTALL_MTD_LIST:-}" "${INSTALL_UFS_BOOT_LUN:-}" \
-			|| { rc=$INSTALL_EX_BOOTLOADER; break; }
+		# In sd mode the bootloader already lives on the current boot media (left
+		# untouched) and the boot env there was rewired above; writing u-boot to
+		# $disk would target the wrong device - e.g. the Rockchip bootrom cannot
+		# load u-boot from NVMe/USB/SATA, so it would silently fail to boot.
+		if [[ "$boot_mode" != sd ]]; then
+			install_write_bootloader "$boot_mode" "$disk" "$mp" "$uboot_dir" "${INSTALL_MTD_LIST:-}" "${INSTALL_UFS_BOOT_LUN:-}" \
+				|| { rc=$INSTALL_EX_BOOTLOADER; break; }
+		fi
 
 		echo 99
 		# Refuse to declare success on an unbootable result. (sd mode boots from

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -109,17 +109,17 @@ install_detect_targets() {
 		# and device-mapper (dm-) nodes.
 		| select(.name | test("^(zram|ram|loop|sr|fd|dm-)[0-9-]") | not)
 		| { n: .name, t: (.tran // ""), sz: (.size // 0),
-		    ps: (."phy-sec" // 512), ro: (.rota // false), md: ((.model // "") | gsub("\t"; " ")) }
+			ps: (."phy-sec" // 512), ro: (.rota // false), md: ((.model // "") | gsub("\t"; " ")) }
 		| .role = ( if   (.n | test("^nvme"))     then "nvme"
-		            elif (.n | test("^mmcblk"))   then "mmc"
-		            elif (.n | test("^mtdblock")) then "mtd"
-		            elif (.t == "usb")            then "usb"
-		            elif (.t == "sata" or .t == "ata") then "sata"
-		            else "disk" end )
+			elif (.n | test("^mmcblk"))   then "mmc"
+			elif (.n | test("^mtdblock")) then "mtd"
+			elif (.t == "usb")            then "usb"
+			elif (.t == "sata" or .t == "ata") then "sata"
+			else "disk" end )
 		| [ .n, .role, (.sz|tostring), (.ps|tostring),
-		    (if .t  == "" then "-" else .t  end),
-		    (.ro|tostring),
-		    (if .md == "" then "-" else .md end) ]
+			(if .t  == "" then "-" else .t  end),
+			(.ro|tostring),
+			(if .md == "" then "-" else .md end) ]
 		| @tsv
 	'
 }
@@ -632,12 +632,12 @@ install_detect_windows() {
 	json="$(lsblk -b -po NAME,FSTYPE,PARTTYPENAME,SIZE --json "$disk" 2>/dev/null)"
 	esp="$(echo "$json" | jq -r '
 		[.blockdevices[]?.children[]?
-		 | select(((.parttypename // "") | test("EFI";"i")) or (.fstype == "vfat"))
-		 | .name] | first // empty')"
+			| select(((.parttypename // "") | test("EFI";"i")) or (.fstype == "vfat"))
+			| .name] | first // empty')"
 	win="$(echo "$json" | jq -r '
 		[.blockdevices[]?.children[]?
-		 | select(.fstype == "ntfs")]
-		 | sort_by(.size) | reverse | (.[0].name // empty)')"
+			| select(.fstype == "ntfs")]
+			| sort_by(.size) | reverse | (.[0].name // empty)')"
 	[[ -n "$esp" && -n "$win" ]] || { install_log ERR "detect_windows: no ESP+NTFS pair on $disk"; return "$INSTALL_EX_NODEV"; }
 	echo "esp=$esp"
 	echo "windows=$win"

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -33,8 +33,8 @@ module_options+=(
 #     (build#9454, #9794, #6905).
 #   * install_apply_partitions lays partitions in MiB units so alignment is
 #     valid on both 512-byte and 4Kn media (build#9454).
-#   * install_write_bootconfig always populates the target /boot and
-#     install_verify refuses an empty /boot -> unbootable installs
+#   * install_populate_boot always populates the target /boot and
+#     install_verify_boot_dir refuses an empty /boot -> unbootable installs
 #     (build#10099, #10064).
 #
 
@@ -140,7 +140,7 @@ install_plan_layout() {
 	#   table=gpt|msdos
 	#   part=<role>:<size>:<fstype>:<flags>       (one line per partition, in order)
 	# where size is an absolute "<N>MiB" or "100%" (fill), and flags is a
-	# comma-separated subset of {esp,boot} ("" for none). Pure: no device I/O.
+	# comma-separated subset of {esp,boot,bios_grub} ("" for none). Pure: no device I/O.
 	local boot_mode="$1" fs="$2" is_uefi="$3" cap="${4:-0}" sec="${5:-512}" has_swap="${6:-0}"
 	local table
 	table="$(install_table_type "$is_uefi" "$cap" "$sec")"
@@ -555,7 +555,14 @@ install_grub_install() {
 		grub_cmd="grub-install --target=i386-pc --recheck $disk"
 	else
 		mountpoint -q "$rootfs/boot/efi" || { install_log ERR "grub: ESP not mounted at $rootfs/boot/efi"; return "$INSTALL_EX_BOOTLOADER"; }
-		arch_target=$([[ "$(arch)" == x86_64 ]] && echo "x86_64-efi" || echo "arm64-efi")
+		case "$(uname -m)" in
+			x86_64) arch_target="x86_64-efi" ;;
+			i?86) arch_target="i386-efi" ;;
+			aarch64|arm64) arch_target="arm64-efi" ;;
+			arm*) arch_target="arm-efi" ;;
+			riscv64) arch_target="riscv64-efi" ;;
+			*) install_log ERR "grub: unsupported UEFI architecture $(uname -m)"; return "$INSTALL_EX_BOOTLOADER" ;;
+		esac
 		grub_cmd="grub-install --target=$arch_target --efi-directory=/boot/efi --bootloader-id=Armbian"
 		if [[ "$mode" == dualboot ]]; then
 			install_enable_os_prober "$rootfs"
@@ -650,7 +657,10 @@ install_enable_os_prober() {
 	# disables os-prober by default; re-enable it via the armbian drop-in.
 	local rootfs="$1"
 	mkdir -p "$rootfs/etc/default/grub.d"
-	echo "GRUB_DISABLE_OS_PROBER=false" >>"$rootfs/etc/default/grub.d/98-armbian.cfg"
+	local cfg="$rootfs/etc/default/grub.d/98-armbian.cfg"
+	# idempotent: repeated installs must not accumulate duplicate lines
+	grep -qxF "GRUB_DISABLE_OS_PROBER=false" "$cfg" 2>/dev/null \
+		|| echo "GRUB_DISABLE_OS_PROBER=false" >>"$cfg"
 	command -v os-prober >/dev/null 2>&1 || chroot "$rootfs" /bin/bash -c "command -v os-prober" >/dev/null 2>&1 \
 		|| install_log WARN "os-prober not present in target; Windows may be missing from the GRUB menu"
 }

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -562,6 +562,9 @@ install_grub_install() {
 	local rc=0
 	chroot "$rootfs" /bin/bash -c "$grub_cmd" >>"$INSTALL_LOG" 2>&1 || rc=1
 	chroot "$rootfs" /bin/bash -c "grub-mkconfig -o /boot/grub/grub.cfg" >>"$INSTALL_LOG" 2>&1 || rc=1
+	# os-prober is unreliable inside the install chroot (it often misses Windows),
+	# so also regenerate grub.cfg once on the first real boot.
+	install_setup_grub_firstboot "$rootfs"
 	# Unwind the API mounts regardless of outcome.
 	awk -v r="$rootfs/sys" '$2 ~ "^"r {print $2}' /proc/mounts | sort -r | xargs -r umount -n 2>/dev/null
 	umount "$rootfs/proc" 2>/dev/null
@@ -602,6 +605,34 @@ install_update_initramfs() {
 	umount "$rootfs/dev" 2>/dev/null
 	[[ "$rc" == 0 ]] || install_log WARN "update-initramfs failed in target; $fs root may not boot"
 	return 0
+}
+
+install_setup_grub_firstboot() {
+	# install_setup_grub_firstboot <rootfs_mount>
+	# Install a one-shot systemd unit that runs update-grub on the first real
+	# boot, then removes itself - so os-prober picks up other OSes (Windows) that
+	# it missed while running in the install chroot.
+	local rootfs="$1"
+	[[ -d "$rootfs/etc/systemd/system" ]] || return 0
+	cat >"$rootfs/etc/systemd/system/armbian-grub-update.service" <<-'EOF'
+		[Unit]
+		Description=Regenerate GRUB config on first boot (detect other OSes)
+		ConditionPathExists=/usr/sbin/update-grub
+		After=multi-user.target
+
+		[Service]
+		Type=oneshot
+		ExecStart=/usr/sbin/update-grub
+		ExecStartPost=-/usr/bin/systemctl --no-reload disable armbian-grub-update.service
+		ExecStartPost=-/bin/rm -f /etc/systemd/system/armbian-grub-update.service
+
+		[Install]
+		WantedBy=multi-user.target
+	EOF
+	# Enable via a wants symlink (chroot `systemctl enable` is unreliable).
+	mkdir -p "$rootfs/etc/systemd/system/multi-user.target.wants"
+	ln -sf ../armbian-grub-update.service \
+		"$rootfs/etc/systemd/system/multi-user.target.wants/armbian-grub-update.service"
 }
 
 install_enable_os_prober() {

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -729,11 +729,14 @@ install_shrink_windows() {
 	pnum="$(grep -oE '[0-9]+$' <<<"$win")"
 	start_b="$(parted -sm "$disk" unit B print 2>/dev/null | awk -F: -v p="$pnum" '$1==p {gsub("B","",$2); print $2}')"
 	[[ -n "$start_b" ]] || { install_log ERR "shrink: cannot read start of partition $pnum"; return "$INSTALL_EX_PARTITION"; }
-	# Leave 16MiB slack so the partition end sits safely past the shrunk fs.
+	# Leave 16MiB slack past the shrunk fs, then round the end UP to a 1 MiB
+	# boundary so the partition created in the freed space starts aligned
+	# (a misaligned start makes parted warn and prompt, and hurts performance).
 	new_end_b=$(( start_b + new_bytes + 16 * 1024 * 1024 ))
+	new_end_b=$(( (new_end_b + 1048575) / 1048576 * 1048576 ))
 	# parted refuses to shrink a partition non-interactively even with --script;
-	# ---pretend-input-tty lets us answer its "are you sure?" prompt with "Yes".
-	printf 'Yes\n' | parted ---pretend-input-tty "$disk" unit B resizepart "$pnum" "${new_end_b}B" >>"$INSTALL_LOG" 2>&1 \
+	# ---pretend-input-tty answers its Yes/No prompts (data-loss, closest-location).
+	printf 'Yes\nYes\n' | parted ---pretend-input-tty "$disk" unit B resizepart "$pnum" "${new_end_b}B" >>"$INSTALL_LOG" 2>&1 \
 		|| { install_log ERR "shrink: resizepart $pnum to ${new_end_b}B failed"; return "$INSTALL_EX_PARTITION"; }
 	partprobe "$disk" >>"$INSTALL_LOG" 2>&1 || true
 	udevadm settle >>"$INSTALL_LOG" 2>&1 || true
@@ -745,29 +748,39 @@ install_create_free_partition() {
 	# Does NOT relabel or wipe - existing partitions are preserved.
 	local disk="$1" fs="$2" hint
 	hint="$(_install_parted_fs_hint "$fs")"
-	# Largest free block (MiB) from parted's free-space report.
-	local fstart fend fsize best_start="" best_size=0 line
+	# Largest free block (MiB) from parted's free-space report - track its END too.
+	local fstart fend fsize best_start="" best_end="" best_size=0
 	while IFS=: read -r _ fstart fend fsize _; do
 		[[ "$fsize" == *MiB ]] || continue
-		local s="${fstart%MiB}" z="${fsize%MiB}"
-		s="${s%.*}"; z="${z%.*}"
-		if (( z > best_size )); then best_size="$z"; best_start="$s"; fi
+		local s="${fstart%MiB}" e="${fend%MiB}" z="${fsize%MiB}"
+		s="${s%.*}"; e="${e%.*}"; z="${z%.*}"
+		if (( z > best_size )); then best_size="$z"; best_start="$s"; best_end="$e"; fi
 	done < <(parted -sm "$disk" unit MiB print free 2>/dev/null | grep ':free;$')
 	[[ -n "$best_start" ]] || { install_log ERR "create_free: no free space on $disk"; return "$INSTALL_EX_NOSPACE"; }
 
+	# Record existing partition numbers: parted numbers by creation order but
+	# LISTS by position, so "the last line" is the wrong partition when the free
+	# space sits before a trailing partition (e.g. a Windows recovery at the disk
+	# end). Diff before/after to find the number that was actually created.
+	local before_nums
+	before_nums="$(parted -sm "$disk" print 2>/dev/null | awk -F: '/^[0-9]/{print $1}')"
+
+	# Fill exactly the free region (best_start..best_end), NOT 100% - 100% would
+	# collide with a trailing partition and force parted to clamp/prompt.
 	local -a mkpart_args=(mkpart primary)
 	[[ -n "$hint" ]] && mkpart_args+=("$hint")
-	mkpart_args+=("${best_start}MiB" "100%")
-	# ---pretend-input-tty + "Yes" accepts parted's alignment adjustment
-	# ("the closest location we can manage is ...") which --script would reject.
-	printf 'Yes\n' | parted ---pretend-input-tty -a optimal "$disk" unit MiB "${mkpart_args[@]}" >>"$INSTALL_LOG" 2>&1 \
+	mkpart_args+=("${best_start}MiB" "${best_end}MiB")
+	printf 'Yes\nYes\n' | parted ---pretend-input-tty -a optimal "$disk" unit MiB "${mkpart_args[@]}" >>"$INSTALL_LOG" 2>&1 \
 		|| { install_log ERR "create_free: mkpart failed"; return "$INSTALL_EX_PARTITION"; }
 	partprobe "$disk" >>"$INSTALL_LOG" 2>&1 || true
 	udevadm settle >>"$INSTALL_LOG" 2>&1 || true
 
-	# The new partition is the highest-numbered one.
-	local newnum
-	newnum="$(parted -sm "$disk" print 2>/dev/null | awk -F: '/^[0-9]/ {n=$1} END{print n}')"
+	# The new partition is the number that is present now but was not before.
+	local n newnum=""
+	while IFS= read -r n; do
+		grep -qxF "$n" <<<"$before_nums" || { newnum="$n"; break; }
+	done < <(parted -sm "$disk" print 2>/dev/null | awk -F: '/^[0-9]/{print $1}')
+	[[ -n "$newnum" ]] || { install_log ERR "create_free: cannot identify the new partition"; return "$INSTALL_EX_PARTITION"; }
 	echo "$(_install_part_dev "$disk" "$newnum")"
 }
 

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -460,7 +460,11 @@ install_verify_boot_dir() {
 	compgen -G "$d/Image*"  >/dev/null 2>&1 && have_kernel=1
 	compgen -G "$d/zImage*" >/dev/null 2>&1 && have_kernel=1
 	compgen -G "$d/uImage*" >/dev/null 2>&1 && have_kernel=1
-	[[ -f "$d/boot.scr" || -f "$d/boot.cmd" || -f "$d/extlinux/extlinux.conf" || -d "$d/grub" ]] && have_script=1
+	# Recognise every boot mechanism Armbian ships: boot.scr/boot.cmd (most
+	# u-boot), boot.ini (amlogic/odroid), uEnv.txt (k3/TI and others),
+	# extlinux.conf (distro boot), grub (x86/UEFI).
+	[[ -f "$d/boot.scr" || -f "$d/boot.cmd" || -f "$d/boot.ini" || -f "$d/uEnv.txt" \
+		|| -f "$d/extlinux/extlinux.conf" || -d "$d/grub" ]] && have_script=1
 	if (( have_kernel == 0 || have_script == 0 )); then
 		install_log ERR "verify: '$d' is not bootable (kernel=$have_kernel script=$have_script)"
 		return "$INSTALL_EX_VERIFY"

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -579,8 +579,11 @@ install_shrink_windows() {
 	# Shrink the NTFS filesystem, then pull the GPT partition end in to match.
 	# The volume must be clean (run chkdsk in Windows first) or ntfsresize aborts.
 	local disk="$1" win="$2" new_bytes="$3"
-	yes | ntfsresize -f --size "$new_bytes" "$win" >>"$INSTALL_LOG" 2>&1 \
-		|| { install_log ERR "shrink: ntfsresize of $win to $new_bytes failed (is the volume clean?)"; return "$INSTALL_EX_PARTITION"; }
+	# Feed the "Are you sure?" answer with a here-string, NOT `yes |`: an infinite
+	# `yes` producer dies of SIGPIPE when ntfsresize exits, which under a caller's
+	# `set -o pipefail` would mask ntfsresize's real (successful) exit code.
+	ntfsresize -f --size "$new_bytes" "$win" <<<'y' >>"$INSTALL_LOG" 2>&1 \
+		|| { install_log ERR "shrink: ntfsresize of $win to $new_bytes failed (is the volume clean? boot Windows and disable Fast Startup / run chkdsk)"; return "$INSTALL_EX_PARTITION"; }
 
 	local pnum start_b new_end_b
 	pnum="$(grep -oE '[0-9]+$' <<<"$win")"

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -412,23 +412,20 @@ install_gen_fstab() {
 }
 
 install_populate_boot() {
-	# install_populate_boot <target_rootfs_mount> [target_boot_mount]
-	# Ensure the target has a non-empty /boot. When a separate boot partition is
-	# mounted, copy the running /boot into it; otherwise ensure /boot exists in
-	# the rootfs. This is the guard against build#10099 (empty /boot).
-	local rootfs="$1" bootmnt="${2:-}"
+	# install_populate_boot <target_rootfs_mount> [copy:0|1] [src]
+	# Sync the running /boot into the target's /boot. The main rootfs rsync
+	# excludes /boot, so this is what actually places the kernel/dtb/boot script -
+	# onto a separate boot partition if one is mounted at <rootfs>/boot, otherwise
+	# into the rootfs itself. copy=0 leaves /boot empty (ARM "sd" mode: boot stays
+	# on the removable media). Guard against build#10099 (empty /boot).
+	local rootfs="$1" copy="${2:-1}" src="${3:-/boot}"
 	[[ -d "$rootfs" ]] || { install_log ERR "populate_boot: rootfs '$rootfs' missing"; return "$INSTALL_EX_BOOTCFG"; }
-	if [[ -n "$bootmnt" ]]; then
-		# Separate boot partition: copy the running /boot onto it.
-		[[ -d "$bootmnt" ]] || { install_log ERR "populate_boot: '$bootmnt' missing"; return "$INSTALL_EX_BOOTCFG"; }
-		rsync -aqx /boot/ "$bootmnt"/ >>"$INSTALL_LOG" 2>&1 \
-			|| { install_log ERR "populate_boot: copy to $bootmnt failed"; return "$INSTALL_EX_BOOTCFG"; }
-	else
-		# No separate boot partition: /boot rides inside the rootfs. The rsync of
-		# / already carried it (unless the exclude list dropped it), so just make
-		# sure the mount point exists for the bind/verify steps.
-		mkdir -p "$rootfs/boot"
-	fi
+	mkdir -p "$rootfs/boot"
+	[[ "$copy" == "1" ]] || return 0
+	# No -x here: on ARM /boot is often a separate mount, and one-filesystem would
+	# skip its contents. Exclude a mounted ESP (that is handled separately).
+	rsync -aq --exclude 'efi/**' "$src"/ "$rootfs/boot"/ >>"$INSTALL_LOG" 2>&1 \
+		|| { install_log ERR "populate_boot: copy $src -> $rootfs/boot failed"; return "$INSTALL_EX_BOOTCFG"; }
 	return 0
 }
 
@@ -734,9 +731,16 @@ install_run_scenario() {
 	[[ -b "$root_dev" ]] || { install_log ERR "scenario: no root partition created"; return "$INSTALL_EX_PARTITION"; }
 	install_make_filesystems "$mkfs_map" || return "$INSTALL_EX_FORMAT"
 
+	# The shipped exclude list drops /boot from the main rootfs rsync (it belongs
+	# on its own partition/tree, synced separately below). /boot is populated into
+	# the target unless boot stays on the removable media (classic ARM "sd" mode).
+	local copy_boot=1
+	[[ "$boot_mode" == sd ]] && copy_boot=0
+
 	# Mount the freshly-formatted target.
 	local mp; mp="$(mktemp -d /mnt/armbian-install.XXXXXX)" || return "$INSTALL_EX_TRANSFER"
 	mount "$root_dev" "$mp" || { install_log ERR "scenario: mount root failed"; rmdir "$mp"; return "$INSTALL_EX_TRANSFER"; }
+	# A separate boot partition mounts at /boot; /boot is then synced onto it.
 	if [[ -n "$boot_dev" ]]; then mkdir -p "$mp/boot"; mount "$boot_dev" "$mp/boot"; fi
 	if [[ -n "$esp_dev" ]]; then mkdir -p "$mp/boot/efi"; fi
 
@@ -744,7 +748,7 @@ install_run_scenario() {
 	local rc=0
 	while :; do
 		install_transfer_rootfs "$mp" "$exclude" || { rc=$INSTALL_EX_TRANSFER; break; }
-		install_populate_boot "$mp" "${boot_dev:+$mp/boot}" || { rc=$INSTALL_EX_BOOTCFG; break; }
+		install_populate_boot "$mp" "$copy_boot" || { rc=$INSTALL_EX_BOOTCFG; break; }
 
 		# fstab from the real, freshly-created UUIDs.
 		local root_uuid boot_uuid="" esp_uuid=""
@@ -755,19 +759,22 @@ install_run_scenario() {
 			|| { rc=$INSTALL_EX_BOOTCFG; break; }
 		grep -q '^tmpfs.*swap' /etc/fstab 2>/dev/null && grep swap /etc/fstab >>"$mp/etc/fstab"
 
-		# Point the board's boot env at the new root (u-boot scenarios only).
-		if [[ "$boot_mode" != uefi ]]; then
-			local env_file="$mp/boot/armbianEnv.txt"
-			[[ -f "$env_file" ]] && install_rewrite_bootenv "$env_file" "$root_uuid" "$fs"
-		fi
+		# Point the board's boot env at the new root (u-boot scenarios only; GRUB
+		# modes are handled by grub-mkconfig).
+		case "$boot_mode" in
+			emmc|sd|mtd|ufs)
+				local env_file="$mp/boot/armbianEnv.txt"
+				[[ -f "$env_file" ]] && install_rewrite_bootenv "$env_file" "$root_uuid" "$fs" ;;
+		esac
 
 		# ESP must be mounted before GRUB runs.
 		[[ -n "$esp_dev" ]] && { mount "$esp_dev" "$mp/boot/efi" || { rc=$INSTALL_EX_BOOTLOADER; break; }; }
 		install_write_bootloader "$boot_mode" "$disk" "$mp" "$uboot_dir" "${INSTALL_MTD_LIST:-}" "${INSTALL_UFS_BOOT_LUN:-}" \
 			|| { rc=$INSTALL_EX_BOOTLOADER; break; }
 
-		# Refuse to declare success on an unbootable result.
-		install_verify_boot_dir "$mp/boot" || { rc=$INSTALL_EX_VERIFY; break; }
+		# Refuse to declare success on an unbootable result. (sd mode boots from
+		# the removable media, so the target has no local /boot to verify.)
+		[[ "$copy_boot" == 1 ]] && { install_verify_boot_dir "$mp/boot" || { rc=$INSTALL_EX_VERIFY; break; }; }
 		install_verify_fstab "$mp/etc/fstab" || { rc=$INSTALL_EX_VERIFY; break; }
 		break
 	done 2>>"$INSTALL_LOG"

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -617,28 +617,59 @@ install_enable_os_prober() {
 
 # ---- Windows dual-boot ------------------------------------------------------
 
+_install_windows_parts() {
+	# _install_windows_parts <lsblk_json>
+	# Pure: pick the ESP and the Windows system NTFS volume from lsblk --json.
+	# The Windows volume is the LARGEST NTFS partition EXCLUDING the small Windows
+	# recovery (WinRE) NTFS partition - so we shrink C:, never the recovery part.
+	# size is sorted with tonumber (lsblk may emit it as a string, and a string
+	# sort would rank 781MB above 63GB). Emits two lines: esp=<dev|> windows=<dev|>
+	local json="$1" esp win
+	esp="$(printf '%s' "$json" | jq -r '
+		[ .blockdevices[]?.children[]?
+		  | select(((.parttypename // "") | test("EFI";"i")) or (.fstype == "vfat"))
+		  | .name ] | first // empty')"
+	win="$(printf '%s' "$json" | jq -r '
+		[ .blockdevices[]?.children[]?
+		  | select(.fstype == "ntfs")
+		  | select(((.parttypename // "") | test("recovery"; "i")) | not) ]
+		| sort_by(.size | tonumber) | reverse | (.[0].name // empty)')"
+	printf 'esp=%s\nwindows=%s\n' "$esp" "$win"
+}
+
 install_detect_windows() {
-	# install_detect_windows <disk>
+	# install_detect_windows <disk> [lsblk_json]
 	# On a GPT disk carrying a Windows install, emit:
 	#   esp=<esp_partition>          existing EFI System Partition (reused)
-	#   windows=<ntfs_partition>     the largest NTFS (Microsoft basic data) part
-	# Returns INSTALL_EX_NODEV if the disk is not a Windows/UEFI layout.
-	local disk="$1"
-	[[ -b "$disk" ]] || return "$INSTALL_EX_NODEV"
-	# GPT is required for a UEFI Windows install.
-	parted -sm "$disk" print 2>/dev/null | grep -q '^/dev/.*:gpt:' || return "$INSTALL_EX_NODEV"
+	#   windows=<ntfs_partition>     the Windows system NTFS volume (not WinRE)
+	# Returns INSTALL_EX_NODEV if the disk is not a shrinkable Windows/UEFI layout.
+	local disk="$1" json="${2:-}"
+	if [[ -z "$json" ]]; then
+		[[ -b "$disk" ]] || return "$INSTALL_EX_NODEV"
+		# GPT is required for a UEFI Windows install.
+		parted -sm "$disk" print 2>/dev/null | grep -q '^/dev/.*:gpt:' || return "$INSTALL_EX_NODEV"
+		json="$(lsblk -b -po NAME,FSTYPE,PARTTYPENAME,SIZE --json "$disk" 2>/dev/null)"
+	fi
 
-	local json esp win
-	json="$(lsblk -b -po NAME,FSTYPE,PARTTYPENAME,SIZE --json "$disk" 2>/dev/null)"
-	esp="$(echo "$json" | jq -r '
-		[.blockdevices[]?.children[]?
-			| select(((.parttypename // "") | test("EFI";"i")) or (.fstype == "vfat"))
-			| .name] | first // empty')"
-	win="$(echo "$json" | jq -r '
-		[.blockdevices[]?.children[]?
-			| select(.fstype == "ntfs")]
-			| sort_by(.size) | reverse | (.[0].name // empty)')"
-	[[ -n "$esp" && -n "$win" ]] || { install_log ERR "detect_windows: no ESP+NTFS pair on $disk"; return "$INSTALL_EX_NODEV"; }
+	local esp win parts
+	parts="$(_install_windows_parts "$json")"
+	esp="$(sed -n 's/^esp=//p' <<<"$parts")"
+	win="$(sed -n 's/^windows=//p' <<<"$parts")"
+	if [[ -z "$esp" || -z "$win" ]]; then
+		# A "Microsoft basic data" partition that is not plain NTFS is almost
+		# always BitLocker-encrypted, which ntfsresize cannot shrink - say so.
+		local enc
+		enc="$(printf '%s' "$json" | jq -r '
+			[ .blockdevices[]?.children[]?
+			  | select(((.parttypename // "") | test("basic data"; "i")) and (.fstype != "ntfs"))
+			  | .name ] | first // empty')"
+		if [[ -n "$enc" ]]; then
+			install_log ERR "detect_windows: $enc is not plain NTFS (likely BitLocker); disable device encryption in Windows to enable dual-boot"
+		else
+			install_log ERR "detect_windows: no ESP+NTFS pair on $disk"
+		fi
+		return "$INSTALL_EX_NODEV"
+	fi
 	echo "esp=$esp"
 	echo "windows=$win"
 }

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -796,8 +796,6 @@ install_run_scenario() {
 	# Mount the freshly-formatted target.
 	local mp; mp="$(mktemp -d /mnt/armbian-install.XXXXXX)" || return "$INSTALL_EX_TRANSFER"
 	mount "$root_dev" "$mp" || { install_log ERR "scenario: mount root failed"; rmdir "$mp"; return "$INSTALL_EX_TRANSFER"; }
-	# A separate boot partition mounts at /boot; /boot is then synced onto it.
-	if [[ -n "$boot_dev" ]]; then mkdir -p "$mp/boot"; mount "$boot_dev" "$mp/boot"; fi
 	if [[ -n "$esp_dev" ]]; then mkdir -p "$mp/boot/efi"; fi
 
 	# One-shot loop so a failing step can `break` straight to teardown. The bar is
@@ -807,6 +805,14 @@ install_run_scenario() {
 	while :; do
 		install_transfer_rootfs "$mp" "$exclude" 1 / 0 90 || { rc=$INSTALL_EX_TRANSFER; break; }
 		echo 92
+		# A separate boot partition must be mounted before /boot is synced onto it;
+		# a silent mount failure would leave the boot partition empty (unbootable),
+		# mirroring the ESP mount guard below.
+		if [[ -n "$boot_dev" ]]; then
+			mkdir -p "$mp/boot"
+			mount "$boot_dev" "$mp/boot" \
+				|| { install_log ERR "scenario: mount boot partition $boot_dev failed"; rc=$INSTALL_EX_BOOTCFG; break; }
+		fi
 		install_populate_boot "$mp" "$copy_boot" || { rc=$INSTALL_EX_BOOTCFG; break; }
 
 		# fstab from the real, freshly-created UUIDs.

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -342,21 +342,26 @@ install_transfer_rootfs() {
 	# rsync / -> target with the exclude list, emitting integer percentages to
 	# progress_fd (default 1) for a gauge. Returns INSTALL_EX_TRANSFER on failure.
 	# src defaults to "/" (the running rootfs); overridable for tests.
-	local dest="$1" exclude="$2" pfd="${3:-1}" src="${4:-/}"
+	# lo/hi scale the emitted percentage into a band, so the caller can reserve
+	# the tail of the bar for the post-copy stages (grub, verify, ...).
+	local dest="$1" exclude="$2" pfd="${3:-1}" src="${4:-/}" lo="${5:-0}" hi="${6:-100}"
 	[[ -d "$dest" ]] || { install_log ERR "transfer: '$dest' is not a directory"; return "$INSTALL_EX_TRANSFER"; }
 	[[ -f "$exclude" ]] || { install_log ERR "transfer: exclude file '$exclude' missing"; return "$INSTALL_EX_TRANSFER"; }
 
-	# Use rsync's own overall byte percentage (--info=progress2) rather than
-	# counting output lines against a dry-run file count, which drifts out of
-	# sync. --no-inc-recursive builds the full file list first so the percentage
-	# is accurate and monotonic from the start (a short pause at 0% up front).
-	# progress2 rewrites its line with \r; split on \r, pull the "NN%" token.
+	# Track rsync's file-count progress (to-chk=REMAIN/TOTAL from --info=progress2)
+	# rather than its byte percentage: for a rootfs (mostly small files) the byte
+	# percentage rushes then crawls through the long small-file tail, while the
+	# file count advances linearly. --no-inc-recursive fixes TOTAL up front so the
+	# fraction is stable. progress2 rewrites its line with \r; split on \r.
 	local rc_file; rc_file="$(mktemp)"
 	{
 		rsync -ax --delete --info=progress2 --no-inc-recursive --exclude-from="$exclude" "$src" "$dest" \
 			| stdbuf -oL tr '\r' '\n' \
-			| stdbuf -oL grep --line-buffered -oE '[0-9]+%' \
-			| stdbuf -oL sed -u 's/%//' >&"$pfd"
+			| stdbuf -oL sed -u -n 's/.*to-chk=\([0-9]*\)\/\([0-9]*\).*/\1 \2/p' \
+			| stdbuf -oL awk -v lo="$lo" -v hi="$hi" '
+				{ if ($2 > 0) { p = lo + int((hi-lo)*($2-$1)/$2);
+				                if (p > hi) p = hi;
+				                if (p != last) { print p; fflush(); last = p } } }' >&"$pfd"
 		echo "${PIPESTATUS[0]}" >"$rc_file"
 	}
 	local rc; rc="$(cat "$rc_file")"; rm -f "$rc_file"
@@ -744,10 +749,13 @@ install_run_scenario() {
 	if [[ -n "$boot_dev" ]]; then mkdir -p "$mp/boot"; mount "$boot_dev" "$mp/boot"; fi
 	if [[ -n "$esp_dev" ]]; then mkdir -p "$mp/boot/efi"; fi
 
-	# One-shot loop so a failing step can `break` straight to teardown.
+	# One-shot loop so a failing step can `break` straight to teardown. The bar is
+	# staged: rsync fills 0-90, the remaining steps advance it to 100 so it never
+	# freezes at ~90% during /boot sync, grub-install and verification.
 	local rc=0
 	while :; do
-		install_transfer_rootfs "$mp" "$exclude" || { rc=$INSTALL_EX_TRANSFER; break; }
+		install_transfer_rootfs "$mp" "$exclude" 1 / 0 90 || { rc=$INSTALL_EX_TRANSFER; break; }
+		echo 92
 		install_populate_boot "$mp" "$copy_boot" || { rc=$INSTALL_EX_BOOTCFG; break; }
 
 		# fstab from the real, freshly-created UUIDs.
@@ -767,15 +775,18 @@ install_run_scenario() {
 				[[ -f "$env_file" ]] && install_rewrite_bootenv "$env_file" "$root_uuid" "$fs" ;;
 		esac
 
+		echo 95
 		# ESP must be mounted before GRUB runs.
 		[[ -n "$esp_dev" ]] && { mount "$esp_dev" "$mp/boot/efi" || { rc=$INSTALL_EX_BOOTLOADER; break; }; }
 		install_write_bootloader "$boot_mode" "$disk" "$mp" "$uboot_dir" "${INSTALL_MTD_LIST:-}" "${INSTALL_UFS_BOOT_LUN:-}" \
 			|| { rc=$INSTALL_EX_BOOTLOADER; break; }
 
+		echo 99
 		# Refuse to declare success on an unbootable result. (sd mode boots from
 		# the removable media, so the target has no local /boot to verify.)
 		[[ "$copy_boot" == 1 ]] && { install_verify_boot_dir "$mp/boot" || { rc=$INSTALL_EX_VERIFY; break; }; }
 		install_verify_fstab "$mp/etc/fstab" || { rc=$INSTALL_EX_VERIFY; break; }
+		echo 100
 		break
 	done 2>>"$INSTALL_LOG"
 
@@ -835,18 +846,22 @@ install_run_dualboot() {
 	mount "$root_dev" "$mp" || { install_log ERR "dualboot: mount root failed"; rmdir "$mp"; return "$INSTALL_EX_TRANSFER"; }
 	mkdir -p "$mp/boot/efi"
 	while :; do
-		install_transfer_rootfs "$mp" "$exclude" || { rc=$INSTALL_EX_TRANSFER; break; }
+		install_transfer_rootfs "$mp" "$exclude" 1 / 0 90 || { rc=$INSTALL_EX_TRANSFER; break; }
+		echo 92
 		install_populate_boot "$mp" || { rc=$INSTALL_EX_BOOTCFG; break; }
 		local root_uuid esp_uuid
 		root_uuid="$(install_uuid "$root_dev")"
 		esp_uuid="$(install_uuid "$esp")"
 		install_gen_fstab "$root_uuid" "$fs" "" ext4 "$esp_uuid" >"$mp/etc/fstab" || { rc=$INSTALL_EX_BOOTCFG; break; }
+		echo 95
 		mount "$esp" "$mp/boot/efi" || { install_log ERR "dualboot: mount ESP failed"; rc=$INSTALL_EX_BOOTLOADER; break; }
 		install_grub_install "$mp" dualboot || { rc=$INSTALL_EX_BOOTLOADER; break; }
+		echo 99
 		install_verify_boot_dir "$mp/boot" || { rc=$INSTALL_EX_VERIFY; break; }
 		install_verify_fstab "$mp/etc/fstab" || { rc=$INSTALL_EX_VERIFY; break; }
 		# The Windows volume must have survived intact.
 		[[ "$(blkid -s TYPE -o value "$win")" == ntfs ]] || { install_log ERR "dualboot: Windows NTFS vanished after install"; rc=$INSTALL_EX_VERIFY; break; }
+		echo 100
 		break
 	done 2>>"$INSTALL_LOG"
 

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -1,0 +1,608 @@
+# shellcheck shell=bash
+# This is a sourced armbian-config module fragment, not a standalone script.
+declare -A module_options
+module_options+=(
+	["module_install_engine,author"]="@igorpecovnik"
+	["module_install_engine,maintainer"]="@igorpecovnik"
+	["module_install_engine,feature"]="module_install_engine"
+	["module_install_engine,example"]="detect plan"
+	["module_install_engine,desc"]="Armbian installer engine (backend library, no UI)"
+	["module_install_engine,status"]="review"
+	["module_install_engine,doc_link"]="https://docs.armbian.com"
+	["module_install_engine,group"]="System"
+	["module_install_engine,port"]=""
+	["module_install_engine,arch"]=""
+)
+
+#
+# module_install_engine.sh - armbian-install backend.
+#
+# Pure, dialog-free, individually testable functions. Every function takes its
+# inputs as explicit arguments (or on stdin) and returns data on stdout or a
+# status code - nothing reaches into ambient globals. The dialog frontend
+# (module_partitioner.sh) and the non-interactive CLI both call into this file;
+# the bats suite under tests/bats/ sources it directly and drives the pure
+# functions with fixtures.
+#
+# Design notes / bugs this shape fixes:
+#   * install_detect_targets emits one TAB-separated record per device and never
+#     space-joins names -> multi-disk concatenation (build#8738).
+#   * install_plan_layout is a pure function of (boot_mode, fs, uefi, capacity,
+#     sector_size, has_swap); it selects GPT when uefi | >2TiB | 4Kn and emits
+#     explicit ESP/boot flags -> MBR-only & missing-boot-flag installs
+#     (build#9454, #9794, #6905).
+#   * install_apply_partitions lays partitions in MiB units so alignment is
+#     valid on both 512-byte and 4Kn media (build#9454).
+#   * install_write_bootconfig always populates the target /boot and
+#     install_verify refuses an empty /boot -> unbootable installs
+#     (build#10099, #10064).
+#
+
+# ---- named exit codes (replace the old scattered magic numbers) -------------
+readonly INSTALL_EX_OK=0
+readonly INSTALL_EX_USAGE=64          # bad arguments
+readonly INSTALL_EX_NODEV=65          # no / invalid target device
+readonly INSTALL_EX_NOSPACE=66        # target too small
+readonly INSTALL_EX_TOOL=67           # required tool / package missing
+readonly INSTALL_EX_PARTITION=68      # partitioning failed
+readonly INSTALL_EX_FORMAT=69         # mkfs failed
+readonly INSTALL_EX_TRANSFER=70       # rootfs copy failed
+readonly INSTALL_EX_BOOTCFG=71        # boot config / fstab rewrite failed
+readonly INSTALL_EX_BOOTLOADER=72     # bootloader write failed
+readonly INSTALL_EX_VERIFY=73         # post-install verification failed
+
+# Log sink. Callers may point INSTALL_LOG at a file; defaults to stderr.
+INSTALL_LOG="${INSTALL_LOG:-/dev/stderr}"
+
+install_log() {
+	# install_log <LEVEL> <message...>
+	local level="$1"; shift
+	printf '%s [%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S' 2>/dev/null || echo now)" "$level" "$*" >>"$INSTALL_LOG" 2>/dev/null || true
+}
+
+# ---- capacity / geometry helpers -------------------------------------------
+
+# 2 TiB in bytes - the msdos/MBR addressing ceiling on 512-byte sectors.
+readonly INSTALL_TWO_TIB=$(( 2 * 1024 * 1024 * 1024 * 1024 ))
+
+install_table_type() {
+	# install_table_type <is_uefi> <capacity_bytes> <sector_size>
+	# GPT when firmware is UEFI, the disk is larger than the MBR ceiling, or the
+	# medium is 4Kn; msdos otherwise. Pure - no device access.
+	local is_uefi="$1" cap="${2:-0}" sec="${3:-512}"
+	if [[ "$is_uefi" == "1" || "$is_uefi" == "uefi" ]] \
+		|| (( cap > INSTALL_TWO_TIB )) \
+		|| (( sec == 4096 )); then
+		echo "gpt"
+	else
+		echo "msdos"
+	fi
+}
+
+# ---- detection --------------------------------------------------------------
+
+# Thin, overridable wrapper around lsblk so tests can inject fixtures.
+_install_lsblk_raw() {
+	lsblk -b -d -o NAME,TYPE,SIZE,PHY-SEC,TRAN,ROTA,MODEL --json 2>/dev/null
+}
+
+install_detect_targets() {
+	# install_detect_targets [root_disk] [lsblk_json]
+	# Emit one TAB-separated record per candidate whole disk:
+	#   name <TAB> role <TAB> size_bytes <TAB> sector_size <TAB> bus <TAB> rota <TAB> model
+	# role in {nvme,mmc,mtd,usb,sata,disk}. The disk hosting the running rootfs
+	# (root_disk, a bare kernel name such as "mmcblk0") is excluded.
+	local root_disk="${1:-}"
+	local json="${2:-}"
+	[[ -z "$json" ]] && json="$(_install_lsblk_raw)"
+	[[ -z "$json" ]] && return "$INSTALL_EX_NODEV"
+
+	echo "$json" | jq -r --arg root "$root_disk" '
+		.blockdevices[]?
+		| select(.type == "disk")
+		| select(.name != $root)
+		| { n: .name, t: (.tran // ""), sz: (.size // 0),
+		    ps: (."phy-sec" // 512), ro: (.rota // false), md: ((.model // "") | gsub("\t"; " ")) }
+		| .role = ( if   (.n | test("^nvme"))     then "nvme"
+		            elif (.n | test("^mmcblk"))   then "mmc"
+		            elif (.n | test("^mtdblock")) then "mtd"
+		            elif (.t == "usb")            then "usb"
+		            elif (.t == "sata" or .t == "ata") then "sata"
+		            else "disk" end )
+		| [ .n, .role, (.sz|tostring), (.ps|tostring), .t, (.ro|tostring), .md ]
+		| @tsv
+	'
+}
+
+# ---- partition planning (pure) ---------------------------------------------
+
+install_plan_layout() {
+	# install_plan_layout <boot_mode> <fs> <is_uefi> <capacity_bytes> <sector_size> [has_swap]
+	#
+	# boot_mode: uefi | emmc | sd | mtd | ufs
+	#   uefi  - full install to an internal disk with an ESP + GRUB
+	#   emmc  - full self-contained install (boot + root) to eMMC/SD
+	#   sd    - boot stays on removable media, only the rootfs lands on the target
+	#   mtd   - boot lives in SPI/MTD flash, only the rootfs lands on the target
+	#   ufs   - boot idblock on a UFS boot LUN, rootfs on the UFS general LUN
+	#
+	# Emits a declarative plan on stdout:
+	#   table=gpt|msdos
+	#   part=<role>:<size>:<fstype>:<flags>       (one line per partition, in order)
+	# where size is an absolute "<N>MiB" or "100%" (fill), and flags is a
+	# comma-separated subset of {esp,boot} ("" for none). Pure: no device I/O.
+	local boot_mode="$1" fs="$2" is_uefi="$3" cap="${4:-0}" sec="${5:-512}" has_swap="${6:-0}"
+	local table
+	table="$(install_table_type "$is_uefi" "$cap" "$sec")"
+
+	local -a parts=()
+	case "$boot_mode" in
+		uefi)
+			# ESP is mandatory and the table is always GPT for UEFI.
+			table="gpt"
+			parts+=("esp:512MiB:vfat:esp,boot")
+			parts+=("root:100%:${fs}:")
+			;;
+		emmc)
+			if [[ "$fs" == "btrfs" || "$fs" == "f2fs" ]]; then
+				# u-boot cannot read btrfs/f2fs -> a dedicated ext4 /boot.
+				parts+=("boot:512MiB:ext4:boot")
+				[[ "$has_swap" == "1" ]] && parts+=("swap:256MiB:swap:")
+				parts+=("root:100%:${fs}:")
+			else
+				# ext4 keeps /boot as a directory on a single partition.
+				parts+=("root:100%:ext4:boot")
+			fi
+			;;
+		sd|mtd|ufs)
+			# Only the rootfs lands here; boot lives elsewhere.
+			parts+=("root:100%:${fs}:boot")
+			;;
+		*)
+			install_log ERR "install_plan_layout: unknown boot mode '$boot_mode'"
+			return "$INSTALL_EX_USAGE"
+			;;
+	esac
+
+	echo "table=$table"
+	local p
+	for p in "${parts[@]}"; do
+		echo "part=$p"
+	done
+}
+
+# Map a logical filesystem to the hint parted understands (empty = let parted
+# skip the type, e.g. f2fs which parted does not know about).
+_install_parted_fs_hint() {
+	case "$1" in
+		vfat)  echo "fat32" ;;
+		swap)  echo "linux-swap" ;;
+		ext4)  echo "ext4" ;;
+		btrfs) echo "btrfs" ;;
+		*)     echo "" ;;
+	esac
+}
+
+# ---- partitioning -----------------------------------------------------------
+
+install_apply_partitions() {
+	# install_apply_partitions <device> [plan]
+	# Applies a plan (from arg or stdin) to <device> with parted, in MiB units so
+	# alignment is correct on 512-byte and 4Kn media alike. Echoes one line per
+	# created partition: "<role> <device_partition>" for the caller to consume.
+	local device="$1"
+	local plan="${2:-}"
+	[[ -z "$plan" ]] && plan="$(cat)"
+	[[ -b "$device" ]] || { install_log ERR "apply_partitions: '$device' is not a block device"; return "$INSTALL_EX_NODEV"; }
+
+	local table="" ; local -a parts=()
+	local line
+	while IFS= read -r line; do
+		case "$line" in
+			table=*) table="${line#table=}" ;;
+			part=*)  parts+=("${line#part=}") ;;
+		esac
+	done <<<"$plan"
+	[[ -n "$table" && ${#parts[@]} -gt 0 ]] || { install_log ERR "apply_partitions: empty plan"; return "$INSTALL_EX_PARTITION"; }
+
+	wipefs -aq "$device" >>"$INSTALL_LOG" 2>&1 || true
+	dd if=/dev/zero of="$device" bs=1M count=10 conv=notrunc >>"$INSTALL_LOG" 2>&1 || true
+	parted -s "$device" mklabel "$table" >>"$INSTALL_LOG" 2>&1 \
+		|| { install_log ERR "apply_partitions: mklabel $table failed"; return "$INSTALL_EX_PARTITION"; }
+
+	local start_mib=1 idx=0
+	local spec role size fstype flags hint end
+	for spec in "${parts[@]}"; do
+		IFS=':' read -r role size fstype flags <<<"$spec"
+		idx=$(( idx + 1 ))
+		hint="$(_install_parted_fs_hint "$fstype")"
+		if [[ "$size" == "100%" ]]; then
+			end="100%"
+		else
+			# "<N>MiB" -> integer MiB, absolute end = start + N.
+			end="$(( start_mib + ${size%MiB} ))MiB"
+		fi
+		# parted's fs-type hint is optional (e.g. f2fs is unknown) - build the
+		# mkpart argv in an array so an empty hint drops out cleanly.
+		local -a mkpart_args=(mkpart primary)
+		[[ -n "$hint" ]] && mkpart_args+=("$hint")
+		mkpart_args+=("${start_mib}MiB" "$end")
+		parted -s -a optimal "$device" "${mkpart_args[@]}" >>"$INSTALL_LOG" 2>&1 \
+			|| { install_log ERR "apply_partitions: mkpart $role failed"; return "$INSTALL_EX_PARTITION"; }
+
+		# Flags are table-aware: on GPT parted aliases "boot" to the ESP flag, so
+		# a plain bootable (non-ESP) partition must use legacy_boot instead.
+		if [[ ",$flags," == *",esp,"* ]]; then
+			parted -s "$device" set "$idx" esp on >>"$INSTALL_LOG" 2>&1 || true
+		fi
+		if [[ ",$flags," == *",boot,"* && ",$flags," != *",esp,"* ]]; then
+			if [[ "$table" == "gpt" ]]; then
+				parted -s "$device" set "$idx" legacy_boot on >>"$INSTALL_LOG" 2>&1 || true
+			else
+				parted -s "$device" set "$idx" boot on >>"$INSTALL_LOG" 2>&1 || true
+			fi
+		fi
+
+		[[ "$size" != "100%" ]] && start_mib=$(( start_mib + ${size%MiB} ))
+		echo "${role} $(_install_part_dev "$device" "$idx")"
+	done
+
+	partprobe "$device" >>"$INSTALL_LOG" 2>&1 || true
+	udevadm settle >>"$INSTALL_LOG" 2>&1 || true
+}
+
+# Partition node naming: /dev/sda -> /dev/sda1 ; /dev/nvme0n1 -> /dev/nvme0n1p1.
+_install_part_dev() {
+	local dev="$1" n="$2"
+	if [[ "$dev" =~ [0-9]$ ]]; then
+		echo "${dev}p${n}"
+	else
+		echo "${dev}${n}"
+	fi
+}
+
+# ---- filesystem creation ----------------------------------------------------
+
+# Which package supplies mkfs.<fs>; empty for the always-present ones.
+_install_fs_pkg() {
+	case "$1" in
+		btrfs) echo "btrfs-progs" ;;
+		f2fs)  echo "f2fs-tools" ;;
+		*)     echo "" ;;
+	esac
+}
+
+install_check_fs_tools() {
+	# install_check_fs_tools <fs> - returns 0 if mkfs.<fs> is present, else the
+	# name of the package that provides it (on stdout) with a non-zero status.
+	local fs="$1"
+	command -v "mkfs.${fs}" >/dev/null 2>&1 && return 0
+	_install_fs_pkg "$fs"
+	return "$INSTALL_EX_TOOL"
+}
+
+install_make_filesystems() {
+	# install_make_filesystems <mapfile>
+	# mapfile lines: "<role> <device_partition> <fstype>". Creates each fs after a
+	# tool pre-flight; ext4 for mvebu drops the 64bit feature (ARMv7 u-boot).
+	local map="$1"
+	[[ -n "$map" ]] || { install_log ERR "make_filesystems: empty map"; return "$INSTALL_EX_FORMAT"; }
+	local role dev fs
+	local -a ext4_opts
+	while read -r role dev fs; do
+		[[ -n "$dev" && -n "$fs" ]] || continue
+		if ! install_check_fs_tools "$fs" >/dev/null; then
+			install_log ERR "make_filesystems: mkfs.$fs missing (install $(_install_fs_pkg "$fs"))"
+			return "$INSTALL_EX_TOOL"
+		fi
+		case "$fs" in
+			ext4)
+				# ARMv7 mvebu u-boot cannot read the ext4 64bit feature.
+				ext4_opts=(-qF)
+				[[ "${LINUXFAMILY:-}" == "mvebu" ]] && ext4_opts=(-O '^64bit' -qF)
+				mkfs.ext4 "${ext4_opts[@]}" "$dev" >>"$INSTALL_LOG" 2>&1 ;;
+			vfat)  mkfs.vfat -F 32 "$dev" >>"$INSTALL_LOG" 2>&1 ;;
+			btrfs) mkfs.btrfs -f "$dev" >>"$INSTALL_LOG" 2>&1 ;;
+			f2fs)  mkfs.f2fs -f "$dev" >>"$INSTALL_LOG" 2>&1 ;;
+			swap)  mkswap "$dev" >>"$INSTALL_LOG" 2>&1 ;;
+			*)     install_log ERR "make_filesystems: unsupported fs '$fs'"; return "$INSTALL_EX_FORMAT" ;;
+		esac || { install_log ERR "make_filesystems: mkfs.$fs on $dev failed"; return "$INSTALL_EX_FORMAT"; }
+	done <<<"$map"
+}
+
+# ---- rootfs transfer --------------------------------------------------------
+
+install_transfer_rootfs() {
+	# install_transfer_rootfs <target_rootfs_mount> <exclude_file> [progress_fd]
+	# rsync / -> target with the exclude list, emitting integer percentages to
+	# progress_fd (default 1) for a gauge. Returns INSTALL_EX_TRANSFER on failure.
+	local dest="$1" exclude="$2" pfd="${3:-1}"
+	[[ -d "$dest" ]] || { install_log ERR "transfer: '$dest' is not a directory"; return "$INSTALL_EX_TRANSFER"; }
+	[[ -f "$exclude" ]] || { install_log ERR "transfer: exclude file '$exclude' missing"; return "$INSTALL_EX_TRANSFER"; }
+
+	local todo
+	todo=$(rsync -anx --delete --stats --exclude-from="$exclude" / "$dest" 2>/dev/null \
+		| awk '/Number of files:/ {gsub(/[.,]/,"",$4); print $4; exit}')
+	[[ "$todo" =~ ^[0-9]+$ && "$todo" -gt 0 ]] || todo=1
+
+	local rc_file; rc_file="$(mktemp)"
+	{
+		rsync -avx --delete --exclude-from="$exclude" / "$dest" \
+			| stdbuf -oL awk -v todo="$todo" '{ p=int(100*NR/todo); if(p>100)p=100; print p; fflush() }' >&"$pfd"
+		echo "${PIPESTATUS[0]}" >"$rc_file"
+	}
+	local rc; rc="$(cat "$rc_file")"; rm -f "$rc_file"
+	[[ "$rc" == "0" ]] || { install_log ERR "transfer: rsync exit $rc"; return "$INSTALL_EX_TRANSFER"; }
+
+	# Second, quiet pass to catch files that changed during the first copy.
+	rsync -ax --delete --exclude-from="$exclude" / "$dest" >>"$INSTALL_LOG" 2>&1 || true
+}
+
+# ---- boot configuration -----------------------------------------------------
+
+install_rewrite_bootenv() {
+	# install_rewrite_bootenv <file> <rootdev> [rootfstype]
+	# Rewrite an armbianEnv.txt-style key=value file to point at <rootdev>
+	# (a "UUID=..." string or a device path) and, if given, <rootfstype>.
+	# Idempotent: keys are updated in place or appended if absent. Pure text op.
+	local file="$1" rootdev="$2" fstype="${3:-}"
+	[[ -f "$file" ]] || return "$INSTALL_EX_BOOTCFG"
+	if grep -q '^rootdev=' "$file"; then
+		sed -i "s|^rootdev=.*|rootdev=${rootdev}|" "$file"
+	else
+		echo "rootdev=${rootdev}" >>"$file"
+	fi
+	if [[ -n "$fstype" ]]; then
+		if grep -q '^rootfstype=' "$file"; then
+			sed -i "s|^rootfstype=.*|rootfstype=${fstype}|" "$file"
+		else
+			echo "rootfstype=${fstype}" >>"$file"
+		fi
+	fi
+}
+
+install_gen_fstab() {
+	# install_gen_fstab <root_uuid> <root_fs> [boot_uuid] [boot_fs] [esp_uuid]
+	# Emit a fresh fstab on stdout. root_* required; boot_* optional (separate
+	# /boot); esp_uuid optional (UEFI /boot/efi). Mirrors the mount option set
+	# the image ships with.
+	local root_uuid="$1" root_fs="$2" boot_uuid="${3:-}" boot_fs="${4:-ext4}" esp_uuid="${5:-}"
+	local root_opts boot_opts
+	case "$root_fs" in
+		btrfs) root_opts="defaults,commit=120,compress=lzo,x-gvfs-hide,subvol=@	0	2" ;;
+		f2fs)  root_opts="defaults,noatime,x-gvfs-hide	0	2" ;;
+		*)     root_opts="defaults,noatime,commit=120,errors=remount-ro,x-gvfs-hide	0	1" ;;
+	esac
+	boot_opts="defaults,noatime,commit=120,errors=remount-ro,x-gvfs-hide	0	2"
+
+	echo "# <file system>	<mount point>	<type>	<options>	<dump>	<pass>"
+	echo "tmpfs	/tmp	tmpfs	defaults,nosuid	0	0"
+	echo "${root_uuid}	/	${root_fs}	${root_opts}"
+	[[ -n "$boot_uuid" ]] && echo "${boot_uuid}	/boot	${boot_fs}	${boot_opts}"
+	[[ -n "$esp_uuid" ]]  && echo "${esp_uuid}	/boot/efi	vfat	defaults	0	2"
+	return 0
+}
+
+install_populate_boot() {
+	# install_populate_boot <target_rootfs_mount> [target_boot_mount]
+	# Ensure the target has a non-empty /boot. When a separate boot partition is
+	# mounted, copy the running /boot into it; otherwise ensure /boot exists in
+	# the rootfs. This is the guard against build#10099 (empty /boot).
+	local rootfs="$1" bootmnt="${2:-}"
+	[[ -d "$rootfs" ]] || { install_log ERR "populate_boot: rootfs '$rootfs' missing"; return "$INSTALL_EX_BOOTCFG"; }
+	if [[ -n "$bootmnt" ]]; then
+		# Separate boot partition: copy the running /boot onto it.
+		[[ -d "$bootmnt" ]] || { install_log ERR "populate_boot: '$bootmnt' missing"; return "$INSTALL_EX_BOOTCFG"; }
+		rsync -aqx /boot/ "$bootmnt"/ >>"$INSTALL_LOG" 2>&1 \
+			|| { install_log ERR "populate_boot: copy to $bootmnt failed"; return "$INSTALL_EX_BOOTCFG"; }
+	else
+		# No separate boot partition: /boot rides inside the rootfs. The rsync of
+		# / already carried it (unless the exclude list dropped it), so just make
+		# sure the mount point exists for the bind/verify steps.
+		mkdir -p "$rootfs/boot"
+	fi
+	return 0
+}
+
+# ---- verification -----------------------------------------------------------
+
+install_verify_boot_dir() {
+	# install_verify_boot_dir <boot_dir>
+	# Assert the directory holds something u-boot/GRUB can actually boot:
+	# a kernel image AND a boot script/config. build#10099/#6905 guard.
+	local d="$1"
+	[[ -d "$d" ]] || { install_log ERR "verify: boot dir '$d' missing"; return "$INSTALL_EX_VERIFY"; }
+	local have_kernel=0 have_script=0
+	compgen -G "$d/vmlinu*" >/dev/null 2>&1 && have_kernel=1
+	compgen -G "$d/Image*"  >/dev/null 2>&1 && have_kernel=1
+	compgen -G "$d/zImage*" >/dev/null 2>&1 && have_kernel=1
+	compgen -G "$d/uImage*" >/dev/null 2>&1 && have_kernel=1
+	[[ -f "$d/boot.scr" || -f "$d/boot.cmd" || -f "$d/extlinux/extlinux.conf" || -d "$d/grub" ]] && have_script=1
+	if (( have_kernel == 0 || have_script == 0 )); then
+		install_log ERR "verify: '$d' is not bootable (kernel=$have_kernel script=$have_script)"
+		return "$INSTALL_EX_VERIFY"
+	fi
+	return 0
+}
+
+install_verify_fstab() {
+	# install_verify_fstab <fstab_file>
+	# Every UUID= referenced must resolve to a real device (blkid). Catches a
+	# root/boot UUID that was never written or points at the wrong partition.
+	local fstab="$1"
+	[[ -f "$fstab" ]] || { install_log ERR "verify: fstab '$fstab' missing"; return "$INSTALL_EX_VERIFY"; }
+	local uuid rc=0
+	while read -r uuid; do
+		[[ -n "$uuid" ]] || continue
+		if ! blkid -U "$uuid" >/dev/null 2>&1; then
+			install_log ERR "verify: fstab UUID $uuid does not resolve"
+			rc="$INSTALL_EX_VERIFY"
+		fi
+	done < <(grep -oE 'UUID=[0-9A-Fa-f-]+' "$fstab" | cut -d= -f2)
+	return "$rc"
+}
+
+# ---- bootloader -------------------------------------------------------------
+
+install_write_bootloader() {
+	# install_write_bootloader <boot_mode> <target_disk> <rootfs_mount> [uboot_dir] [mtd_list] [ufs_boot_lun]
+	# Dispatches to the board-provided u-boot hooks (sourced at runtime from
+	# /usr/lib/u-boot/platform_install.sh) or GRUB for UEFI. Returns
+	# INSTALL_EX_BOOTLOADER on failure.
+	local boot_mode="$1" disk="$2" rootfs="$3" uboot_dir="${4:-${DIR:-}}" mtd_list="${5:-}" ufs_boot="${6:-}"
+	case "$boot_mode" in
+		uefi)
+			install_grub_install "$rootfs" ;;
+		mtd)
+			[[ "$(type -t write_uboot_platform_mtd)" == function ]] || { install_log ERR "bootloader: write_uboot_platform_mtd missing"; return "$INSTALL_EX_BOOTLOADER"; }
+			write_uboot_platform_mtd "$uboot_dir" "/dev/${mtd_list%% *}" "$INSTALL_LOG" "$mtd_list" \
+				|| { install_log ERR "bootloader: MTD write failed"; return "$INSTALL_EX_BOOTLOADER"; } ;;
+		ufs)
+			[[ "$(type -t write_uboot_platform_ufs)" == function ]] || { install_log ERR "bootloader: write_uboot_platform_ufs missing"; return "$INSTALL_EX_BOOTLOADER"; }
+			write_uboot_platform_ufs "$uboot_dir" "$ufs_boot" "$disk" \
+				|| { install_log ERR "bootloader: UFS write failed"; return "$INSTALL_EX_BOOTLOADER"; } ;;
+		emmc|sd)
+			[[ "$(type -t write_uboot_platform)" == function ]] || { install_log ERR "bootloader: write_uboot_platform missing"; return "$INSTALL_EX_BOOTLOADER"; }
+			write_uboot_platform "$uboot_dir" "$disk" \
+				|| { install_log ERR "bootloader: u-boot write to $disk failed"; return "$INSTALL_EX_BOOTLOADER"; } ;;
+		*)
+			install_log ERR "bootloader: unknown boot mode '$boot_mode'"; return "$INSTALL_EX_USAGE" ;;
+	esac
+}
+
+install_grub_install() {
+	# install_grub_install <rootfs_mount>
+	# Bind-mount /dev,/proc,/sys and run grub-install + grub-mkconfig in the
+	# target. The ESP must already be mounted at <rootfs>/boot/efi.
+	local rootfs="$1" arch_target
+	mountpoint -q "$rootfs/boot/efi" || { install_log ERR "grub: ESP not mounted at $rootfs/boot/efi"; return "$INSTALL_EX_BOOTLOADER"; }
+	mkdir -p "$rootfs"/{dev,proc,sys}
+	mount --bind /dev "$rootfs/dev"
+	mount --make-rslave --bind /dev/pts "$rootfs/dev/pts"
+	mount --bind /proc "$rootfs/proc"
+	mount --make-rslave --rbind /sys "$rootfs/sys"
+	arch_target=$([[ "$(arch)" == x86_64 ]] && echo "x86_64-efi" || echo "arm64-efi")
+	local rc=0
+	chroot "$rootfs" /bin/bash -c "grub-install --target=$arch_target --efi-directory=/boot/efi --bootloader-id=Armbian --removable" >>"$INSTALL_LOG" 2>&1 || rc=1
+	chroot "$rootfs" /bin/bash -c "grub-mkconfig -o /boot/grub/grub.cfg" >>"$INSTALL_LOG" 2>&1 || rc=1
+	# Unwind the API mounts regardless of outcome.
+	awk -v r="$rootfs/sys" '$2 ~ "^"r {print $2}' /proc/mounts | sort -r | xargs -r umount -n 2>/dev/null
+	umount "$rootfs/proc" 2>/dev/null
+	umount "$rootfs/dev/pts" 2>/dev/null
+	umount "$rootfs/dev" 2>/dev/null
+	[[ "$rc" == 0 ]] || { install_log ERR "grub: install failed"; return "$INSTALL_EX_BOOTLOADER"; }
+}
+
+# ---- orchestration ----------------------------------------------------------
+
+install_uuid() {
+	# install_uuid <device_partition> -> "UUID=<uuid>" (empty on failure)
+	local u; u="$(blkid -s UUID -o value "$1" 2>/dev/null)"
+	[[ -n "$u" ]] && echo "UUID=$u"
+}
+
+install_run_scenario() {
+	# install_run_scenario <boot_mode> <target_disk> <fs> <exclude_file> [uboot_dir]
+	#
+	# The single entrypoint shared by the dialog TUI and the non-interactive CLI.
+	# Composes the tested primitives (plan -> apply -> mkfs -> transfer -> boot
+	# config -> bootloader -> verify) for one target. Side-effecting; validated by
+	# the loopback integration test and by board/KVM smoke before rollout.
+	local boot_mode="$1" disk="$2" fs="$3" exclude="$4" uboot_dir="${5:-${DIR:-}}"
+	# Deterministic tool output (parted/blkid flag names etc. are localised).
+	# The scenario is a terminal operation, so exporting here is fine.
+	export LC_ALL=C LANG=C
+	[[ -b "$disk" ]] || { install_log ERR "scenario: '$disk' is not a block device"; return "$INSTALL_EX_NODEV"; }
+	[[ -f "$exclude" ]] || { install_log ERR "scenario: exclude file '$exclude' missing"; return "$INSTALL_EX_TRANSFER"; }
+
+	# Geometry + firmware context feed the pure planner.
+	local cap sec is_uefi=0 has_swap=0
+	cap="$(blockdev --getsize64 "$disk" 2>/dev/null || echo 0)"
+	sec="$(cat "/sys/block/$(basename "$disk")/queue/physical_block_size" 2>/dev/null || echo 512)"
+	[[ "$boot_mode" == uefi ]] && is_uefi=1
+	grep -q swap /etc/fstab 2>/dev/null && has_swap=1
+
+	local plan; plan="$(install_plan_layout "$boot_mode" "$fs" "$is_uefi" "$cap" "$sec" "$has_swap")" \
+		|| { install_log ERR "scenario: planning failed"; return "$INSTALL_EX_PARTITION"; }
+	install_log INFO "scenario: $boot_mode on $disk (${cap}B, ${sec}B sectors) fs=$fs"$'\n'"$plan"
+
+	# Partition, then build the mkfs map + remember the role->device mapping.
+	local partmap; partmap="$(install_apply_partitions "$disk" "$plan")" || return "$INSTALL_EX_PARTITION"
+	local esp_dev="" boot_dev="" root_dev="" swap_dev="" role dev
+	local mkfs_map=""
+	while read -r role dev; do
+		[[ -n "$dev" ]] || continue
+		case "$role" in
+			esp)  esp_dev="$dev";  mkfs_map+="esp $dev vfat"$'\n' ;;
+			boot) boot_dev="$dev"; mkfs_map+="boot $dev ext4"$'\n' ;;
+			swap) swap_dev="$dev"; mkfs_map+="swap $dev swap"$'\n' ;;
+			root) root_dev="$dev"; mkfs_map+="root $dev $fs"$'\n' ;;
+		esac
+	done <<<"$partmap"
+	[[ -b "$root_dev" ]] || { install_log ERR "scenario: no root partition created"; return "$INSTALL_EX_PARTITION"; }
+	install_make_filesystems "$mkfs_map" || return "$INSTALL_EX_FORMAT"
+
+	# Mount the freshly-formatted target.
+	local mp; mp="$(mktemp -d /mnt/armbian-install.XXXXXX)" || return "$INSTALL_EX_TRANSFER"
+	mount "$root_dev" "$mp" || { install_log ERR "scenario: mount root failed"; rmdir "$mp"; return "$INSTALL_EX_TRANSFER"; }
+	if [[ -n "$boot_dev" ]]; then mkdir -p "$mp/boot"; mount "$boot_dev" "$mp/boot"; fi
+	if [[ -n "$esp_dev" ]]; then mkdir -p "$mp/boot/efi"; fi
+
+	# One-shot loop so a failing step can `break` straight to teardown.
+	local rc=0
+	while :; do
+		install_transfer_rootfs "$mp" "$exclude" || { rc=$INSTALL_EX_TRANSFER; break; }
+		install_populate_boot "$mp" "${boot_dev:+$mp/boot}" || { rc=$INSTALL_EX_BOOTCFG; break; }
+
+		# fstab from the real, freshly-created UUIDs.
+		local root_uuid boot_uuid="" esp_uuid=""
+		root_uuid="$(install_uuid "$root_dev")"
+		[[ -n "$boot_dev" ]] && boot_uuid="$(install_uuid "$boot_dev")"
+		[[ -n "$esp_dev" ]]  && esp_uuid="$(install_uuid "$esp_dev")"
+		install_gen_fstab "$root_uuid" "$fs" "$boot_uuid" ext4 "$esp_uuid" >"$mp/etc/fstab" \
+			|| { rc=$INSTALL_EX_BOOTCFG; break; }
+		grep -q '^tmpfs.*swap' /etc/fstab 2>/dev/null && grep swap /etc/fstab >>"$mp/etc/fstab"
+
+		# Point the board's boot env at the new root (u-boot scenarios only).
+		if [[ "$boot_mode" != uefi ]]; then
+			local env_file="$mp/boot/armbianEnv.txt"
+			[[ -f "$env_file" ]] && install_rewrite_bootenv "$env_file" "$root_uuid" "$fs"
+		fi
+
+		# ESP must be mounted before GRUB runs.
+		[[ -n "$esp_dev" ]] && { mount "$esp_dev" "$mp/boot/efi" || { rc=$INSTALL_EX_BOOTLOADER; break; }; }
+		install_write_bootloader "$boot_mode" "$disk" "$mp" "$uboot_dir" "${INSTALL_MTD_LIST:-}" "${INSTALL_UFS_BOOT_LUN:-}" \
+			|| { rc=$INSTALL_EX_BOOTLOADER; break; }
+
+		# Refuse to declare success on an unbootable result.
+		install_verify_boot_dir "$mp/boot" || { rc=$INSTALL_EX_VERIFY; break; }
+		install_verify_fstab "$mp/etc/fstab" || { rc=$INSTALL_EX_VERIFY; break; }
+		break
+	done 2>>"$INSTALL_LOG"
+
+	# Teardown (best effort).
+	sync
+	mountpoint -q "$mp/boot/efi" && umount "$mp/boot/efi" 2>/dev/null
+	mountpoint -q "$mp/boot" && umount "$mp/boot" 2>/dev/null
+	umount "$mp" 2>/dev/null
+	rmdir "$mp" 2>/dev/null
+
+	[[ "$rc" == 0 ]] && install_log INFO "scenario: $boot_mode install to $disk completed"
+	return "$rc"
+}
+
+# ---- entrypoint dispatch (for `armbian-config module_install_engine ...`) ----
+
+module_install_engine() {
+	local commands
+	IFS=' ' read -r -a commands <<<"${module_options["module_install_engine,example"]}"
+	case "$1" in
+		"${commands[0]}")   # detect
+			shift; install_detect_targets "$@" ;;
+		"${commands[1]}")   # plan
+			shift; install_plan_layout "$@" ;;
+		*)
+			echo "Usage: module_install_engine {detect|plan} ..." >&2
+			return "$INSTALL_EX_USAGE" ;;
+	esac
+}

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -97,10 +97,17 @@ install_detect_targets() {
 	[[ -z "$json" ]] && json="$(_install_lsblk_raw)"
 	[[ -z "$json" ]] && return "$INSTALL_EX_NODEV"
 
+	# Note: empty fields are emitted as "-" (never ""), because a `read` loop with
+	# IFS=$'\t' collapses consecutive tabs (tab is IFS-whitespace) and an empty
+	# column would shift every field after it.
 	echo "$json" | jq -r --arg root "$root_disk" '
 		.blockdevices[]?
 		| select(.type == "disk")
 		| select(.name != $root)
+		# Drop pseudo/virtual block devices that are never install targets:
+		# zram (compressed RAM swap), ram disks, loop, optical (sr), floppy (fd),
+		# and device-mapper (dm-) nodes.
+		| select(.name | test("^(zram|ram|loop|sr|fd|dm-)[0-9-]") | not)
 		| { n: .name, t: (.tran // ""), sz: (.size // 0),
 		    ps: (."phy-sec" // 512), ro: (.rota // false), md: ((.model // "") | gsub("\t"; " ")) }
 		| .role = ( if   (.n | test("^nvme"))     then "nvme"
@@ -109,7 +116,10 @@ install_detect_targets() {
 		            elif (.t == "usb")            then "usb"
 		            elif (.t == "sata" or .t == "ata") then "sata"
 		            else "disk" end )
-		| [ .n, .role, (.sz|tostring), (.ps|tostring), .t, (.ro|tostring), .md ]
+		| [ .n, .role, (.sz|tostring), (.ps|tostring),
+		    (if .t  == "" then "-" else .t  end),
+		    (.ro|tostring),
+		    (if .md == "" then "-" else .md end) ]
 		| @tsv
 	'
 }

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -471,10 +471,15 @@ install_write_bootloader() {
 }
 
 install_grub_install() {
-	# install_grub_install <rootfs_mount>
+	# install_grub_install <rootfs_mount> [mode]
 	# Bind-mount /dev,/proc,/sys and run grub-install + grub-mkconfig in the
 	# target. The ESP must already be mounted at <rootfs>/boot/efi.
-	local rootfs="$1" arch_target
+	#   mode=solo     (default) sole-OS install: --removable, so it boots even
+	#                 without a working NVRAM entry (typical for wiped disks).
+	#   mode=dualboot keep an existing OS (Windows): NO --removable (leave the
+	#                 /EFI/BOOT fallback alone) and turn on os-prober so the
+	#                 GRUB menu offers the other OS.
+	local rootfs="$1" mode="${2:-solo}" arch_target
 	mountpoint -q "$rootfs/boot/efi" || { install_log ERR "grub: ESP not mounted at $rootfs/boot/efi"; return "$INSTALL_EX_BOOTLOADER"; }
 	mkdir -p "$rootfs"/{dev,proc,sys}
 	mount --bind /dev "$rootfs/dev"
@@ -482,8 +487,14 @@ install_grub_install() {
 	mount --bind /proc "$rootfs/proc"
 	mount --make-rslave --rbind /sys "$rootfs/sys"
 	arch_target=$([[ "$(arch)" == x86_64 ]] && echo "x86_64-efi" || echo "arm64-efi")
+	local grub_opts="--target=$arch_target --efi-directory=/boot/efi --bootloader-id=Armbian"
+	if [[ "$mode" == dualboot ]]; then
+		install_enable_os_prober "$rootfs"
+	else
+		grub_opts+=" --removable"
+	fi
 	local rc=0
-	chroot "$rootfs" /bin/bash -c "grub-install --target=$arch_target --efi-directory=/boot/efi --bootloader-id=Armbian --removable" >>"$INSTALL_LOG" 2>&1 || rc=1
+	chroot "$rootfs" /bin/bash -c "grub-install $grub_opts" >>"$INSTALL_LOG" 2>&1 || rc=1
 	chroot "$rootfs" /bin/bash -c "grub-mkconfig -o /boot/grub/grub.cfg" >>"$INSTALL_LOG" 2>&1 || rc=1
 	# Unwind the API mounts regardless of outcome.
 	awk -v r="$rootfs/sys" '$2 ~ "^"r {print $2}' /proc/mounts | sort -r | xargs -r umount -n 2>/dev/null
@@ -491,6 +502,130 @@ install_grub_install() {
 	umount "$rootfs/dev/pts" 2>/dev/null
 	umount "$rootfs/dev" 2>/dev/null
 	[[ "$rc" == 0 ]] || { install_log ERR "grub: install failed"; return "$INSTALL_EX_BOOTLOADER"; }
+}
+
+install_enable_os_prober() {
+	# install_enable_os_prober <rootfs_mount>
+	# Make grub-mkconfig scan for other operating systems (Windows). GRUB 2.06+
+	# disables os-prober by default; re-enable it via the armbian drop-in.
+	local rootfs="$1"
+	mkdir -p "$rootfs/etc/default/grub.d"
+	echo "GRUB_DISABLE_OS_PROBER=false" >>"$rootfs/etc/default/grub.d/98-armbian.cfg"
+	command -v os-prober >/dev/null 2>&1 || chroot "$rootfs" /bin/bash -c "command -v os-prober" >/dev/null 2>&1 \
+		|| install_log WARN "os-prober not present in target; Windows may be missing from the GRUB menu"
+}
+
+# ---- Windows dual-boot ------------------------------------------------------
+
+install_detect_windows() {
+	# install_detect_windows <disk>
+	# On a GPT disk carrying a Windows install, emit:
+	#   esp=<esp_partition>          existing EFI System Partition (reused)
+	#   windows=<ntfs_partition>     the largest NTFS (Microsoft basic data) part
+	# Returns INSTALL_EX_NODEV if the disk is not a Windows/UEFI layout.
+	local disk="$1"
+	[[ -b "$disk" ]] || return "$INSTALL_EX_NODEV"
+	# GPT is required for a UEFI Windows install.
+	parted -sm "$disk" print 2>/dev/null | grep -q '^/dev/.*:gpt:' || return "$INSTALL_EX_NODEV"
+
+	local json esp win
+	json="$(lsblk -b -po NAME,FSTYPE,PARTTYPENAME,SIZE --json "$disk" 2>/dev/null)"
+	esp="$(echo "$json" | jq -r '
+		[.blockdevices[]?.children[]?
+		 | select(((.parttypename // "") | test("EFI";"i")) or (.fstype == "vfat"))
+		 | .name] | first // empty')"
+	win="$(echo "$json" | jq -r '
+		[.blockdevices[]?.children[]?
+		 | select(.fstype == "ntfs")]
+		 | sort_by(.size) | reverse | (.[0].name // empty)')"
+	[[ -n "$esp" && -n "$win" ]] || { install_log ERR "detect_windows: no ESP+NTFS pair on $disk"; return "$INSTALL_EX_NODEV"; }
+	echo "esp=$esp"
+	echo "windows=$win"
+}
+
+install_windows_min_bytes() {
+	# install_windows_min_bytes <ntfs_partition>
+	# Smallest size ntfsresize will shrink the volume to, in bytes (0 on failure).
+	local dev="$1" out
+	out="$(ntfsresize -f --info "$dev" 2>/dev/null \
+		| grep -iE 'You might resize' | grep -oE '[0-9]+ bytes' | grep -oE '[0-9]+' | head -1)"
+	[[ -z "$out" ]] && out="$(ntfsresize -f --info "$dev" 2>/dev/null \
+		| awk -F'[:(]' '/[Cc]urrent volume size/ {gsub(/[^0-9]/,"",$2); print $2; exit}')"
+	echo "${out:-0}"
+}
+
+install_dualboot_plan() {
+	# install_dualboot_plan <win_size_bytes> <win_min_bytes> <tail_free_bytes> <want_bytes>
+	# Pure: decide how small Windows must become to free <want_bytes> for Armbian,
+	# keeping a safety margin above the NTFS minimum. Echoes "shrink_to=<bytes>"
+	# (the new Windows size) or fails with INSTALL_EX_NOSPACE if it will not fit.
+	local wsize="$1" wmin="$2" tail="${3:-0}" want="$4"
+	local margin=$(( 8 * 1024 * 1024 * 1024 ))          # keep >=8GiB above the ntfs min
+	local shrinkable=$(( wsize - (wmin + margin) ))
+	(( shrinkable < 0 )) && shrinkable=0
+	local avail=$(( shrinkable + tail ))
+	if (( want > avail )); then
+		install_log ERR "dualboot: need $want bytes but only $avail free (shrinkable=$shrinkable, tail=$tail)"
+		return "$INSTALL_EX_NOSPACE"
+	fi
+	# Use any existing free tail first, only then eat into Windows.
+	local from_win=0
+	(( want > tail )) && from_win=$(( want - tail ))
+	echo "shrink_to=$(( wsize - from_win ))"
+}
+
+install_shrink_windows() {
+	# install_shrink_windows <disk> <windows_partition> <new_size_bytes>
+	# Shrink the NTFS filesystem, then pull the GPT partition end in to match.
+	# The volume must be clean (run chkdsk in Windows first) or ntfsresize aborts.
+	local disk="$1" win="$2" new_bytes="$3"
+	yes | ntfsresize -f --size "$new_bytes" "$win" >>"$INSTALL_LOG" 2>&1 \
+		|| { install_log ERR "shrink: ntfsresize of $win to $new_bytes failed (is the volume clean?)"; return "$INSTALL_EX_PARTITION"; }
+
+	local pnum start_b new_end_b
+	pnum="$(grep -oE '[0-9]+$' <<<"$win")"
+	start_b="$(parted -sm "$disk" unit B print 2>/dev/null | awk -F: -v p="$pnum" '$1==p {gsub("B","",$2); print $2}')"
+	[[ -n "$start_b" ]] || { install_log ERR "shrink: cannot read start of partition $pnum"; return "$INSTALL_EX_PARTITION"; }
+	# Leave 16MiB slack so the partition end sits safely past the shrunk fs.
+	new_end_b=$(( start_b + new_bytes + 16 * 1024 * 1024 ))
+	# parted refuses to shrink a partition non-interactively even with --script;
+	# ---pretend-input-tty lets us answer its "are you sure?" prompt with "Yes".
+	printf 'Yes\n' | parted ---pretend-input-tty "$disk" unit B resizepart "$pnum" "${new_end_b}B" >>"$INSTALL_LOG" 2>&1 \
+		|| { install_log ERR "shrink: resizepart $pnum to ${new_end_b}B failed"; return "$INSTALL_EX_PARTITION"; }
+	partprobe "$disk" >>"$INSTALL_LOG" 2>&1 || true
+	udevadm settle >>"$INSTALL_LOG" 2>&1 || true
+}
+
+install_create_free_partition() {
+	# install_create_free_partition <disk> <fs>
+	# Create one partition filling the largest free region and echo its device.
+	# Does NOT relabel or wipe - existing partitions are preserved.
+	local disk="$1" fs="$2" hint
+	hint="$(_install_parted_fs_hint "$fs")"
+	# Largest free block (MiB) from parted's free-space report.
+	local fstart fend fsize best_start="" best_size=0 line
+	while IFS=: read -r _ fstart fend fsize _; do
+		[[ "$fsize" == *MiB ]] || continue
+		local s="${fstart%MiB}" z="${fsize%MiB}"
+		s="${s%.*}"; z="${z%.*}"
+		if (( z > best_size )); then best_size="$z"; best_start="$s"; fi
+	done < <(parted -sm "$disk" unit MiB print free 2>/dev/null | grep ':free;$')
+	[[ -n "$best_start" ]] || { install_log ERR "create_free: no free space on $disk"; return "$INSTALL_EX_NOSPACE"; }
+
+	local -a mkpart_args=(mkpart primary)
+	[[ -n "$hint" ]] && mkpart_args+=("$hint")
+	mkpart_args+=("${best_start}MiB" "100%")
+	# ---pretend-input-tty + "Yes" accepts parted's alignment adjustment
+	# ("the closest location we can manage is ...") which --script would reject.
+	printf 'Yes\n' | parted ---pretend-input-tty -a optimal "$disk" unit MiB "${mkpart_args[@]}" >>"$INSTALL_LOG" 2>&1 \
+		|| { install_log ERR "create_free: mkpart failed"; return "$INSTALL_EX_PARTITION"; }
+	partprobe "$disk" >>"$INSTALL_LOG" 2>&1 || true
+	udevadm settle >>"$INSTALL_LOG" 2>&1 || true
+
+	# The new partition is the highest-numbered one.
+	local newnum
+	newnum="$(parted -sm "$disk" print 2>/dev/null | awk -F: '/^[0-9]/ {n=$1} END{print n}')"
+	echo "$(_install_part_dev "$disk" "$newnum")"
 }
 
 # ---- orchestration ----------------------------------------------------------
@@ -588,6 +723,74 @@ install_run_scenario() {
 	rmdir "$mp" 2>/dev/null
 
 	[[ "$rc" == 0 ]] && install_log INFO "scenario: $boot_mode install to $disk completed"
+	return "$rc"
+}
+
+install_run_dualboot() {
+	# install_run_dualboot <disk> <fs> <exclude_file> <armbian_bytes> [uboot_dir]
+	#
+	# Non-destructive UEFI install alongside Windows: shrink the NTFS volume,
+	# create an Armbian partition in the freed tail, reuse the existing Windows
+	# ESP, and set up GRUB + os-prober dual-boot. The disk keeps its partition
+	# table and every existing partition.
+	local disk="$1" fs="$2" exclude="$3" want="$4"
+	export LC_ALL=C LANG=C
+	[[ -b "$disk" ]] || { install_log ERR "dualboot: '$disk' not a block device"; return "$INSTALL_EX_NODEV"; }
+	[[ -f "$exclude" ]] || { install_log ERR "dualboot: exclude '$exclude' missing"; return "$INSTALL_EX_TRANSFER"; }
+	[[ "$want" =~ ^[0-9]+$ && "$want" -gt 0 ]] || { install_log ERR "dualboot: bad size '$want'"; return "$INSTALL_EX_USAGE"; }
+	command -v ntfsresize >/dev/null 2>&1 || { install_log ERR "dualboot: ntfsresize missing - install the ntfs-3g package"; return "$INSTALL_EX_TOOL"; }
+
+	# 1) locate the existing Windows ESP + NTFS volume (nothing is touched yet).
+	local wi esp win
+	wi="$(install_detect_windows "$disk")" || { install_log ERR "dualboot: no Windows/UEFI layout on $disk"; return "$INSTALL_EX_NODEV"; }
+	esp="$(sed -n 's/^esp=//p' <<<"$wi")"
+	win="$(sed -n 's/^windows=//p' <<<"$wi")"
+	install_log INFO "dualboot: ESP=$esp Windows=$win on $disk"
+
+	# 2) plan how far to shrink Windows to free <want> bytes.
+	local wsize wmin new_win plan
+	wsize="$(blockdev --getsize64 "$win")"
+	wmin="$(install_windows_min_bytes "$win")"
+	plan="$(install_dualboot_plan "$wsize" "$wmin" 0 "$want")" || return "$INSTALL_EX_NOSPACE"
+	new_win="$(sed -n 's/^shrink_to=//p' <<<"$plan")"
+
+	# 3) shrink Windows (only if we must eat into it).
+	if (( new_win < wsize )); then
+		install_shrink_windows "$disk" "$win" "$new_win" || return "$INSTALL_EX_PARTITION"
+	fi
+
+	# 4) create + format the Armbian partition in the freed tail.
+	local root_dev
+	root_dev="$(install_create_free_partition "$disk" "$fs")" || return "$INSTALL_EX_PARTITION"
+	[[ -b "$root_dev" ]] || { install_log ERR "dualboot: new partition '$root_dev' missing"; return "$INSTALL_EX_PARTITION"; }
+	install_make_filesystems "root $root_dev $fs" || return "$INSTALL_EX_FORMAT"
+
+	# 5) install into it, reusing the existing ESP for GRUB.
+	local mp rc=0
+	mp="$(mktemp -d /mnt/armbian-install.XXXXXX)" || return "$INSTALL_EX_TRANSFER"
+	mount "$root_dev" "$mp" || { install_log ERR "dualboot: mount root failed"; rmdir "$mp"; return "$INSTALL_EX_TRANSFER"; }
+	mkdir -p "$mp/boot/efi"
+	while :; do
+		install_transfer_rootfs "$mp" "$exclude" || { rc=$INSTALL_EX_TRANSFER; break; }
+		install_populate_boot "$mp" || { rc=$INSTALL_EX_BOOTCFG; break; }
+		local root_uuid esp_uuid
+		root_uuid="$(install_uuid "$root_dev")"
+		esp_uuid="$(install_uuid "$esp")"
+		install_gen_fstab "$root_uuid" "$fs" "" ext4 "$esp_uuid" >"$mp/etc/fstab" || { rc=$INSTALL_EX_BOOTCFG; break; }
+		mount "$esp" "$mp/boot/efi" || { install_log ERR "dualboot: mount ESP failed"; rc=$INSTALL_EX_BOOTLOADER; break; }
+		install_grub_install "$mp" dualboot || { rc=$INSTALL_EX_BOOTLOADER; break; }
+		install_verify_boot_dir "$mp/boot" || { rc=$INSTALL_EX_VERIFY; break; }
+		install_verify_fstab "$mp/etc/fstab" || { rc=$INSTALL_EX_VERIFY; break; }
+		# The Windows volume must have survived intact.
+		[[ "$(blkid -s TYPE -o value "$win")" == ntfs ]] || { install_log ERR "dualboot: Windows NTFS vanished after install"; rc=$INSTALL_EX_VERIFY; break; }
+		break
+	done 2>>"$INSTALL_LOG"
+
+	sync
+	mountpoint -q "$mp/boot/efi" && umount "$mp/boot/efi" 2>/dev/null
+	umount "$mp" 2>/dev/null
+	rmdir "$mp" 2>/dev/null
+	[[ "$rc" == 0 ]] && install_log INFO "dualboot: Armbian installed alongside Windows on $disk"
 	return "$rc"
 }
 

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -407,11 +407,11 @@ install_rewrite_bootenv() {
 }
 
 install_gen_fstab() {
-	# install_gen_fstab <root_uuid> <root_fs> [boot_uuid] [boot_fs] [esp_uuid]
+	# install_gen_fstab <root_uuid> <root_fs> [boot_uuid] [boot_fs] [esp_uuid] [swap_uuid]
 	# Emit a fresh fstab on stdout. root_* required; boot_* optional (separate
-	# /boot); esp_uuid optional (UEFI /boot/efi). Mirrors the mount option set
-	# the image ships with.
-	local root_uuid="$1" root_fs="$2" boot_uuid="${3:-}" boot_fs="${4:-ext4}" esp_uuid="${5:-}"
+	# /boot); esp_uuid optional (UEFI /boot/efi); swap_uuid optional (a dedicated
+	# swap partition). Mirrors the mount option set the image ships with.
+	local root_uuid="$1" root_fs="$2" boot_uuid="${3:-}" boot_fs="${4:-ext4}" esp_uuid="${5:-}" swap_uuid="${6:-}"
 	local root_opts boot_opts
 	case "$root_fs" in
 		btrfs) root_opts="defaults,commit=120,compress=lzo,x-gvfs-hide,subvol=@	0	2" ;;
@@ -425,6 +425,7 @@ install_gen_fstab() {
 	echo "${root_uuid}	/	${root_fs}	${root_opts}"
 	[[ -n "$boot_uuid" ]] && echo "${boot_uuid}	/boot	${boot_fs}	${boot_opts}"
 	[[ -n "$esp_uuid" ]]  && echo "${esp_uuid}	/boot/efi	vfat	defaults	0	2"
+	[[ -n "$swap_uuid" ]] && echo "${swap_uuid}	none	swap	sw	0	0"
 	return 0
 }
 
@@ -816,13 +817,18 @@ install_run_scenario() {
 		install_populate_boot "$mp" "$copy_boot" || { rc=$INSTALL_EX_BOOTCFG; break; }
 
 		# fstab from the real, freshly-created UUIDs.
-		local root_uuid boot_uuid="" esp_uuid=""
+		local root_uuid boot_uuid="" esp_uuid="" swap_uuid=""
 		root_uuid="$(install_uuid "$root_dev")"
 		[[ -n "$boot_dev" ]] && boot_uuid="$(install_uuid "$boot_dev")"
 		[[ -n "$esp_dev" ]]  && esp_uuid="$(install_uuid "$esp_dev")"
-		install_gen_fstab "$root_uuid" "$fs" "$boot_uuid" ext4 "$esp_uuid" >"$mp/etc/fstab" \
+		[[ -n "$swap_dev" ]] && swap_uuid="$(install_uuid "$swap_dev")"
+		install_gen_fstab "$root_uuid" "$fs" "$boot_uuid" ext4 "$esp_uuid" "$swap_uuid" >"$mp/etc/fstab" \
 			|| { rc=$INSTALL_EX_BOOTCFG; break; }
-		grep -q '^tmpfs.*swap' /etc/fstab 2>/dev/null && grep swap /etc/fstab >>"$mp/etc/fstab"
+		# No dedicated swap partition -> carry over the host's swap entries (e.g. a
+		# /var/swap swapfile) so the target keeps swap.
+		if [[ -z "$swap_dev" ]] && grep -qE '^[^#].*[[:space:]]swap[[:space:]]' /etc/fstab 2>/dev/null; then
+			grep -E '^[^#].*[[:space:]]swap[[:space:]]' /etc/fstab >>"$mp/etc/fstab"
+		fi
 
 		# Point the board's boot env at the new root (u-boot scenarios only; GRUB
 		# modes are handled by grub-mkconfig).

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -569,6 +569,40 @@ install_grub_install() {
 	[[ "$rc" == 0 ]] || { install_log ERR "grub: install failed"; return "$INSTALL_EX_BOOTLOADER"; }
 }
 
+install_update_initramfs() {
+	# install_update_initramfs <rootfs_mount> <fs>
+	# Rebuild the target's initramfs so a module root filesystem (btrfs, f2fs)
+	# is actually present at boot. Armbian sets MODULES=list, which does NOT
+	# auto-include the root-fs module, and the installer inherits the source's
+	# initramfs (built for the source's root fs) - so an f2fs/btrfs root would be
+	# unbootable without this. Built-in filesystems (ext4/vfat) need nothing.
+	# Best effort: a failure is logged, not fatal.
+	local rootfs="$1" fs="$2"
+	case "$fs" in ext2|ext3|ext4|vfat|msdos) return 0 ;; esac
+	command -v chroot >/dev/null 2>&1 || return 0
+	[[ -x "$rootfs/usr/sbin/update-initramfs" || -x "$rootfs/sbin/update-initramfs" ]] || {
+		install_log WARN "update-initramfs: not present in target; $fs root may not boot"; return 0; }
+
+	# Force the fs module into the initramfs module list (list mode ships only
+	# what is listed here).
+	local modfile="$rootfs/etc/initramfs-tools/modules"
+	if [[ -f "$modfile" ]] && ! grep -qxF "$fs" "$modfile"; then
+		echo "$fs" >>"$modfile"
+	fi
+
+	mkdir -p "$rootfs"/{dev,proc,sys}
+	mount --bind /dev "$rootfs/dev"
+	mount --bind /proc "$rootfs/proc"
+	mount --bind /sys "$rootfs/sys"
+	local rc=0
+	chroot "$rootfs" /bin/bash -c "update-initramfs -u -k all" >>"$INSTALL_LOG" 2>&1 || rc=1
+	umount "$rootfs/sys" 2>/dev/null
+	umount "$rootfs/proc" 2>/dev/null
+	umount "$rootfs/dev" 2>/dev/null
+	[[ "$rc" == 0 ]] || install_log WARN "update-initramfs failed in target; $fs root may not boot"
+	return 0
+}
+
 install_enable_os_prober() {
 	# install_enable_os_prober <rootfs_mount>
 	# Make grub-mkconfig scan for other operating systems (Windows). GRUB 2.06+
@@ -792,6 +826,10 @@ install_run_scenario() {
 				[[ -f "$env_file" ]] && install_rewrite_bootenv "$env_file" "$root_uuid" "$fs" ;;
 		esac
 
+		# Rebuild the target initramfs so a module root fs (btrfs/f2fs) boots
+		# under MODULES=list. Only when the target owns its /boot.
+		[[ "$copy_boot" == 1 ]] && install_update_initramfs "$mp" "$fs"
+
 		echo 95
 		# ESP must be mounted before GRUB runs.
 		[[ -n "$esp_dev" ]] && { mount "$esp_dev" "$mp/boot/efi" || { rc=$INSTALL_EX_BOOTLOADER; break; }; }
@@ -873,6 +911,7 @@ install_run_dualboot() {
 		root_uuid="$(install_uuid "$root_dev")"
 		esp_uuid="$(install_uuid "$esp")"
 		install_gen_fstab "$root_uuid" "$fs" "" ext4 "$esp_uuid" >"$mp/etc/fstab" || { rc=$INSTALL_EX_BOOTCFG; break; }
+		install_update_initramfs "$mp" "$fs"
 		echo 95
 		mount "$esp" "$mp/boot/efi" || { install_log ERR "dualboot: mount ESP failed"; rc=$INSTALL_EX_BOOTLOADER; break; }
 		install_grub_install "$mp" dualboot || { rc=$INSTALL_EX_BOOTLOADER; break; }

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -832,6 +832,42 @@ install_uuid() {
 	[[ -n "$u" ]] && echo "UUID=$u"
 }
 
+install_map_current_boot() {
+	# install_map_current_boot <target_fstab> <target_root_mount>
+	# For "sd" mode (boot stays on the current media, rootfs on the target):
+	# make the current media's /boot visible inside the target at /boot so kernel
+	# and initramfs upgrades on the target land where u-boot actually reads them.
+	# Mirrors the classic armbian-install behaviour:
+	#   * dedicated /boot partition  -> mount it straight at /boot
+	#   * /boot is a dir on the root -> mount that partition at /media/boot-media
+	#                                   and bind /media/boot-media/boot -> /boot
+	# All entries use nofail so a later-removed boot medium never blocks boot.
+	local fstab="$1" mp="$2"
+	local boot_src boot_uuid boot_fstype
+	boot_src="$(findmnt -no SOURCE /boot 2>/dev/null || true)"
+	if [[ -n "$boot_src" ]]; then
+		boot_uuid="$(install_uuid "$boot_src")"
+		boot_fstype="$(findmnt -no FSTYPE /boot 2>/dev/null || true)"
+		[[ -n "$boot_uuid" && -n "$boot_fstype" ]] \
+			|| { install_log ERR "boot-map: cannot resolve current /boot partition ($boot_src)"; return "$INSTALL_EX_BOOTCFG"; }
+		printf '%s\t/boot\t%s\tdefaults,nofail\t0\t2\n' "$boot_uuid" "$boot_fstype" >>"$fstab"
+		install_log INFO "boot-map: target /boot -> current boot partition $boot_src ($boot_fstype)"
+		return 0
+	fi
+	# /boot is a directory on the current media's root partition.
+	local root_src root_media_uuid root_media_fstype
+	root_src="$(findmnt -no SOURCE / 2>/dev/null || true)"
+	root_media_uuid="$(install_uuid "$root_src")"
+	root_media_fstype="$(findmnt -no FSTYPE / 2>/dev/null || true)"
+	[[ -n "$root_media_uuid" && -n "$root_media_fstype" ]] \
+		|| { install_log ERR "boot-map: cannot resolve current root partition ($root_src)"; return "$INSTALL_EX_BOOTCFG"; }
+	mkdir -p "$mp/media/boot-media" || { install_log ERR "boot-map: mkdir /media/boot-media failed"; return "$INSTALL_EX_BOOTCFG"; }
+	printf '%s\t/media/boot-media\t%s\tdefaults,nofail\t0\t2\n' "$root_media_uuid" "$root_media_fstype" >>"$fstab"
+	printf '/media/boot-media/boot\t/boot\tnone\tbind,nofail\t0\t0\n' >>"$fstab"
+	install_log INFO "boot-map: target /boot -> bind of current root $root_src (/media/boot-media/boot)"
+	return 0
+}
+
 install_run_scenario() {
 	# install_run_scenario <boot_mode> <target_disk> <fs> <exclude_file> [uboot_dir]
 	#
@@ -931,19 +967,23 @@ install_run_scenario() {
 				[[ -f "$env_file" ]] && install_rewrite_bootenv "$env_file" "$root_uuid" "$fs" ;;
 			sd)
 				# Boot stays on the current media (the SD/eMMC the board booted
-				# from); only the rootfs moved to $disk. Point the CURRENT media's
-				# boot env at the new root so u-boot keeps loading the kernel from it
-				# but mounts rootfs from $disk. The target has no /boot of its own,
-				# so without this the board would keep booting its old rootfs.
+				# from); only the rootfs moved to $disk. Two things are needed:
+				#   1. point the CURRENT media's boot env at the new root, so u-boot
+				#      (loaded from that media) keeps loading the kernel from there
+				#      but tells the kernel to mount rootfs from $disk; and
+				#   2. map that media's /boot into the target at /boot, so kernel and
+				#      initramfs upgrades on the target land where u-boot reads them.
+				# Without (1) the board keeps booting its old rootfs.
 				local env_file="/boot/armbianEnv.txt"
-				if [[ -f "$env_file" ]]; then
-					install_rewrite_bootenv "$env_file" "$root_uuid" "$fs" \
-						|| { install_log ERR "scenario: failed to point current boot env ($env_file) at new root $root_uuid"; rc=$INSTALL_EX_BOOTCFG; break; }
-					install_log INFO "scenario: pointed current boot media ($env_file) at new root $root_uuid ($fs)"
-				else
+				if [[ ! -f "$env_file" ]]; then
 					install_log ERR "scenario: sd mode but current boot env ($env_file) is missing; cannot make $disk bootable"
 					rc=$INSTALL_EX_BOOTCFG; break
-				fi ;;
+				fi
+				install_rewrite_bootenv "$env_file" "$root_uuid" "$fs" \
+					|| { install_log ERR "scenario: failed to point current boot env ($env_file) at new root $root_uuid"; rc=$INSTALL_EX_BOOTCFG; break; }
+				install_map_current_boot "$mp/etc/fstab" "$mp" \
+					|| { install_log ERR "scenario: failed to map current /boot into target fstab"; rc=$INSTALL_EX_BOOTCFG; break; }
+				install_log INFO "scenario: pointed current boot media ($env_file) at new root $root_uuid ($fs) and mapped its /boot into the target" ;;
 		esac
 
 		# Rebuild the target initramfs so a module root fs (btrfs/f2fs) boots

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -367,6 +367,7 @@ install_transfer_rootfs() {
 	# fraction is stable. progress2 rewrites its line with \r; split on \r.
 	local rc_file; rc_file="$(mktemp)"
 	{
+		# editorconfig-checker-disable
 		rsync -ax --delete --info=progress2 --no-inc-recursive --exclude-from="$exclude" "$src" "$dest" \
 			| stdbuf -oL tr '\r' '\n' \
 			| stdbuf -oL sed -u -n 's/.*to-chk=\([0-9]*\)\/\([0-9]*\).*/\1 \2/p' \
@@ -374,6 +375,7 @@ install_transfer_rootfs() {
 				{ if ($2 > 0) { p = lo + int((hi-lo)*($2-$1)/$2);
 				                if (p > hi) p = hi;
 				                if (p != last) { print p; fflush(); last = p } } }' >&"$pfd"
+		# editorconfig-checker-enable
 		echo "${PIPESTATUS[0]}" >"$rc_file"
 	}
 	local rc; rc="$(cat "$rc_file")"; rm -f "$rc_file"
@@ -675,6 +677,7 @@ _install_windows_parts() {
 	# size is sorted with tonumber (lsblk may emit it as a string, and a string
 	# sort would rank 781MB above 63GB). Emits two lines: esp=<dev|> windows=<dev|>
 	local json="$1" esp win
+	# editorconfig-checker-disable
 	esp="$(printf '%s' "$json" | jq -r '
 		[ .blockdevices[]?.children[]?
 		  | select(((.parttypename // "") | test("EFI";"i")) or (.fstype == "vfat"))
@@ -684,6 +687,7 @@ _install_windows_parts() {
 		  | select(.fstype == "ntfs")
 		  | select(((.parttypename // "") | test("recovery"; "i")) | not) ]
 		| sort_by(.size | tonumber) | reverse | (.[0].name // empty)')"
+	# editorconfig-checker-enable
 	printf 'esp=%s\nwindows=%s\n' "$esp" "$win"
 }
 
@@ -709,10 +713,12 @@ install_detect_windows() {
 		# A "Microsoft basic data" partition that is not plain NTFS is almost
 		# always BitLocker-encrypted, which ntfsresize cannot shrink - say so.
 		local enc
+		# editorconfig-checker-disable
 		enc="$(printf '%s' "$json" | jq -r '
 			[ .blockdevices[]?.children[]?
 			  | select(((.parttypename // "") | test("basic data"; "i")) and (.fstype != "ntfs"))
 			  | .name ] | first // empty')"
+		# editorconfig-checker-enable
 		if [[ -n "$enc" ]]; then
 			install_log ERR "detect_windows: $enc is not plain NTFS (likely BitLocker); disable device encryption in Windows to enable dual-boot"
 		else

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -306,6 +306,18 @@ install_check_fs_tools() {
 	return "$INSTALL_EX_TOOL"
 }
 
+install_fs_kernel_supported() {
+	# install_fs_kernel_supported <fs> - true if the RUNNING kernel can mount it.
+	# The mkfs tool can exist while the kernel lacks the driver (e.g. f2fs on a
+	# cloud kernel): mkfs succeeds but the subsequent mount fails. Try to load the
+	# module, then check /proc/filesystems.
+	local fs="$1"
+	case "$fs" in ext2|ext3|ext4|vfat|msdos) return 0 ;; esac   # always built in
+	grep -qw "$fs" /proc/filesystems && return 0
+	modprobe "$fs" >/dev/null 2>&1 || true
+	grep -qw "$fs" /proc/filesystems
+}
+
 install_make_filesystems() {
 	# install_make_filesystems <mapfile>
 	# mapfile lines: "<role> <device_partition> <fstype>". Creates each fs after a
@@ -711,6 +723,8 @@ install_run_scenario() {
 		|| { install_log ERR "scenario: no bootloader method for '$boot_mode' on this system (u-boot hooks or grub-install missing) - refusing to modify $disk"; return "$INSTALL_EX_BOOTLOADER"; }
 	install_check_fs_tools "$fs" >/dev/null \
 		|| { install_log ERR "scenario: mkfs.$fs not installed (need $(_install_fs_pkg "$fs")) - refusing to modify $disk"; return "$INSTALL_EX_TOOL"; }
+	install_fs_kernel_supported "$fs" \
+		|| { install_log ERR "scenario: running kernel cannot mount $fs (no driver) - refusing to modify $disk"; return "$INSTALL_EX_TOOL"; }
 
 	# Geometry + firmware context feed the pure planner.
 	local cap sec is_uefi=0 has_swap=0
@@ -818,6 +832,7 @@ install_run_dualboot() {
 	[[ "$want" =~ ^[0-9]+$ && "$want" -gt 0 ]] || { install_log ERR "dualboot: bad size '$want'"; return "$INSTALL_EX_USAGE"; }
 	command -v ntfsresize >/dev/null 2>&1 || { install_log ERR "dualboot: ntfsresize missing - install the ntfs-3g package"; return "$INSTALL_EX_TOOL"; }
 	install_check_fs_tools "$fs" >/dev/null || { install_log ERR "dualboot: mkfs.$fs not installed (need $(_install_fs_pkg "$fs")) - refusing to modify $disk"; return "$INSTALL_EX_TOOL"; }
+	install_fs_kernel_supported "$fs" || { install_log ERR "dualboot: running kernel cannot mount $fs (no driver) - refusing to modify $disk"; return "$INSTALL_EX_TOOL"; }
 	command -v grub-install >/dev/null 2>&1 || { install_log ERR "dualboot: grub-install missing - refusing to modify $disk"; return "$INSTALL_EX_BOOTLOADER"; }
 
 	# 1) locate the existing Windows ESP + NTFS volume (nothing is touched yet).

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -511,6 +511,11 @@ install_write_bootloader() {
 	# /usr/lib/u-boot/platform_install.sh) or GRUB for UEFI. Returns
 	# INSTALL_EX_BOOTLOADER on failure.
 	local boot_mode="$1" disk="$2" rootfs="$3" uboot_dir="${4:-${DIR:-}}" mtd_list="${5:-}" ufs_boot="${6:-}"
+	# Some board u-boot hooks (notably TI k3: BeaglePlay/BeagleBone) copy files to
+	# ${MOUNT}/boot instead of dd-ing to the device. The stock installers never
+	# set MOUNT, so those files went to the RUNNING system's /boot, not the
+	# target. Point MOUNT at the target rootfs so they land in the right place.
+	export MOUNT="$rootfs"
 	case "$boot_mode" in
 		uefi)
 			install_grub_install "$rootfs" solo ;;

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -674,6 +674,15 @@ install_detect_windows() {
 	echo "windows=$win"
 }
 
+install_disk_has_bitlocker() {
+	# install_disk_has_bitlocker <disk> [lsblk_json]
+	# True if the disk carries a BitLocker-encrypted volume. Used to explain why
+	# dual-boot is unavailable (ntfsresize cannot shrink an encrypted volume).
+	local disk="$1" json="${2:-}"
+	[[ -z "$json" ]] && json="$(lsblk -b -po NAME,FSTYPE,PARTTYPENAME,SIZE --json "$disk" 2>/dev/null)"
+	printf '%s' "$json" | jq -e 'any(.blockdevices[]?.children[]?; (.fstype // "") | test("bitlocker"; "i"))' >/dev/null 2>&1
+}
+
 install_windows_min_bytes() {
 	# install_windows_min_bytes <ntfs_partition>
 	# Smallest size ntfsresize will shrink the volume to, in bytes (0 on failure).

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -341,26 +341,29 @@ install_transfer_rootfs() {
 	# install_transfer_rootfs <target_rootfs_mount> <exclude_file> [progress_fd]
 	# rsync / -> target with the exclude list, emitting integer percentages to
 	# progress_fd (default 1) for a gauge. Returns INSTALL_EX_TRANSFER on failure.
-	local dest="$1" exclude="$2" pfd="${3:-1}"
+	# src defaults to "/" (the running rootfs); overridable for tests.
+	local dest="$1" exclude="$2" pfd="${3:-1}" src="${4:-/}"
 	[[ -d "$dest" ]] || { install_log ERR "transfer: '$dest' is not a directory"; return "$INSTALL_EX_TRANSFER"; }
 	[[ -f "$exclude" ]] || { install_log ERR "transfer: exclude file '$exclude' missing"; return "$INSTALL_EX_TRANSFER"; }
 
-	local todo
-	todo=$(rsync -anx --delete --stats --exclude-from="$exclude" / "$dest" 2>/dev/null \
-		| awk '/Number of files:/ {gsub(/[.,]/,"",$4); print $4; exit}')
-	[[ "$todo" =~ ^[0-9]+$ && "$todo" -gt 0 ]] || todo=1
-
+	# Use rsync's own overall byte percentage (--info=progress2) rather than
+	# counting output lines against a dry-run file count, which drifts out of
+	# sync. --no-inc-recursive builds the full file list first so the percentage
+	# is accurate and monotonic from the start (a short pause at 0% up front).
+	# progress2 rewrites its line with \r; split on \r, pull the "NN%" token.
 	local rc_file; rc_file="$(mktemp)"
 	{
-		rsync -avx --delete --exclude-from="$exclude" / "$dest" \
-			| stdbuf -oL awk -v todo="$todo" '{ p=int(100*NR/todo); if(p>100)p=100; print p; fflush() }' >&"$pfd"
+		rsync -ax --delete --info=progress2 --no-inc-recursive --exclude-from="$exclude" "$src" "$dest" \
+			| stdbuf -oL tr '\r' '\n' \
+			| stdbuf -oL grep --line-buffered -oE '[0-9]+%' \
+			| stdbuf -oL sed -u 's/%//' >&"$pfd"
 		echo "${PIPESTATUS[0]}" >"$rc_file"
 	}
 	local rc; rc="$(cat "$rc_file")"; rm -f "$rc_file"
 	[[ "$rc" == "0" ]] || { install_log ERR "transfer: rsync exit $rc"; return "$INSTALL_EX_TRANSFER"; }
 
 	# Second, quiet pass to catch files that changed during the first copy.
-	rsync -ax --delete --exclude-from="$exclude" / "$dest" >>"$INSTALL_LOG" 2>&1 || true
+	rsync -ax --delete --exclude-from="$exclude" "$src" "$dest" >>"$INSTALL_LOG" 2>&1 || true
 }
 
 # ---- boot configuration -----------------------------------------------------

--- a/tools/modules/system/module_partitioner.sh
+++ b/tools/modules/system/module_partitioner.sh
@@ -160,12 +160,13 @@ partitioner_tui() {
 		[[ -z "$boot" ]] && return "$INSTALL_EX_OK"
 	fi
 
-	# 3) filesystem
+	# 3) filesystem - only offer what the running kernel can actually mount
+	# (mkfs.f2fs can succeed on a kernel with no f2fs driver, then mount fails).
 	local fs
-	fs=$(dialog_menu " $title " "\nRoot filesystem for /dev/$disk:" 0 60 6 -- \
-		ext4 "Default, most compatible" \
-		btrfs "Copy-on-write, compression, snapshots" \
-		f2fs "Flash-friendly log-structured fs")
+	local -a fsmenu=(ext4 "Default, most compatible")
+	install_fs_kernel_supported btrfs && fsmenu+=(btrfs "Copy-on-write, compression, snapshots")
+	install_fs_kernel_supported f2fs  && fsmenu+=(f2fs "Flash-friendly log-structured fs")
+	fs=$(dialog_menu " $title " "\nRoot filesystem for /dev/$disk:" 0 60 6 -- "${fsmenu[@]}")
 	[[ -z "$fs" ]] && return "$INSTALL_EX_OK"
 	if ! partitioner_ensure_fs_tool "$fs" 1; then
 		dialog_msgbox " $title " "\nCannot format as $fs: mkfs.$fs is unavailable.\n\nInstall the package and try again."

--- a/tools/modules/system/module_partitioner.sh
+++ b/tools/modules/system/module_partitioner.sh
@@ -50,9 +50,10 @@ partitioner_disk_label() {
 	local name="$1" role="$2" size_bytes="$3" bus="$4" model="$5"
 	local human
 	human=$(numfmt --to=iec --suffix=B "$size_bytes" 2>/dev/null || echo "${size_bytes}B")
+	# "-" is the detect placeholder for an absent bus/model column.
 	local info="$role"
-	[[ -n "$bus" && "$bus" != "null" ]] && info="$bus $role"
-	[[ -n "$model" && "$model" != "null" ]] && info="$model"
+	[[ -n "$bus" && "$bus" != "null" && "$bus" != "-" ]] && info="$bus $role"
+	[[ -n "$model" && "$model" != "null" && "$model" != "-" ]] && info="$model"
 	printf '%-10s %8s  %s' "/dev/$name" "$human" "$info"
 }
 

--- a/tools/modules/system/module_partitioner.sh
+++ b/tools/modules/system/module_partitioner.sh
@@ -57,31 +57,45 @@ partitioner_disk_label() {
 	printf '%-10s %8s  %s' "/dev/$name" "$human" "$info"
 }
 
-# Boot modes that make sense for a given target role + firmware.
+# Boot modes that actually work on this system for a given target, gated by
+# capability so we never offer a mode whose bootloader cannot be written:
+#   * UEFI firmware present            -> GRUB EFI (uefi, +dualboot with Windows)
+#   * u-boot board (ARM)               -> media-specific u-boot modes
+#   * x86 legacy BIOS (no EFI/u-boot)  -> GRUB BIOS (grub-pc)
 partitioner_modes_for() {
 	local role="$1" disk="$2"
+	local -a m=()
+	local have_uboot=0
+	[[ "$(type -t write_uboot_platform)" == function ]] && have_uboot=1
+
 	if [[ -d /sys/firmware/efi ]]; then
-		# Offer dual-boot first when an existing Windows/UEFI layout is present.
 		if [[ -n "$disk" ]] && install_detect_windows "/dev/$disk" >/dev/null 2>&1; then
-			echo "uefi-dualboot uefi"
-		else
-			echo "uefi"
+			m+=(uefi-dualboot)
 		fi
-		return
+		m+=(uefi)
 	fi
-	case "$role" in
-		mmc)          echo "emmc sd" ;;   # eMMC can host a full install or just root
-		nvme|sata|usb) echo "sd" ;;       # boot stays on removable media, root here
-		mtd)          echo "mtd" ;;
-		ufs)          echo "ufs" ;;
-		*)            echo "sd" ;;
-	esac
+	if [[ "$have_uboot" -eq 1 ]]; then
+		case "$role" in
+			mmc)           m+=(emmc sd) ;;   # eMMC: full install or just root
+			nvme|sata|usb) m+=(sd) ;;        # boot on removable media, root here
+			mtd)           m+=(mtd) ;;
+			ufs)           m+=(ufs) ;;
+		esac
+	fi
+	# x86 legacy BIOS: neither EFI firmware nor a u-boot board.
+	if [[ ! -d /sys/firmware/efi && "$have_uboot" -eq 0 ]] && command -v grub-install >/dev/null 2>&1; then
+		m+=(bios)
+	fi
+
+	[[ ${#m[@]} -eq 0 ]] && m+=(uefi)   # last-resort fallback
+	echo "${m[@]}"
 }
 
 partitioner_mode_desc() {
 	case "$1" in
 		uefi-dualboot) echo "Dual-boot: shrink Windows, install Armbian alongside it" ;;
 		uefi) echo "UEFI install with GRUB (ERASES the disk)" ;;
+		bios) echo "Legacy BIOS install with GRUB (ERASES the disk)" ;;
 		emmc) echo "Full install to this device (boot + system)" ;;
 		sd)   echo "Keep boot on current media, system on this disk" ;;
 		mtd)  echo "Boot from SPI/MTD flash, system on this disk" ;;
@@ -191,7 +205,7 @@ partitioner_cli_install() {
 	done
 
 	[[ -b "$target" ]] || { echo "armbian-install: --target must be a block device" >&2; return "$INSTALL_EX_NODEV"; }
-	case "$boot" in uefi|uefi-dualboot|emmc|sd|mtd|ufs) ;; *) echo "armbian-install: --boot must be one of uefi|uefi-dualboot|emmc|sd|mtd|ufs" >&2; return "$INSTALL_EX_USAGE" ;; esac
+	case "$boot" in uefi|uefi-dualboot|bios|emmc|sd|mtd|ufs) ;; *) echo "armbian-install: --boot must be one of uefi|uefi-dualboot|bios|emmc|sd|mtd|ufs" >&2; return "$INSTALL_EX_USAGE" ;; esac
 	case "$fs"   in ext4|btrfs|f2fs) ;;     *) echo "armbian-install: --fs must be one of ext4|btrfs|f2fs" >&2; return "$INSTALL_EX_USAGE" ;; esac
 	[[ -f "$INSTALL_EXCLUDE" ]] || { echo "armbian-install: exclude list $INSTALL_EXCLUDE missing" >&2; return "$INSTALL_EX_TRANSFER"; }
 
@@ -252,7 +266,7 @@ partitioner_help() {
 
 	Non-interactive:
 	  armbian-install --target /dev/sdX --boot <mode> --fs <fs> --yes
-	    --boot   uefi | uefi-dualboot | emmc | sd | mtd | ufs
+	    --boot   uefi | uefi-dualboot | bios | emmc | sd | mtd | ufs
 	    --fs     ext4 | btrfs | f2fs
 	    --size   GiB for Armbian (uefi-dualboot only; shrinks Windows)
 	    --yes    required to actually modify the target

--- a/tools/modules/system/module_partitioner.sh
+++ b/tools/modules/system/module_partitioner.sh
@@ -150,6 +150,12 @@ partitioner_tui() {
 
 	# 2) boot mode (dual-boot is offered when Windows is detected on the disk)
 	local -a modes; read -r -a modes <<<"$(partitioner_modes_for "$disk_role" "$disk")"
+	# Explain a missing dual-boot option when the disk holds a BitLocker Windows,
+	# instead of the option silently vanishing.
+	if [[ -d /sys/firmware/efi && " ${modes[*]} " != *" uefi-dualboot "* ]] \
+		&& install_disk_has_bitlocker "/dev/$disk"; then
+		dialog_msgbox " $title " "\n/dev/$disk has a Windows install with \Zb\Z1BitLocker\Zn device encryption, which cannot be resized for dual-boot.\n\nIn Windows: turn off Device Encryption / BitLocker (or 'manage-bde -off C:'), let it fully decrypt, then run the installer again."
+	fi
 	local boot
 	if [[ "${#modes[@]}" -eq 1 ]]; then
 		boot="${modes[0]}"

--- a/tools/modules/system/module_partitioner.sh
+++ b/tools/modules/system/module_partitioner.sh
@@ -150,11 +150,14 @@ partitioner_tui() {
 
 	# 2) boot mode (dual-boot is offered when Windows is detected on the disk)
 	local -a modes; read -r -a modes <<<"$(partitioner_modes_for "$disk_role" "$disk")"
-	# Explain a missing dual-boot option when the disk holds a BitLocker Windows,
-	# instead of the option silently vanishing.
+	# When the disk holds a BitLocker Windows, dual-boot is impossible (ntfsresize
+	# cannot shrink it). Explain why and let the user either cancel or wipe the
+	# whole disk, instead of the option silently vanishing.
 	if [[ -d /sys/firmware/efi && " ${modes[*]} " != *" uefi-dualboot "* ]] \
 		&& install_disk_has_bitlocker "/dev/$disk"; then
-		dialog_msgbox " $title " "\n/dev/$disk has a Windows install with \Zb\Z1BitLocker\Zn device encryption, which cannot be resized for dual-boot.\n\nIn Windows: turn off Device Encryption / BitLocker (or 'manage-bde -off C:'), let it fully decrypt, then run the installer again."
+		if ! dialog_yesno " $title " "\n/dev/$disk has a Windows install with \Zb\Z1BitLocker\Zn device encryption, which cannot be resized for dual-boot.\n\nTo dual-boot: turn off Device Encryption / BitLocker in Windows ('manage-bde -off C:'), let it fully decrypt, then re-run.\n\nOr WIPE the whole disk and install Armbian only?" "Wipe & install" "Cancel" 15 76; then
+			return "$INSTALL_EX_OK"
+		fi
 	fi
 	local boot
 	if [[ "${#modes[@]}" -eq 1 ]]; then

--- a/tools/modules/system/module_partitioner.sh
+++ b/tools/modules/system/module_partitioner.sh
@@ -58,9 +58,15 @@ partitioner_disk_label() {
 
 # Boot modes that make sense for a given target role + firmware.
 partitioner_modes_for() {
-	local role="$1"
+	local role="$1" disk="$2"
 	if [[ -d /sys/firmware/efi ]]; then
-		echo "uefi"; return
+		# Offer dual-boot first when an existing Windows/UEFI layout is present.
+		if [[ -n "$disk" ]] && install_detect_windows "/dev/$disk" >/dev/null 2>&1; then
+			echo "uefi-dualboot uefi"
+		else
+			echo "uefi"
+		fi
+		return
 	fi
 	case "$role" in
 		mmc)          echo "emmc sd" ;;   # eMMC can host a full install or just root
@@ -73,7 +79,8 @@ partitioner_modes_for() {
 
 partitioner_mode_desc() {
 	case "$1" in
-		uefi) echo "UEFI install with GRUB (ESP + rootfs on this disk)" ;;
+		uefi-dualboot) echo "Dual-boot: shrink Windows, install Armbian alongside it" ;;
+		uefi) echo "UEFI install with GRUB (ERASES the disk)" ;;
 		emmc) echo "Full install to this device (boot + system)" ;;
 		sd)   echo "Keep boot on current media, system on this disk" ;;
 		mtd)  echo "Boot from SPI/MTD flash, system on this disk" ;;
@@ -104,13 +111,13 @@ partitioner_tui() {
 	done <<<"$records"
 
 	local disk
-	disk=$(dialog_menu " $title " "\nSelect the destination disk (ALL DATA WILL BE ERASED):" 0 76 10 -- "${menu[@]}")
+	disk=$(dialog_menu " $title " "\nSelect the destination disk:" 0 76 10 -- "${menu[@]}")
 	[[ -z "$disk" ]] && return "$INSTALL_EX_OK"
 	local disk_role="mmc" i
 	for i in "${!names[@]}"; do [[ "${names[$i]}" == "$disk" ]] && disk_role="${roles[$i]}"; done
 
-	# 2) boot mode
-	local -a modes; read -r -a modes <<<"$(partitioner_modes_for "$disk_role")"
+	# 2) boot mode (dual-boot is offered when Windows is detected on the disk)
+	local -a modes; read -r -a modes <<<"$(partitioner_modes_for "$disk_role" "$disk")"
 	local boot
 	if [[ "${#modes[@]}" -eq 1 ]]; then
 		boot="${modes[0]}"
@@ -129,15 +136,30 @@ partitioner_tui() {
 		f2fs "Flash-friendly log-structured fs")
 	[[ -z "$fs" ]] && return "$INSTALL_EX_OK"
 
-	# 4) confirm
-	if ! dialog_yesno " WARNING " "\nThis will ERASE /dev/$disk and install Armbian ($boot, $fs).\n\nProceed?" "Erase and install" "Cancel" 10 70; then
-		return "$INSTALL_EX_OK"
+	# 4) dual-boot needs a size; other modes erase the whole disk.
+	local want_bytes=0
+	if [[ "$boot" == uefi-dualboot ]]; then
+		local gib
+		gib=$(dialog_inputbox " $title " "\nGiB to give Armbian (taken by shrinking Windows):" "32")
+		[[ "$gib" =~ ^[0-9]+$ && "$gib" -gt 0 ]] || { dialog_msgbox " $title " "\nInvalid size."; return "$INSTALL_EX_USAGE"; }
+		want_bytes=$(( gib * 1024 * 1024 * 1024 ))
+		if ! dialog_yesno " WARNING " "\nThis will SHRINK Windows on /dev/$disk and install Armbian ($fs, ${gib}GiB) alongside it.\n\nBack up first. Proceed?" "Shrink and install" "Cancel" 11 72; then
+			return "$INSTALL_EX_OK"
+		fi
+	else
+		if ! dialog_yesno " WARNING " "\nThis will ERASE /dev/$disk and install Armbian ($boot, $fs).\n\nProceed?" "Erase and install" "Cancel" 10 70; then
+			return "$INSTALL_EX_OK"
+		fi
 	fi
 
 	# 5) run - pipe the transfer percentage into a gauge, capture the real rc.
 	local rc_file; rc_file="$(mktemp)"
 	{
-		install_run_scenario "$boot" "/dev/$disk" "$fs" "$INSTALL_EXCLUDE"
+		if [[ "$boot" == uefi-dualboot ]]; then
+			install_run_dualboot "/dev/$disk" "$fs" "$INSTALL_EXCLUDE" "$want_bytes"
+		else
+			install_run_scenario "$boot" "/dev/$disk" "$fs" "$INSTALL_EXCLUDE"
+		fi
 		echo "$?" >"$rc_file"
 	} | dialog_gauge " $title " "\nInstalling to /dev/$disk - please wait..." 10 74
 	local rc; rc="$(cat "$rc_file")"; rm -f "$rc_file"
@@ -153,31 +175,38 @@ partitioner_tui() {
 # ---- non-interactive CLI ----------------------------------------------------
 
 partitioner_cli_install() {
-	# partitioner_cli_install --target /dev/X --boot MODE --fs FS [--yes]
-	local target="" boot="" fs="ext4" assume_yes=0
+	# partitioner_cli_install --target /dev/X --boot MODE --fs FS [--size GiB] [--yes]
+	local target="" boot="" fs="ext4" assume_yes=0 size_gib=0
 	INSTALL_LOG="/var/log/armbian-install.log"
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 			--target) target="$2"; shift 2 ;;
 			--boot)   boot="$2";   shift 2 ;;
 			--fs)     fs="$2";     shift 2 ;;
+			--size)   size_gib="$2"; shift 2 ;;
 			--yes|-y) assume_yes=1; shift ;;
 			*) echo "armbian-install: unknown argument '$1'" >&2; return "$INSTALL_EX_USAGE" ;;
 		esac
 	done
 
 	[[ -b "$target" ]] || { echo "armbian-install: --target must be a block device" >&2; return "$INSTALL_EX_NODEV"; }
-	case "$boot" in uefi|emmc|sd|mtd|ufs) ;; *) echo "armbian-install: --boot must be one of uefi|emmc|sd|mtd|ufs" >&2; return "$INSTALL_EX_USAGE" ;; esac
+	case "$boot" in uefi|uefi-dualboot|emmc|sd|mtd|ufs) ;; *) echo "armbian-install: --boot must be one of uefi|uefi-dualboot|emmc|sd|mtd|ufs" >&2; return "$INSTALL_EX_USAGE" ;; esac
 	case "$fs"   in ext4|btrfs|f2fs) ;;     *) echo "armbian-install: --fs must be one of ext4|btrfs|f2fs" >&2; return "$INSTALL_EX_USAGE" ;; esac
 	[[ -f "$INSTALL_EXCLUDE" ]] || { echo "armbian-install: exclude list $INSTALL_EXCLUDE missing" >&2; return "$INSTALL_EX_TRANSFER"; }
 
 	if [[ "$assume_yes" -ne 1 ]]; then
-		echo "armbian-install: refusing to ERASE $target without --yes" >&2
+		echo "armbian-install: refusing to modify $target without --yes" >&2
 		return "$INSTALL_EX_USAGE"
 	fi
 
-	echo "Installing Armbian to $target ($boot, $fs)..."
-	install_run_scenario "$boot" "$target" "$fs" "$INSTALL_EXCLUDE"
+	if [[ "$boot" == uefi-dualboot ]]; then
+		[[ "$size_gib" =~ ^[0-9]+$ && "$size_gib" -gt 0 ]] || { echo "armbian-install: --size <GiB> is required for uefi-dualboot" >&2; return "$INSTALL_EX_USAGE"; }
+		echo "Installing Armbian alongside Windows on $target (${size_gib}GiB, $fs)..."
+		install_run_dualboot "$target" "$fs" "$INSTALL_EXCLUDE" $(( size_gib * 1024 * 1024 * 1024 ))
+	else
+		echo "Installing Armbian to $target ($boot, $fs)..."
+		install_run_scenario "$boot" "$target" "$fs" "$INSTALL_EXCLUDE"
+	fi
 	local rc=$?
 	[[ "$rc" == 0 ]] && echo "Done." || echo "Failed (code $rc). See ${INSTALL_LOG:-install log}." >&2
 	return "$rc"
@@ -222,9 +251,13 @@ partitioner_help() {
 
 	Non-interactive:
 	  armbian-install --target /dev/sdX --boot <mode> --fs <fs> --yes
-	    --boot   uefi | emmc | sd | mtd | ufs
+	    --boot   uefi | uefi-dualboot | emmc | sd | mtd | ufs
 	    --fs     ext4 | btrfs | f2fs
-	    --yes    required to actually erase the target
+	    --size   GiB for Armbian (uefi-dualboot only; shrinks Windows)
+	    --yes    required to actually modify the target
+
+	Dual-boot with Windows 10/11 (UEFI):
+	  armbian-install --target /dev/sdX --boot uefi-dualboot --fs ext4 --size 32 --yes
 
 	Machine-readable:
 	  armbian-install --api detect

--- a/tools/modules/system/module_partitioner.sh
+++ b/tools/modules/system/module_partitioner.sh
@@ -298,6 +298,7 @@ partitioner_api() {
 }
 
 partitioner_help() {
+	# editorconfig-checker-disable
 	cat <<-EOF
 	Armbian installer - transfer the running system to internal storage.
 
@@ -318,6 +319,7 @@ partitioner_help() {
 	  armbian-install --api detect
 	  armbian-install --api plan --target /dev/sdX --boot uefi --fs ext4
 	EOF
+	# editorconfig-checker-enable
 }
 
 # ---- dispatch ---------------------------------------------------------------

--- a/tools/modules/system/module_partitioner.sh
+++ b/tools/modules/system/module_partitioner.sh
@@ -87,7 +87,8 @@ partitioner_modes_for() {
 		m+=(bios)
 	fi
 
-	[[ ${#m[@]} -eq 0 ]] && m+=(uefi)   # last-resort fallback
+	# No writable boot mode for this firmware/disk: emit nothing so the caller
+	# can show a clear error rather than offer a mode guaranteed to fail.
 	echo "${m[@]}"
 }
 
@@ -150,6 +151,10 @@ partitioner_tui() {
 
 	# 2) boot mode (dual-boot is offered when Windows is detected on the disk)
 	local -a modes; read -r -a modes <<<"$(partitioner_modes_for "$disk_role" "$disk")"
+	if [[ ${#modes[@]} -eq 0 ]]; then
+		dialog_msgbox " $title " "\nNo bootable install method is available for /dev/$disk on this system (no EFI firmware, no GRUB, and no board u-boot support)."
+		return "$INSTALL_EX_BOOTLOADER"
+	fi
 	# When the disk holds a BitLocker Windows, dual-boot is impossible (ntfsresize
 	# cannot shrink it). Explain why and let the user either cancel or wipe the
 	# whole disk, instead of the option silently vanishing.
@@ -226,10 +231,10 @@ partitioner_cli_install() {
 	INSTALL_LOG="/var/log/armbian-install.log"
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
-			--target) target="$2"; shift 2 ;;
-			--boot)   boot="$2";   shift 2 ;;
-			--fs)     fs="$2";     shift 2 ;;
-			--size)   size_gib="$2"; shift 2 ;;
+			--target) [[ $# -ge 2 ]] || { echo "armbian-install: --target requires a value" >&2; return "$INSTALL_EX_USAGE"; }; target="$2"; shift 2 ;;
+			--boot)   [[ $# -ge 2 ]] || { echo "armbian-install: --boot requires a value" >&2; return "$INSTALL_EX_USAGE"; }; boot="$2"; shift 2 ;;
+			--fs)     [[ $# -ge 2 ]] || { echo "armbian-install: --fs requires a value" >&2; return "$INSTALL_EX_USAGE"; }; fs="$2"; shift 2 ;;
+			--size)   [[ $# -ge 2 ]] || { echo "armbian-install: --size requires a value" >&2; return "$INSTALL_EX_USAGE"; }; size_gib="$2"; shift 2 ;;
 			--yes|-y) assume_yes=1; shift ;;
 			*) echo "armbian-install: unknown argument '$1'" >&2; return "$INSTALL_EX_USAGE" ;;
 		esac

--- a/tools/modules/system/module_partitioner.sh
+++ b/tools/modules/system/module_partitioner.sh
@@ -104,6 +104,23 @@ partitioner_mode_desc() {
 	esac
 }
 
+# Ensure mkfs.<fs> is available (the engine refuses to wipe without it). Offers
+# to install the providing package. interactive=1 uses dialogs, 0 prints/plain.
+# Returns 0 when the tool is usable.
+partitioner_ensure_fs_tool() {
+	local fs="$1" interactive="${2:-1}" pkg=""
+	command -v "mkfs.$fs" >/dev/null 2>&1 && return 0
+	case "$fs" in btrfs) pkg="btrfs-progs" ;; f2fs) pkg="f2fs-tools" ;; *) return 1 ;; esac
+	if [[ "$interactive" == 1 ]]; then
+		dialog_yesno " Install $pkg " "\nmkfs.$fs is not installed.\n\nInstall $pkg now?" "Install" "Cancel" 9 60 || return 1
+		dialog_infobox " Armbian installer " "\nInstalling $pkg ..." 5 44 2>/dev/null
+	else
+		echo "Installing $pkg ..."
+	fi
+	pkg_install "$pkg" >>"${INSTALL_LOG:-/dev/null}" 2>&1
+	command -v "mkfs.$fs" >/dev/null 2>&1
+}
+
 # ---- interactive TUI --------------------------------------------------------
 
 partitioner_tui() {
@@ -150,6 +167,10 @@ partitioner_tui() {
 		btrfs "Copy-on-write, compression, snapshots" \
 		f2fs "Flash-friendly log-structured fs")
 	[[ -z "$fs" ]] && return "$INSTALL_EX_OK"
+	if ! partitioner_ensure_fs_tool "$fs" 1; then
+		dialog_msgbox " $title " "\nCannot format as $fs: mkfs.$fs is unavailable.\n\nInstall the package and try again."
+		return "$INSTALL_EX_TOOL"
+	fi
 
 	# 4) dual-boot needs a size; other modes erase the whole disk.
 	local want_bytes=0
@@ -212,6 +233,10 @@ partitioner_cli_install() {
 	if [[ "$assume_yes" -ne 1 ]]; then
 		echo "armbian-install: refusing to modify $target without --yes" >&2
 		return "$INSTALL_EX_USAGE"
+	fi
+	if ! partitioner_ensure_fs_tool "$fs" 0; then
+		echo "armbian-install: mkfs.$fs unavailable; install its package and retry" >&2
+		return "$INSTALL_EX_TOOL"
 	fi
 
 	if [[ "$boot" == uefi-dualboot ]]; then

--- a/tools/modules/system/module_partitioner.sh
+++ b/tools/modules/system/module_partitioner.sh
@@ -1,0 +1,262 @@
+# shellcheck shell=bash
+# This is a sourced armbian-config module fragment, not a standalone script.
+declare -A module_options
+module_options+=(
+	["module_partitioner,author"]="@igorpecovnik"
+	["module_partitioner,maintainer"]="@igorpecovnik"
+	["module_partitioner,feature"]="module_partitioner"
+	["module_partitioner,example"]="run install detect plan help"
+	["module_partitioner,desc"]="Armbian installer (transfer rootfs to eMMC/NVMe/SATA/USB/UFS)"
+	["module_partitioner,status"]="review"
+	["module_partitioner,doc_link"]="https://docs.armbian.com"
+	["module_partitioner,group"]="System"
+	["module_partitioner,port"]=""
+	["module_partitioner,arch"]=""
+)
+
+#
+# module_partitioner.sh - armbian-install frontend.
+#
+# Thin layer over module_install_engine.sh: it collects the target disk, boot
+# mode and filesystem (interactively via dialog, or from CLI flags) and then
+# calls the single shared entrypoint install_run_scenario. No install logic
+# lives here.
+#
+# Invocation:
+#   module_partitioner run                         interactive dialog TUI
+#   module_partitioner install --target /dev/sdX --boot emmc --fs ext4 --yes
+#   module_partitioner detect                      TSV inventory (machine)
+#   module_partitioner plan --target /dev/sdX --boot uefi --fs ext4
+#
+# The /usr/bin/armbian-install shim shipped by the bsp package execs:
+#   armbian-config --api module_partitioner "$@"
+# so a bare `armbian-install` lands in the TUI and `armbian-install --target …`
+# runs unattended.
+
+# Where the rsync exclude list lives (shipped by the bsp package).
+: "${INSTALL_EXCLUDE:=/usr/lib/armbian-install/exclude.txt}"
+
+# Which whole disk hosts the currently running rootfs (excluded as a target).
+partitioner_root_disk() {
+	local root_uuid root_part
+	root_uuid=$(sed -e 's/^.*root=//' -e 's/ .*$//' </proc/cmdline)
+	root_part=$(blkid | tr -d '":' | grep -w "${root_uuid#UUID=}" | awk '{print $1}' | head -1)
+	[[ -z "$root_part" ]] && root_part=$(findmnt -no SOURCE / 2>/dev/null)
+	lsblk -ndo pkname "$root_part" 2>/dev/null
+}
+
+# A human label for one detect record (TSV: name role size sector bus rota model).
+partitioner_disk_label() {
+	local name="$1" role="$2" size_bytes="$3" bus="$4" model="$5"
+	local human
+	human=$(numfmt --to=iec --suffix=B "$size_bytes" 2>/dev/null || echo "${size_bytes}B")
+	local info="$role"
+	[[ -n "$bus" && "$bus" != "null" ]] && info="$bus $role"
+	[[ -n "$model" && "$model" != "null" ]] && info="$model"
+	printf '%-10s %8s  %s' "/dev/$name" "$human" "$info"
+}
+
+# Boot modes that make sense for a given target role + firmware.
+partitioner_modes_for() {
+	local role="$1"
+	if [[ -d /sys/firmware/efi ]]; then
+		echo "uefi"; return
+	fi
+	case "$role" in
+		mmc)          echo "emmc sd" ;;   # eMMC can host a full install or just root
+		nvme|sata|usb) echo "sd" ;;       # boot stays on removable media, root here
+		mtd)          echo "mtd" ;;
+		ufs)          echo "ufs" ;;
+		*)            echo "sd" ;;
+	esac
+}
+
+partitioner_mode_desc() {
+	case "$1" in
+		uefi) echo "UEFI install with GRUB (ESP + rootfs on this disk)" ;;
+		emmc) echo "Full install to this device (boot + system)" ;;
+		sd)   echo "Keep boot on current media, system on this disk" ;;
+		mtd)  echo "Boot from SPI/MTD flash, system on this disk" ;;
+		ufs)  echo "Boot idblock on UFS boot LUN, system on UFS" ;;
+		*)    echo "$1" ;;
+	esac
+}
+
+# ---- interactive TUI --------------------------------------------------------
+
+partitioner_tui() {
+	local title="Armbian installer"
+	INSTALL_LOG="/var/log/armbian-install.log"
+	local root_disk; root_disk="$(partitioner_root_disk)"
+
+	# 1) target disk
+	local records; records="$(install_detect_targets "$root_disk")"
+	if [[ -z "$records" ]]; then
+		dialog_msgbox " $title " "\nNo installation targets were found.\n\nAttach an eMMC/NVMe/SATA/USB disk and try again."
+		return "$INSTALL_EX_NODEV"
+	fi
+	local -a menu=() names=() roles=()
+	local name role size sec bus rota model
+	while IFS=$'\t' read -r name role size sec bus rota model; do
+		[[ -n "$name" ]] || continue
+		names+=("$name"); roles+=("$role")
+		menu+=("$name" "$(partitioner_disk_label "$name" "$role" "$size" "$bus" "$model")")
+	done <<<"$records"
+
+	local disk
+	disk=$(dialog_menu " $title " "\nSelect the destination disk (ALL DATA WILL BE ERASED):" 0 76 10 -- "${menu[@]}")
+	[[ -z "$disk" ]] && return "$INSTALL_EX_OK"
+	local disk_role="mmc" i
+	for i in "${!names[@]}"; do [[ "${names[$i]}" == "$disk" ]] && disk_role="${roles[$i]}"; done
+
+	# 2) boot mode
+	local -a modes; read -r -a modes <<<"$(partitioner_modes_for "$disk_role")"
+	local boot
+	if [[ "${#modes[@]}" -eq 1 ]]; then
+		boot="${modes[0]}"
+	else
+		local -a mmenu=()
+		for i in "${modes[@]}"; do mmenu+=("$i" "$(partitioner_mode_desc "$i")"); done
+		boot=$(dialog_menu " $title " "\nChoose how /dev/$disk should boot:" 0 76 8 -- "${mmenu[@]}")
+		[[ -z "$boot" ]] && return "$INSTALL_EX_OK"
+	fi
+
+	# 3) filesystem
+	local fs
+	fs=$(dialog_menu " $title " "\nRoot filesystem for /dev/$disk:" 0 60 6 -- \
+		ext4 "Default, most compatible" \
+		btrfs "Copy-on-write, compression, snapshots" \
+		f2fs "Flash-friendly log-structured fs")
+	[[ -z "$fs" ]] && return "$INSTALL_EX_OK"
+
+	# 4) confirm
+	if ! dialog_yesno " WARNING " "\nThis will ERASE /dev/$disk and install Armbian ($boot, $fs).\n\nProceed?" "Erase and install" "Cancel" 10 70; then
+		return "$INSTALL_EX_OK"
+	fi
+
+	# 5) run - pipe the transfer percentage into a gauge, capture the real rc.
+	local rc_file; rc_file="$(mktemp)"
+	{
+		install_run_scenario "$boot" "/dev/$disk" "$fs" "$INSTALL_EXCLUDE"
+		echo "$?" >"$rc_file"
+	} | dialog_gauge " $title " "\nInstalling to /dev/$disk - please wait..." 10 74
+	local rc; rc="$(cat "$rc_file")"; rm -f "$rc_file"
+
+	if [[ "$rc" == "0" ]]; then
+		dialog_msgbox " $title " "\nInstallation to /dev/$disk finished successfully.\n\nRemove the boot media (if applicable) and reboot."
+	else
+		dialog_msgbox " $title " "\nInstallation FAILED (code $rc).\n\nSee ${INSTALL_LOG:-the install log} for details."
+	fi
+	return "$rc"
+}
+
+# ---- non-interactive CLI ----------------------------------------------------
+
+partitioner_cli_install() {
+	# partitioner_cli_install --target /dev/X --boot MODE --fs FS [--yes]
+	local target="" boot="" fs="ext4" assume_yes=0
+	INSTALL_LOG="/var/log/armbian-install.log"
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+			--target) target="$2"; shift 2 ;;
+			--boot)   boot="$2";   shift 2 ;;
+			--fs)     fs="$2";     shift 2 ;;
+			--yes|-y) assume_yes=1; shift ;;
+			*) echo "armbian-install: unknown argument '$1'" >&2; return "$INSTALL_EX_USAGE" ;;
+		esac
+	done
+
+	[[ -b "$target" ]] || { echo "armbian-install: --target must be a block device" >&2; return "$INSTALL_EX_NODEV"; }
+	case "$boot" in uefi|emmc|sd|mtd|ufs) ;; *) echo "armbian-install: --boot must be one of uefi|emmc|sd|mtd|ufs" >&2; return "$INSTALL_EX_USAGE" ;; esac
+	case "$fs"   in ext4|btrfs|f2fs) ;;     *) echo "armbian-install: --fs must be one of ext4|btrfs|f2fs" >&2; return "$INSTALL_EX_USAGE" ;; esac
+	[[ -f "$INSTALL_EXCLUDE" ]] || { echo "armbian-install: exclude list $INSTALL_EXCLUDE missing" >&2; return "$INSTALL_EX_TRANSFER"; }
+
+	if [[ "$assume_yes" -ne 1 ]]; then
+		echo "armbian-install: refusing to ERASE $target without --yes" >&2
+		return "$INSTALL_EX_USAGE"
+	fi
+
+	echo "Installing Armbian to $target ($boot, $fs)..."
+	install_run_scenario "$boot" "$target" "$fs" "$INSTALL_EXCLUDE"
+	local rc=$?
+	[[ "$rc" == 0 ]] && echo "Done." || echo "Failed (code $rc). See ${INSTALL_LOG:-install log}." >&2
+	return "$rc"
+}
+
+# ---- --api helpers (machine-readable, for scripts and tests) ----------------
+
+partitioner_api() {
+	# partitioner_api detect|plan [flags]
+	local what="$1"; shift
+	case "$what" in
+		detect)
+			install_detect_targets "$(partitioner_root_disk)" ;;
+		plan)
+			local target="" boot="" fs="ext4"
+			while [[ $# -gt 0 ]]; do
+				case "$1" in
+					--target) target="$2"; shift 2 ;;
+					--boot)   boot="$2";   shift 2 ;;
+					--fs)     fs="$2";     shift 2 ;;
+					*) shift ;;
+				esac
+			done
+			local cap=0 sec=512 uefi=0
+			if [[ -b "$target" ]]; then
+				cap="$(blockdev --getsize64 "$target" 2>/dev/null || echo 0)"
+				sec="$(cat "/sys/block/$(basename "$target")/queue/physical_block_size" 2>/dev/null || echo 512)"
+			fi
+			[[ "$boot" == uefi ]] && uefi=1
+			install_plan_layout "$boot" "$fs" "$uefi" "$cap" "$sec" 0 ;;
+		*)
+			echo "usage: armbian-install --api {detect|plan}" >&2; return "$INSTALL_EX_USAGE" ;;
+	esac
+}
+
+partitioner_help() {
+	cat <<-EOF
+	Armbian installer - transfer the running system to internal storage.
+
+	Interactive:
+	  armbian-install
+
+	Non-interactive:
+	  armbian-install --target /dev/sdX --boot <mode> --fs <fs> --yes
+	    --boot   uefi | emmc | sd | mtd | ufs
+	    --fs     ext4 | btrfs | f2fs
+	    --yes    required to actually erase the target
+
+	Machine-readable:
+	  armbian-install --api detect
+	  armbian-install --api plan --target /dev/sdX --boot uefi --fs ext4
+	EOF
+}
+
+# ---- dispatch ---------------------------------------------------------------
+
+module_partitioner() {
+	# Source the board u-boot hooks so install_write_bootloader can find them.
+	[[ -f /usr/lib/u-boot/platform_install.sh ]] && source /usr/lib/u-boot/platform_install.sh
+
+	local commands
+	IFS=' ' read -r -a commands <<<"${module_options["module_partitioner,example"]}"
+
+	case "$1" in
+		"${commands[0]}"|"")              # run (or bare invocation) -> TUI
+			partitioner_tui ;;
+		"${commands[1]}")                 # install -> non-interactive
+			shift; partitioner_cli_install "$@" ;;
+		"${commands[2]}")                 # detect -> engine inventory
+			partitioner_api detect ;;
+		"${commands[3]}")                 # plan -> engine planner
+			shift; partitioner_api plan "$@" ;;
+		"${commands[4]}"|-h|--help)       # help
+			partitioner_help ;;
+		--target)                         # bare flags from the shim -> CLI
+			partitioner_cli_install "$@" ;;
+		--api)                            # bare --api from the shim
+			shift; partitioner_api "$@" ;;
+		*)
+			partitioner_help; return "$INSTALL_EX_USAGE" ;;
+	esac
+}


### PR DESCRIPTION
## What

Redesign the fragile 1220-line `armbian-install` bsp monolith into a small, single-responsibility **engine library** + a thin **dialog frontend** + a first-class **non-interactive CLI**, all inside armbian-config. Companion PR in build replaces the old script with a shim: armbian/build (branch `armbian-install-shim`).

## Why

The old tool tangled detection, UI, partitioning, mkfs, rsync, boot-config rewriting and u-boot writing into one `create_armbian()` with no tests and no non-interactive path — so the same bug classes kept shipping. This structure fixes them **by construction** and locks each with a test.

## Layout

- **`tools/modules/functions/module_install_engine.sh`** — pure, dialog-free primitives: `install_detect_targets`, pure `install_table_type`/`install_plan_layout`, `install_apply_partitions`, `install_make_filesystems`, `install_transfer_rootfs`, `install_gen_fstab`/`install_rewrite_bootenv`/`install_populate_boot`, `install_write_bootloader`/`install_grub_install`, `install_verify_*`, and the shared `install_run_scenario` orchestrator. Named exit codes replace magic numbers.
- **`tools/modules/system/module_partitioner.sh`** — thin dialog TUI (reuses existing `dialog_*` helpers) + non-interactive CLI (`--target/--boot/--fs/--yes`, `--api detect|plan`). Both funnel into `install_run_scenario`.
- **`tests/bats/`** + **`.github/workflows/maintenance-bats.yml`** — 28 unit tests + 5 loopback integration tests, in CI.

## Bugs fixed (each with a test)

| Bug | Fix |
|---|---|
| build#8738 multi-disk name concatenation | detect emits one TSV record per device |
| build#9454 / #9794 MBR-only, >2TiB / 4Kn | planner picks GPT when uefi ∨ >2TiB ∨ 4Kn; MiB-aligned partitions |
| build#6905 missing boot/ESP flag | explicit esp/boot flags in the plan |
| build#10099 / #10064 empty /boot | `install_populate_boot` + `install_verify_boot_dir` refuse an unbootable result |

## Testing

- **28/28 unit + 5/5 loopback** pass (loopback exercised on a real `losetup` device: partition → mkfs → fstab, incl. GPT/MBR/flag/blocksize). shellcheck `--severity=error` clean.

## Not yet validated

`install_run_scenario`'s full end-to-end path (rootfs rsync + real bootloader/GRUB write) needs board/KVM smoke before the bsp shim is cut over — the u-boot scenarios depend on board `write_uboot_platform*` hooks that only exist on a real image.

## Dropped

Legacy sunxi NAND (`/dev/nand`, `format_nand`, a10/a13/a20 assets).