### PR TITLE
module_cockpit: install virt-manager GUI when a desktop is present

### DIFF
--- a/tools/modules/software/module_cockpit.sh
+++ b/tools/modules/software/module_cockpit.sh
@@ -42,6 +42,14 @@ function module_cockpit() {
 			# which is what libvirt + cockpit-machines actually need.
 			pkg_install cockpit cockpit-ws cockpit-system cockpit-storaged cockpit-machines dnsmasq virtinst qemu-utils qemu-system
 
+			# On a desktop, also install the virt-manager GUI so VMs can be
+			# managed locally, not just through Cockpit's web UI. Headless
+			# servers skip it to avoid pulling in GTK and its dependencies.
+			check_desktop
+			if [[ -n "${DESKTOP_INSTALLED}" ]]; then
+				pkg_install virt-manager
+			fi
+
 			usermod -a -G libvirt libvirtdbus
 			usermod -a -G libvirt libvirt-qemu
 
@@ -75,6 +83,7 @@ function module_cockpit() {
 				virsh net-destroy ${bridge}
 				virsh net-undefine ${bridge}
 			done
+			pkg_installed virt-manager && pkg_remove virt-manager
 			pkg_remove cockpit cockpit-ws cockpit-system cockpit-storaged cockpit-machines dnsmasq virtinst qemu-utils qemu-system
 
 		;;


### PR DESCRIPTION
## What

When installing Cockpit + the QEMU/libvirt stack, also install **`virt-manager`** — but only on desktop systems.

## Why

Cockpit's `cockpit-machines` gives a web UI for VMs, but on a desktop a local `virt-manager` GUI is often more convenient. Headless servers don't want it — it drags in GTK and related desktop dependencies.

## How

- **Install:** after the existing `pkg_install … qemu-system`, call the existing `check_desktop` helper and install `virt-manager` only when `DESKTOP_INSTALLED` is set (nodm/lightdm/gdm3 detected).
- **Remove:** remove `virt-manager` first, guarded by `pkg_installed virt-manager` so headless removes stay clean.

Reuses the established `check_desktop` idiom, so detection matches the rest of configng (keys off nodm/lightdm/gdm3).