### PR TITLE
armbian-install: don't offer eMMC boot0/boot1/rpmb as install targets

### DIFF
--- a/tests/bats/detect.bats
+++ b/tests/bats/detect.bats
@@ -56,6 +56,19 @@ setup() {
 	echo "$output" | grep -qP '^sda\tusb\t'
 }
 
+@test "detect: excludes eMMC boot0/boot1/rpmb hardware partitions" {
+	# An eMMC exposes read-only boot areas and an RPMB partition as their own
+	# TYPE=disk devices (see the installer's destination menu). Only the main
+	# mmcblk0 user-data device may be offered as an install target.
+	run install_detect_targets "" "$(cat "$FIX/lsblk_emmc.json")"
+	[ "$status" -eq 0 ]
+	[ "${#lines[@]}" -eq 1 ]
+	echo "$output" | grep -qP '^mmcblk0\tmmc\t'
+	[[ "$output" != *"boot0"* ]]
+	[[ "$output" != *"boot1"* ]]
+	[[ "$output" != *"rpmb"* ]]
+}
+
 @test "detect: surfaces sector size and model" {
 	run install_detect_targets "" "$(cat "$FIX/lsblk_4kn_large.json")"
 	# 4Kn NVMe reports phy-sec 4096 in field 4.

--- a/tests/bats/fixtures/lsblk_emmc.json
+++ b/tests/bats/fixtures/lsblk_emmc.json
@@ -1,0 +1,8 @@
+{
+    "blockdevices": [
+        {"name":"mmcblk0","type":"disk","size":63316279296,"phy-sec":512,"tran":null,"rota":false,"model":"mmc"},
+        {"name":"mmcblk0boot0","type":"disk","size":4194304,"phy-sec":512,"tran":null,"rota":false,"model":"mmc"},
+        {"name":"mmcblk0boot1","type":"disk","size":4194304,"phy-sec":512,"tran":null,"rota":false,"model":"mmc"},
+        {"name":"mmcblk0rpmb","type":"disk","size":4194304,"phy-sec":512,"tran":null,"rota":false,"model":"mmc"}
+    ]
+}

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -108,6 +108,11 @@ install_detect_targets() {
 		# zram (compressed RAM swap), ram disks, loop, optical (sr), floppy (fd),
 		# and device-mapper (dm-) nodes.
 		| select(.name | test("^(zram|ram|loop|sr|fd|dm-)[0-9-]") | not)
+		# eMMC exposes its read-only boot areas (mmcblkXboot0/boot1) and the
+		# RPMB partition as their own TYPE=disk block devices. They are ~4 MB,
+		# not writable as normal storage, and never valid install targets, so
+		# drop them - only the main mmcblkX user-data device is a candidate.
+		| select(.name | test("^mmcblk[0-9]+(boot[0-9]+|rpmb)$") | not)
 		| { n: .name, t: (.tran // ""), sz: (.size // 0),
 			ps: (."phy-sec" // 512), ro: (.rota // false), md: ((.model // "") | gsub("\t"; " ")) }
 		| .role = ( if   (.n | test("^nvme"))     then "nvme"


### PR DESCRIPTION
## Problem

Installing to eMMC, the destination-disk menu lists the eMMC **boot hardware partitions** alongside the real disk:

```
mmcblk0        /dev/mmcblk0        59GB   mmc mmc
mmcblk0boot0   /dev/mmcblk0boot0   4.0MB  mmc mmc
mmcblk0boot1   /dev/mmcblk0boot1   4.0MB  mmc mmc
```

`mmcblk0boot0`/`boot1` (and `mmcblk0rpmb`) are read-only boot/RPMB hardware areas that lsblk reports as their own `TYPE=disk` devices. They are ~4 MB, not writable as normal storage, and never valid install destinations — but `install_detect_targets` selected on `.type == "disk"` and so surfaced them as choices.

## Fix

Drop names matching `^mmcblk[0-9]+(boot[0-9]+|rpmb)$` in the `install_detect_targets` jq, right after the existing pseudo-device filter. Only the main `mmcblkX` user-data device is offered.

## Tests

- New fixture `tests/bats/fixtures/lsblk_emmc.json` (mmcblk0 + boot0 + boot1 + rpmb).
- New `detect.bats` case: asserts exactly one record (`mmcblk0`) and that `boot0`/`boot1`/`rpmb` are absent.

Verified with a direct smoke run (bats not available in my env): the eMMC fixture now yields only `mmcblk0`, the existing multidisk fixture is unchanged, and a multi-digit controller (`mmcblk12boot0`) is handled correctly.