### PR TITLE
module_docker: install docker-buildx on distro-maintained installs

### DIFF
--- a/tools/modules/software/module_docker.sh
+++ b/tools/modules/software/module_docker.sh
@@ -59,7 +59,7 @@ function module_docker() {
 				if pkg_installed docker-compose-plugin; then pkg_remove docker-compose-plugin; fi
 				rm -f /etc/apt/sources.list.d/docker.list
 				# install new
-				pkg_install docker.io docker-cli docker-compose
+				pkg_install docker.io docker-cli docker-compose docker-buildx
 			fi
 			groupadd docker 2>/dev/null || true
 			if [[ -n "${SUDO_USER}" ]]; then
@@ -162,7 +162,7 @@ function module_docker() {
 				pkg_remove docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 				rm -f /etc/apt/sources.list.d/docker.list
 			else
-				pkg_remove docker.io docker-cli docker-compose
+				pkg_remove docker.io docker-cli docker-compose docker-buildx
 			fi
 			# Remove docker0 bridge interface if it exists
 			if ip link show docker0 &>/dev/null; then


### PR DESCRIPTION
## What

Adds `docker-buildx` to the **distro-maintained** Docker install path in `tools/modules/software/module_docker.sh` (and to the matching uninstall).

```diff
- pkg_install docker.io docker-cli docker-compose
+ pkg_install docker.io docker-cli docker-compose docker-buildx
```

## Why

The module has two install branches:

- **upstream docker-ce** (bookworm/trixie) — already installs `docker-buildx-plugin`.
- **distro-maintained** (everything else) — installed only `docker.io docker-cli docker-compose`, so `docker buildx` was missing.

This makes buildx available regardless of which branch a release takes. On Debian/Ubuntu the distro build of the plugin is packaged as `docker-buildx` (the upstream repo's is `docker-buildx-plugin`). The uninstall path is updated symmetrically.