### PR TITLE
json: fix duplicate and over-length menu IDs

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -760,9 +760,9 @@ Outputs:
 	--cmd APT001 - apt-cacher-ng caching proxy install
 	--cmd APT002 - apt-cacher-ng remove (http://localhost:3142/acng-report.html)
 	--cmd APT003 - apt-cacher-ng purge with cache folder
-	--cmd GCDN001 - git_cdn GitHub caching proxy install
-	--cmd GCDN002 - git_cdn remove
-	--cmd GCDN003 - git_cdn purge with cache folder
+	--cmd GCD001 - git_cdn GitHub caching proxy install
+	--cmd GCD002 - git_cdn remove
+	--cmd GCD003 - git_cdn purge with cache folder
 	--cmd SMB001 - SAMBA Remote File share
 	--cmd WBM001 - Webmin web-based management tool
     Media - Media servers, organizers and editors

--- a/tools/json/config.localisation.json
+++ b/tools/json/config.localisation.json
@@ -41,7 +41,7 @@
                     "help": "Change Keyboard layout"
                 },
                 {
-                    "id": "APT001",
+                    "id": "APM001",
                     "description": "Change APT mirrors",
                     "about": "This will change the APT mirrors",
                     "command": [

--- a/tools/json/config.software.json
+++ b/tools/json/config.software.json
@@ -1453,7 +1453,7 @@
                             "help": "apt-cacher-ng purge with cache folder"
                         },
                         {
-                            "id": "GCDN001",
+                            "id": "GCD001",
                             "description": "git_cdn GitHub caching proxy install",
                             "short": "git_cdn",
                             "module": "module_git_cdn",
@@ -1468,7 +1468,7 @@
                             "help": "git_cdn is a git+http(s) proxy that mirrors an upstream git server (GitHub) on your LAN, so repeated clones/fetches of the same repo across multiple hosts only pull new objects from upstream once."
                         },
                         {
-                            "id": "GCDN002",
+                            "id": "GCD002",
                             "description": "git_cdn remove",
                             "about": "This operation will remove the git_cdn container",
                             "command": [
@@ -1480,7 +1480,7 @@
                             "help": "git_cdn remove"
                         },
                         {
-                            "id": "GCDN003",
+                            "id": "GCD003",
                             "description": "git_cdn purge with cache folder",
                             "about": "This operation will purge git_cdn cache data and remove the container",
                             "command": [


### PR DESCRIPTION
Fixes the two repo-wide JSON validation checks that are red on `main`:

- **Check Duplicate IDs** — `APT001` was used twice: `config.localisation.json` ("Change APT mirrors") and `config.software.json` (apt-cacher-ng). Renamed the **localisation** entry to `APM001` (unique, matches the 3-letter+3-digit convention). The documented `--cmd APT001` (apt-cacher-ng) is unchanged.
- **Check ID Lengths** (IDs must be exactly 6 chars) — git_cdn's `GCDN001/002/003` were 7 chars → `GCD001/002/003`; `--cmd` refs in `DOCUMENTATION.md` updated to match.

No behaviour change (IDs are just unique menu / `--cmd` handles). Verified locally: no duplicate and no non-6-char IDs remain (excluding the category IDs the checks exclude).

Kept **separate** from #951 (armbian-install redesign) since these predate it and are in files #951 doesn't touch. The coding-style check on #951 is PR-specific (its `module_*.sh` don't exist on main) and is handled there.