### PR TITLE
armbian-install: make eMMC installs boot on RK3588 (u-boot offset + GPT table)

### DIFF
--- a/tests/bats/detect.bats
+++ b/tests/bats/detect.bats
@@ -69,6 +69,32 @@ setup() {
 	[[ "$output" != *"rpmb"* ]]
 }
 
+@test "source table: selects the /boot device's type, not /'s, when they differ" {
+	# SD /boot (gpt) + NVMe root (msdos): u-boot reads /boot, so the target must
+	# replicate the /boot device's table (gpt), not the root device's.
+	findmnt() { case "$*" in *' /boot'*) echo /dev/mmcblk0p1 ;; *) echo /dev/nvme0n1p1 ;; esac; }
+	lsblk()   {
+		local a="$*"
+		if [[ "$a" == *PKNAME* ]]; then
+			[[ "$a" == *mmcblk0p1* ]] && echo mmcblk0
+			[[ "$a" == *nvme0n1p1* ]] && echo nvme0n1
+		elif [[ "$a" == *PTTYPE* ]]; then
+			[[ "$a" == *mmcblk0* ]] && echo gpt
+			[[ "$a" == *nvme0n1* ]] && echo dos
+		fi
+	}
+	run install_source_table_type
+	[ "$output" = "gpt" ]
+}
+
+@test "source table: falls back to / when /boot is not a separate mount" {
+	# /boot is a dir on / (no mount) -> use the root device's table.
+	findmnt() { case "$*" in *' /boot'*) echo "" ;; *) echo /dev/mmcblk0p1 ;; esac; }
+	lsblk()   { case "$*" in *PKNAME*) echo mmcblk0 ;; *PTTYPE*) echo dos ;; esac; }
+	run install_source_table_type
+	[ "$output" = "msdos" ]
+}
+
 @test "detect: surfaces sector size and model" {
 	run install_detect_targets "" "$(cat "$FIX/lsblk_4kn_large.json")"
 	# 4Kn NVMe reports phy-sec 4096 in field 4.

--- a/tests/bats/integration_loopback.bats
+++ b/tests/bats/integration_loopback.bats
@@ -47,6 +47,9 @@ teardown() {
 	LC_ALL=C parted -sm "$LOOP" print | grep -q 'boot'
 	[ -b "${LOOP}p1" ]
 	[ ! -b "${LOOP}p2" ]
+	# p1 must start at 16MiB so it clears the on-device u-boot region
+	# (idbloader@32KiB + u-boot.itb@8MiB); starting at 1MiB corrupts boot.
+	LC_ALL=C parted -sm "$LOOP" unit MiB print | grep -qE '^1:16\.0MiB:'
 }
 
 @test "loopback: apply_partitions echoes role->device for each partition" {

--- a/tests/bats/plan.bats
+++ b/tests/bats/plan.bats
@@ -76,6 +76,23 @@ setup() {
 	[[ "$output" != *"part=boot:"* ]]
 }
 
+@test "plan emmc: reserves 16MiB before the first partition for on-device u-boot" {
+	# emmc dd's idbloader (32KiB) + u-boot.itb (8MiB) to raw sectors of this same
+	# device, so the first partition must start at 16MiB (classic FIRSTSECTOR=32768)
+	# or the filesystem and the bootloader clobber each other and the board won't boot.
+	run install_plan_layout emmc ext4 0 $(( 16 * GIB )) 512 0
+	[[ "$output" == *"start=16"* ]]
+}
+
+@test "plan: non-emmc modes keep the 1MiB start (u-boot lives off this device)" {
+	run install_plan_layout uefi ext4 1 $(( 16 * GIB )) 512 0
+	[[ "$output" == *"start=1"* ]]
+	run install_plan_layout sd ext4 0 $(( 500 * GIB )) 512 0
+	[[ "$output" == *"start=1"* ]]
+	run install_plan_layout bios ext4 0 $(( 20 * GIB )) 512 0
+	[[ "$output" == *"start=1"* ]]
+}
+
 @test "plan emmc btrfs: separate ext4 boot + btrfs root (u-boot can't read btrfs)" {
 	run install_plan_layout emmc btrfs 0 $(( 16 * GIB )) 512 0
 	[[ "$output" == *"part=boot:512MiB:ext4:boot"* ]]

--- a/tests/bats/plan.bats
+++ b/tests/bats/plan.bats
@@ -33,6 +33,25 @@ setup() {
 	[ "$output" = "gpt" ]
 }
 
+@test "table: honours a gpt preference when nothing forces the choice" {
+	# eMMC/SD installs replicate the running image's table so the board's u-boot
+	# can read it - Rockchip vendor u-boot (2017.09) parses GPT only.
+	run install_table_type 0 $(( 16 * GIB )) 512 gpt
+	[ "$output" = "gpt" ]
+}
+
+@test "table: honours an msdos preference (Allwinner: SPL at 8KiB clashes with GPT)" {
+	run install_table_type 0 $(( 16 * GIB )) 512 msdos
+	[ "$output" = "msdos" ]
+}
+
+@test "table: hard requirements override the preference (4Kn / >2TiB still gpt)" {
+	run install_table_type 0 $(( 16 * GIB )) 4096 msdos
+	[ "$output" = "gpt" ]
+	run install_table_type 0 $(( 4 * TIB )) 512 msdos
+	[ "$output" = "gpt" ]
+}
+
 # --- uefi layout -------------------------------------------------------------
 
 @test "plan uefi: gpt, ESP first with esp+boot flags, root fills rest" {
@@ -74,6 +93,19 @@ setup() {
 	[[ "$output" == *"part=root:100%:ext4:boot"* ]]
 	# ext4 keeps /boot as a directory: no separate boot partition.
 	[[ "$output" != *"part=boot:"* ]]
+}
+
+@test "plan emmc: replicates a gpt source table so Rockchip vendor u-boot can read it" {
+	# Regression: an MBR eMMC made the RK3588 vendor u-boot loop on
+	# "Invalid GPT" and never find the kernel. Passing the source's gpt through
+	# must yield a gpt target.
+	run install_plan_layout emmc ext4 0 $(( 16 * GIB )) 512 0 gpt
+	[[ "$output" == *"table=gpt"* ]]
+}
+
+@test "plan emmc: an msdos source stays msdos (Allwinner)" {
+	run install_plan_layout emmc ext4 0 $(( 16 * GIB )) 512 0 msdos
+	[[ "$output" == *"table=msdos"* ]]
 }
 
 @test "plan emmc: reserves 16MiB before the first partition for on-device u-boot" {

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -66,17 +66,44 @@ install_log() {
 readonly INSTALL_TWO_TIB=$(( 2 * 1024 * 1024 * 1024 * 1024 ))
 
 install_table_type() {
-	# install_table_type <is_uefi> <capacity_bytes> <sector_size>
+	# install_table_type <is_uefi> <capacity_bytes> <sector_size> [preferred]
 	# GPT when firmware is UEFI, the disk is larger than the MBR ceiling, or the
-	# medium is 4Kn; msdos otherwise. Pure - no device access.
-	local is_uefi="$1" cap="${2:-0}" sec="${3:-512}"
+	# medium is 4Kn - these are hard requirements and override everything. When
+	# none of those force the choice, honour <preferred> (gpt|msdos) if given -
+	# this is how an eMMC/SD install replicates the running image's table type so
+	# the board's u-boot can actually read it. Falls back to msdos. Pure - no
+	# device access.
+	local is_uefi="$1" cap="${2:-0}" sec="${3:-512}" preferred="${4:-}"
 	if [[ "$is_uefi" == "1" || "$is_uefi" == "uefi" ]] \
 		|| (( cap > INSTALL_TWO_TIB )) \
 		|| (( sec == 4096 )); then
 		echo "gpt"
-	else
-		echo "msdos"
+		return 0
 	fi
+	case "$preferred" in
+		gpt|msdos) echo "$preferred" ;;
+		*)         echo "msdos" ;;
+	esac
+}
+
+install_source_table_type() {
+	# Echo the partition-table type (gpt|msdos) of the disk the running system
+	# boots from, or nothing if it can't be determined. An eMMC/SD install must
+	# replicate this so the board's bootloader can read the result: Rockchip
+	# vendor u-boot (2017.09) parses GPT only - an MBR eMMC gives endless
+	# "Invalid GPT" and never finds the kernel - while Allwinner needs MBR
+	# because its SPL at sector 16 (8KiB) overlaps a GPT partition-entry array.
+	# Impure: reads the live block layout.
+	local rootsrc disk ptt
+	rootsrc="$(findmnt -no SOURCE / 2>/dev/null)" || return 0
+	[[ -n "$rootsrc" ]] || return 0
+	disk="$(lsblk -no PKNAME "$rootsrc" 2>/dev/null | head -1)"
+	[[ -n "$disk" ]] || return 0
+	ptt="$(lsblk -ndo PTTYPE "/dev/$disk" 2>/dev/null | head -1)"
+	case "$ptt" in
+		gpt) echo "gpt" ;;
+		dos) echo "msdos" ;;
+	esac
 }
 
 # ---- detection --------------------------------------------------------------
@@ -132,7 +159,11 @@ install_detect_targets() {
 # ---- partition planning (pure) ---------------------------------------------
 
 install_plan_layout() {
-	# install_plan_layout <boot_mode> <fs> <is_uefi> <capacity_bytes> <sector_size> [has_swap]
+	# install_plan_layout <boot_mode> <fs> <is_uefi> <capacity_bytes> <sector_size> [has_swap] [table_pref]
+	#
+	# table_pref (gpt|msdos): preferred partition table when capacity/sector/uefi
+	# don't force GPT - used to replicate the running image's table type on an
+	# eMMC/SD target so the board's u-boot can read it. Empty = default (msdos).
 	#
 	# boot_mode: uefi | emmc | sd | mtd | ufs
 	#   uefi  - full install to an internal disk with an ESP + GRUB
@@ -146,9 +177,9 @@ install_plan_layout() {
 	#   part=<role>:<size>:<fstype>:<flags>       (one line per partition, in order)
 	# where size is an absolute "<N>MiB" or "100%" (fill), and flags is a
 	# comma-separated subset of {esp,boot,bios_grub} ("" for none). Pure: no device I/O.
-	local boot_mode="$1" fs="$2" is_uefi="$3" cap="${4:-0}" sec="${5:-512}" has_swap="${6:-0}"
+	local boot_mode="$1" fs="$2" is_uefi="$3" cap="${4:-0}" sec="${5:-512}" has_swap="${6:-0}" table_pref="${7:-}"
 	local table
-	table="$(install_table_type "$is_uefi" "$cap" "$sec")"
+	table="$(install_table_type "$is_uefi" "$cap" "$sec" "$table_pref")"
 
 	local -a parts=()
 	case "$boot_mode" in
@@ -932,7 +963,17 @@ install_run_scenario() {
 	[[ "$boot_mode" == uefi ]] && is_uefi=1
 	grep -q swap /etc/fstab 2>/dev/null && has_swap=1
 
-	local plan; plan="$(install_plan_layout "$boot_mode" "$fs" "$is_uefi" "$cap" "$sec" "$has_swap")" \
+	# eMMC/SD installs must use the same partition-table type as the running
+	# image so the board's u-boot can read the result (Rockchip vendor u-boot
+	# reads GPT only; Allwinner needs MBR). Replicate the source; the planner
+	# still upgrades to GPT when capacity/sector size demand it.
+	local table_pref=""
+	case "$boot_mode" in
+		emmc|sd) table_pref="$(install_source_table_type)"
+			[[ -n "$table_pref" ]] && install_log INFO "scenario: inheriting source partition table '$table_pref' for $boot_mode" ;;
+	esac
+
+	local plan; plan="$(install_plan_layout "$boot_mode" "$fs" "$is_uefi" "$cap" "$sec" "$has_swap" "$table_pref")" \
 		|| { install_log ERR "scenario: planning failed"; return "$INSTALL_EX_PARTITION"; }
 	install_log INFO "scenario: $boot_mode on $disk (${cap}B, ${sec}B sectors) fs=$fs"$'\n'"$plan"
 

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -87,17 +87,22 @@ install_table_type() {
 }
 
 install_source_table_type() {
-	# Echo the partition-table type (gpt|msdos) of the disk the running system
+	# Echo the partition-table type (gpt|msdos) of the disk the board actually
 	# boots from, or nothing if it can't be determined. An eMMC/SD install must
 	# replicate this so the board's bootloader can read the result: Rockchip
 	# vendor u-boot (2017.09) parses GPT only - an MBR eMMC gives endless
 	# "Invalid GPT" and never finds the kernel - while Allwinner needs MBR
 	# because its SPL at sector 16 (8KiB) overlaps a GPT partition-entry array.
-	# Impure: reads the live block layout.
-	local rootsrc disk ptt
-	rootsrc="$(findmnt -no SOURCE / 2>/dev/null)" || return 0
-	[[ -n "$rootsrc" ]] || return 0
-	disk="$(lsblk -no PKNAME "$rootsrc" 2>/dev/null | head -1)"
+	#
+	# Prefer the device that holds /boot: that is the one u-boot reads, and it can
+	# be a different disk with a different table than / (e.g. SD /boot + NVMe root).
+	# Fall back to / when /boot is not its own mount. --nofsroot strips any bind or
+	# subvolume suffix so lsblk gets a bare device. Impure: reads the live layout.
+	local src disk ptt
+	src="$(findmnt -no SOURCE --nofsroot /boot 2>/dev/null)"
+	[[ "$src" == /dev/* ]] || src="$(findmnt -no SOURCE --nofsroot / 2>/dev/null)"
+	[[ "$src" == /dev/* ]] || return 0
+	disk="$(lsblk -no PKNAME "$src" 2>/dev/null | head -1)"
 	[[ -n "$disk" ]] || return 0
 	ptt="$(lsblk -ndo PTTYPE "/dev/$disk" 2>/dev/null | head -1)"
 	case "$ptt" in

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -190,6 +190,17 @@ install_plan_layout() {
 			;;
 	esac
 
+	# First-partition start offset, in MiB. emmc is the only mode that writes
+	# u-boot to raw sectors of this same device (idbloader at 32KiB, u-boot.itb
+	# at 8MiB on Rockchip et al.), so its first partition must clear that region
+	# or the filesystem and the bootloader overwrite each other and the board
+	# won't boot. 16MiB matches the classic installer's FIRSTSECTOR=32768 and
+	# covers every SoC's bootloader area. All other modes keep u-boot off this
+	# device (SPI/UFS) or on removable media, so 1MiB alignment is fine.
+	local start_mib=1
+	[[ "$boot_mode" == emmc ]] && start_mib=16
+
+	echo "start=$start_mib"
 	echo "table=$table"
 	local p
 	for p in "${parts[@]}"; do
@@ -221,11 +232,12 @@ install_apply_partitions() {
 	[[ -z "$plan" ]] && plan="$(cat)"
 	[[ -b "$device" ]] || { install_log ERR "apply_partitions: '$device' is not a block device"; return "$INSTALL_EX_NODEV"; }
 
-	local table="" ; local -a parts=()
+	local table="" start_override="" ; local -a parts=()
 	local line
 	while IFS= read -r line; do
 		case "$line" in
 			table=*) table="${line#table=}" ;;
+			start=*) start_override="${line#start=}" ;;
 			part=*)  parts+=("${line#part=}") ;;
 		esac
 	done <<<"$plan"
@@ -236,7 +248,9 @@ install_apply_partitions() {
 	parted -s "$device" mklabel "$table" >>"$INSTALL_LOG" 2>&1 \
 		|| { install_log ERR "apply_partitions: mklabel $table failed"; return "$INSTALL_EX_PARTITION"; }
 
-	local start_mib=1 idx=0
+	# Honour the plan's start offset (emmc reserves 16MiB for on-device u-boot);
+	# default to 1MiB when a plan predates the directive.
+	local start_mib="${start_override:-1}" idx=0
 	local spec role size fstype flags hint end
 	for spec in "${parts[@]}"; do
 		IFS=':' read -r role size fstype flags <<<"$spec"


### PR DESCRIPTION
Makes the new install engine produce a **bootable eMMC** image. Found and fixed against **Banana Pi M7 (RK3588)** with serial-console confirmation — two independent bugs, both required for boot.

## Bug 1 — first partition overlapped u-boot

`install_apply_partitions` started the first partition at a fixed **1 MiB** for every mode. In `emmc` mode u-boot is dd'd to raw sectors of the same device (`u-boot.itb` at sector 16384 = **8 MiB**), so a 1 MiB partition overlaps it → filesystem and bootloader clobber each other.

**Fix:** thread a `start=` offset through the plan — `start=16` (MiB) for `emmc` (matching the classic `FIRSTSECTOR=32768`), `start=1` otherwise. `install_apply_partitions` honours it.

## Bug 2 — MBR table the board's u-boot can't read

With Bug 1 fixed, u-boot is present and clear, but the board still wouldn't boot. Serial showed the **Rockchip vendor u-boot 2017.09** reading the eMMC as **GPT only**:

```
part_get_info_efi: *** ERROR: Invalid GPT ***
part_get_info_efi: *** ERROR: Invalid Backup GPT ***     (× hundreds)
android_image_load_by_partname: Can't find part: boot
FIT: No boot partition ... Unknown command 'bootrkp'
```

`install_table_type` picked `msdos` for a small non-UEFI disk; this vendor u-boot parses GPT only, so it never finds the kernel and falls through Android→PXE→FIT.

**Fix:** replicate the running image's partition-table type (what the classic installer does), rather than deciding purely by capacity. `install_source_table_type` detects the source root disk's `PTTYPE`; `install_run_scenario` passes it to the planner for `emmc`/`sd`. Forcing GPT universally would be wrong — Allwinner needs MBR because its SPL at sector 16 (8 KiB) overlaps a GPT partition-entry array — so this **inherits** rather than forces. Hard requirements (UEFI, >2 TiB, 4Kn) still upgrade to GPT.

## Tests

`plan.bats` (23) + `detect.bats` (7) + `bootconfig.bats` (26) green locally; `integration_loopback` skips without root (runs in CI). New cases cover the 16 MiB emmc offset, the table-type preference (honoured / overridden by hard requirements), and emmc gpt-source→gpt / msdos-source→msdos.

## Hardware validation

Root-caused via UART on the M7 (RK3588 vendor u-boot). Needs a confirming eMMC install + boot on that board once merged.