### PR TITLE
software/jellyfin - Add host mounts for music, books

### DIFF
--- a/tools/modules/software/module_jellyfin.sh
+++ b/tools/modules/software/module_jellyfin.sh
@@ -81,6 +81,8 @@ function module_jellyfin () {
 				-v "${base_dir}/config:/config" \
 				-v "${base_dir}/tvseries:/data/tvshows" \
 				-v "${base_dir}/movies:/data/movies" \
+				-v "${base_dir}/music:/data/music" \
+				-v "${base_dir}/books:/data/books" \
 				--restart=always \
 				"$dockerimage"
 		;;


### PR DESCRIPTION
# Description

I wanted to use Jellyfin to listen to music and read books, but couldn't add libraries for them as only `movies` and `tvshows` mounts were configured.  

This change adds two more mounts on the hosts for these new media types, making Armbian+Jellyfin useful out-of-the-box for more media types.


# Implementation Details

This change adds two new directories to the Docker command that creates the container in the same way the existing `movies` and `tvshows` directories are created.  

This is needed to allow Jellyfin access to additional directories on the underlying host for `music` and `books` media.

No other changes or dependencies are introduced.

# Documentation Summary

- [ ] **Metadata Included:**  
> No metadata was added.

- [ ] **Document Generated:**  
> Command run but no output was generated

# Testing Procedure

The tests below were completed on KDE Plasma 6.7.3.

- [X] Test 1: Ran `tools/config-assemble.sh -t` with no errors
- [X] Test 2: Ran `tools/config-assemble.sh -p` with no changes

# Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have ensured that my changes do not introduce new warnings or errors
- [X] No new external dependencies are included
- [X] Changes have been tested and verified
- [X] I have included necessary metadata in the code, including associative arrays
