### PR TITLE
software modules: fix status-branch syntax, unsafe rm, and plex dispatch

### DIFF
--- a/tools/modules/software/module_plexmediaserver.sh
+++ b/tools/modules/software/module_plexmediaserver.sh
@@ -1,8 +1,8 @@
 module_options+=(
 	["module_plexmediaserver,author"]="@schwar3kat"
 	["module_plexmediaserver,maintainer"]="@igorpecovnik"
-	["module_plexmediaserver,feature"]="Install plexmediaserver"
-	["module_plexmediaserver,example"]="install remove status"
+	["module_plexmediaserver,feature"]="module_plexmediaserver"
+	["module_plexmediaserver,example"]="install remove status help"
 	["module_plexmediaserver,desc"]="Install plexmediaserver from repo using apt"
 	["module_plexmediaserver,status"]="Active"
 	["module_plexmediaserver,doc_link"]="https://www.plex.tv/"
@@ -49,13 +49,7 @@ module_plexmediaserver() {
 			fi
 		;;
 		"${commands[3]}")
-			echo -e "\nUsage: ${module_options["module_portainer,feature"]} <command>"
-			echo -e "Commands:  ${module_options["module_portainer,example"]}"
-			echo "Available commands:"
-			echo -e "\tinstall\t- Install $title."
-			echo -e "\tstatus\t- Installation status $title."
-			echo -e "\tremove\t- Remove $title."
-			echo
+			show_module_help "module_plexmediaserver" "$title" "" "native"
 		;;
 		*)
 			${module_options["module_plexmediaserver,feature"]} ${commands[3]}

--- a/tools/modules/software/module_webmin.sh
+++ b/tools/modules/software/module_webmin.sh
@@ -56,8 +56,8 @@ function module_webmin() {
 			## remove webmin
 			srv_disable webmin
 			pkg_remove webmin
-			rm /etc/apt/sources.list.d/webmin.list
-			rm /usr/share/keyrings/webmin-archive-keyring.gpg
+			rm -f /etc/apt/sources.list.d/webmin.list
+			rm -f /usr/share/keyrings/webmin-archive-keyring.gpg
 			pkg_update
 			echo "Webmin removed successfully."
 		;;
@@ -91,7 +91,7 @@ function module_webmin() {
 			if srv_active webmin; then
 				echo "Webmin service is active."
 				return 0
-			elif ! srv_enabled webmin ]]; then
+			elif ! srv_enabled webmin; then
 				echo "Webmin service is disabled."
 				return 1
 			else

--- a/tools/modules/software/module_zerotier.sh
+++ b/tools/modules/software/module_zerotier.sh
@@ -53,9 +53,9 @@ function module_zerotier() {
 			## remove zerotier-one
 			srv_disable zerotier-one
 			pkg_remove zerotier-one
-			rm -R /var/lib/zerotier-one
-			rm /etc/apt/trusted.gpg.d/zerotier.gpg
-			rm /etc/apt/sources.list.d/zerotier.list
+			rm -rf /var/lib/zerotier-one
+			rm -f /etc/apt/trusted.gpg.d/zerotier.gpg
+			rm -f /etc/apt/sources.list.d/zerotier.list
 			pkg_update
 			echo "Zerotier removed successfully."
 		;;
@@ -93,7 +93,7 @@ function module_zerotier() {
 			if srv_active zerotier-one; then
 				echo "Zerotier service is active."
 				return 0
-			elif ! srv_enabled zerotier-one ]]; then
+			elif ! srv_enabled zerotier-one; then
 				echo "Zerotier service is disabled."
 				return 1
 			else


### PR DESCRIPTION
Three confirmed defects found while scanning the software modules for optimizations. Each is small and independently correct.

## 1. Stray `]]` in status branch — `module_webmin`, `module_zerotier`
Both had:
```sh
elif ! srv_enabled webmin ]]; then
```
There is no opening `[[`, so `]]` is passed as an argument to `srv_enabled`, corrupting the "service disabled" detection in the status command. Removed the stray token.

## 2. Unsafe `rm` in remove paths — `module_webmin`, `module_zerotier`
Remove branches used bare `rm` / `rm -R` on the apt `.list`, keyring, and data dir. If any is already gone, `rm` exits non-zero and aborts the rest of the remove flow (and its trailing `pkg_update` / status echo). Switched to `rm -f` / `rm -rf`, matching docker/omv/proxmox.

## 3. Broken dispatch — `module_plexmediaserver`
- `,feature` was `"Install plexmediaserver"` — **not a function name** — so the default case ran `${feature} ${commands[3]}` → tried to execute the command `Install`.
- The help block referenced `module_portainer,feature`/`,example` (copy-paste leftover) and `commands[3]`, which was out of range (`example` only had 3 entries).

Fix: set `,feature` to `module_plexmediaserver`, add `help` to `,example`, and route help through `show_module_help … native` (the repo convention), replacing the hand-rolled block.

All three files pass `bash -n`. No behavioural change beyond the fixes.