### PR TITLE
armbian-install: "boot from eMMC, root on NVMe/SATA/USB" (split install)

### DIFF
--- a/tests/bats/integration_loopback.bats
+++ b/tests/bats/integration_loopback.bats
@@ -52,6 +52,18 @@ teardown() {
 	LC_ALL=C parted -sm "$LOOP" unit MiB print | grep -qE '^1:16\.0MiB:'
 }
 
+@test "loopback: emmc-boot plan yields /boot + /emmc_storage, p1 at 16MiB" {
+	local plan; plan="$(install_plan_layout emmc-boot ext4 0 $((8*1024*1024*1024)) 512 0 gpt)"
+	run install_apply_partitions "$LOOP" "$plan"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"boot ${LOOP}p1"* ]]
+	[[ "$output" == *"storage ${LOOP}p2"* ]]
+	[ -b "${LOOP}p1" ]
+	[ -b "${LOOP}p2" ]
+	# boot partition clears the u-boot region and is ~512MiB; storage fills the rest
+	LC_ALL=C parted -sm "$LOOP" unit MiB print | grep -qE '^1:16\.0MiB:528'
+}
+
 @test "loopback: apply_partitions echoes role->device for each partition" {
 	local plan; plan="$(install_plan_layout uefi ext4 1 $((8*1024*1024*1024)) 512 0)"
 	run install_apply_partitions "$LOOP" "$plan"

--- a/tests/bats/plan.bats
+++ b/tests/bats/plan.bats
@@ -143,6 +143,28 @@ setup() {
 	[[ "$output" != *"part=swap:"* ]]
 }
 
+# --- split install: eMMC boot device (root lives on NVMe/SATA/USB) -----------
+
+@test "plan emmc-boot: u-boot gap + ext4 /boot + /emmc_storage data partition" {
+	run install_plan_layout emmc-boot ext4 0 $(( 58 * GIB )) 512 0 gpt
+	[ "$status" -eq 0 ]
+	# 16MiB reserve so u-boot (raw sectors) clears the first partition
+	[[ "$output" == *"start=16"* ]]
+	# a small boot-flagged ext4 /boot the board's u-boot can read...
+	[[ "$output" == *"part=boot:512MiB:ext4:boot"* ]]
+	# ...and the rest as an ext4 data partition (mounted at /emmc_storage)
+	[[ "$output" == *"part=storage:100%:ext4:"* ]]
+	# root does NOT live on the eMMC in this mode
+	[[ "$output" != *"part=root:"* ]]
+}
+
+@test "plan emmc-boot: replicates the source table type (gpt for Rockchip vendor u-boot)" {
+	run install_plan_layout emmc-boot ext4 0 $(( 58 * GIB )) 512 0 gpt
+	[[ "$output" == *"table=gpt"* ]]
+	run install_plan_layout emmc-boot ext4 0 $(( 58 * GIB )) 512 0 msdos
+	[[ "$output" == *"table=msdos"* ]]
+}
+
 # --- rootfs-only layouts (boot lives elsewhere) ------------------------------
 
 @test "plan sd: single boot-flagged root partition" {

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -216,6 +216,16 @@ install_plan_layout() {
 				parts+=("root:100%:ext4:boot")
 			fi
 			;;
+		emmc-boot)
+			# eMMC used as the BOOT device in a split install: the root filesystem
+			# lives on another disk (e.g. NVMe, which the SoC bootrom cannot load
+			# u-boot from). eMMC carries u-boot in the 16MiB gap, a dedicated ext4
+			# /boot the board's u-boot can always read, and the remainder as a data
+			# partition auto-mounted at /emmc_storage (the fs is fixed to ext4 here;
+			# the <fs> argument applies to the root device, planned separately).
+			parts+=("boot:512MiB:ext4:boot")
+			parts+=("storage:100%:ext4:")
+			;;
 		sd|mtd|ufs)
 			# Only the rootfs lands here; boot lives elsewhere.
 			parts+=("root:100%:${fs}:boot")
@@ -234,7 +244,7 @@ install_plan_layout() {
 	# covers every SoC's bootloader area. All other modes keep u-boot off this
 	# device (SPI/UFS) or on removable media, so 1MiB alignment is fine.
 	local start_mib=1
-	[[ "$boot_mode" == emmc ]] && start_mib=16
+	[[ "$boot_mode" == emmc || "$boot_mode" == emmc-boot ]] && start_mib=16
 
 	echo "start=$start_mib"
 	echo "table=$table"
@@ -1100,6 +1110,124 @@ install_run_scenario() {
 	rmdir "$mp" 2>/dev/null
 
 	[[ "$rc" == 0 ]] && install_log INFO "scenario: $boot_mode install to $disk completed"
+	return "$rc"
+}
+
+install_run_split() {
+	# install_run_split <boot_disk> <root_disk> <fs> <exclude_file> [uboot_dir]
+	#
+	# "Split" ARM install: the SoC bootrom cannot load u-boot from NVMe/SATA/USB,
+	# so boot lives on an internal eMMC while the root filesystem lives on the
+	# fast/large target. The eMMC gets u-boot (raw sectors) + a dedicated ext4
+	# /boot that the board's u-boot can always read + the remaining space as a
+	# data partition auto-mounted at /emmc_storage. The target disk gets only the
+	# rootfs; its fstab mounts /boot from the eMMC boot partition. Restores the
+	# classic installer's "Boot from eMMC - system on SATA/USB/NVMe".
+	local boot_disk="$1" root_disk="$2" fs="$3" exclude="$4" uboot_dir="${5:-${DIR:-}}"
+	export LC_ALL=C LANG=C
+	[[ -b "$boot_disk" ]] || { install_log ERR "split: boot device '$boot_disk' is not a block device"; return "$INSTALL_EX_NODEV"; }
+	[[ -b "$root_disk" ]] || { install_log ERR "split: root device '$root_disk' is not a block device"; return "$INSTALL_EX_NODEV"; }
+	[[ "$boot_disk" != "$root_disk" ]] || { install_log ERR "split: boot and root device must differ ('$boot_disk')"; return "$INSTALL_EX_USAGE"; }
+	[[ -f "$exclude" ]] || { install_log ERR "split: exclude file '$exclude' missing"; return "$INSTALL_EX_TRANSFER"; }
+	# Pre-flight: u-boot hook + filesystem tooling must exist BEFORE we wipe.
+	[[ "$(type -t write_uboot_platform)" == function ]] \
+		|| { install_log ERR "split: write_uboot_platform hook missing - refusing to modify $boot_disk"; return "$INSTALL_EX_BOOTLOADER"; }
+	install_check_fs_tools "$fs" >/dev/null \
+		|| { install_log ERR "split: mkfs.$fs not installed (need $(_install_fs_pkg "$fs")) - refusing to modify $root_disk"; return "$INSTALL_EX_TOOL"; }
+	install_fs_kernel_supported "$fs" \
+		|| { install_log ERR "split: running kernel cannot mount $fs - refusing to modify $root_disk"; return "$INSTALL_EX_TOOL"; }
+
+	# Geometry for each device feeds the pure planner.
+	local bcap bsec rcap rsec
+	bcap="$(blockdev --getsize64 "$boot_disk" 2>/dev/null || echo 0)"
+	bsec="$(cat "/sys/block/$(basename "$boot_disk")/queue/physical_block_size" 2>/dev/null || echo 512)"
+	rcap="$(blockdev --getsize64 "$root_disk" 2>/dev/null || echo 0)"
+	rsec="$(cat "/sys/block/$(basename "$root_disk")/queue/physical_block_size" 2>/dev/null || echo 512)"
+	# eMMC must carry a table its u-boot can read (Rockchip vendor = GPT only);
+	# replicate the running image's table type.
+	local table_pref; table_pref="$(install_source_table_type)"
+
+	local bplan rplan
+	bplan="$(install_plan_layout emmc-boot ext4 0 "$bcap" "$bsec" 0 "$table_pref")" \
+		|| { install_log ERR "split: eMMC boot planning failed"; return "$INSTALL_EX_PARTITION"; }
+	rplan="$(install_plan_layout sd "$fs" 0 "$rcap" "$rsec" 0 "$table_pref")" \
+		|| { install_log ERR "split: root planning failed"; return "$INSTALL_EX_PARTITION"; }
+	install_log INFO "split: boot device $boot_disk"$'\n'"$bplan"$'\n'"split: root device $root_disk"$'\n'"$rplan"
+
+	# Partition both devices before formatting anything.
+	local bpartmap rpartmap
+	bpartmap="$(install_apply_partitions "$boot_disk" "$bplan")" || return "$INSTALL_EX_PARTITION"
+	rpartmap="$(install_apply_partitions "$root_disk" "$rplan")" || return "$INSTALL_EX_PARTITION"
+
+	local boot_part="" storage_part="" root_part="" role dev mkfs_map=""
+	while read -r role dev; do
+		[[ -n "$dev" ]] || continue
+		case "$role" in
+			boot)    boot_part="$dev";    mkfs_map+="boot $dev ext4"$'\n' ;;
+			storage) storage_part="$dev"; mkfs_map+="storage $dev ext4"$'\n' ;;
+		esac
+	done <<<"$bpartmap"
+	while read -r role dev; do
+		[[ -n "$dev" ]] || continue
+		[[ "$role" == root ]] && { root_part="$dev"; mkfs_map+="root $dev $fs"$'\n'; }
+	done <<<"$rpartmap"
+	[[ -b "$boot_part" && -b "$root_part" ]] || { install_log ERR "split: expected boot+root partitions not created"; return "$INSTALL_EX_PARTITION"; }
+	install_make_filesystems "$mkfs_map" || return "$INSTALL_EX_FORMAT"
+
+	local mp; mp="$(mktemp -d /mnt/armbian-install.XXXXXX)" || return "$INSTALL_EX_TRANSFER"
+	mount "$root_part" "$mp" || { install_log ERR "split: mount root $root_part failed"; rmdir "$mp"; return "$INSTALL_EX_TRANSFER"; }
+
+	local rc=0
+	while :; do
+		install_transfer_rootfs "$mp" "$exclude" 1 / 0 90 || { rc=$INSTALL_EX_TRANSFER; break; }
+		echo 92
+		# The eMMC boot partition carries /boot (kernel, dtb, boot script); mount it
+		# before populating or the files land on the rootfs and u-boot never sees them.
+		mkdir -p "$mp/boot"
+		mount "$boot_part" "$mp/boot" || { install_log ERR "split: mount boot $boot_part failed"; rc=$INSTALL_EX_BOOTCFG; break; }
+		install_populate_boot "$mp" 1 || { rc=$INSTALL_EX_BOOTCFG; break; }
+
+		local root_uuid boot_uuid storage_uuid
+		root_uuid="$(install_uuid "$root_part")"
+		boot_uuid="$(install_uuid "$boot_part")"
+		storage_uuid="$(install_uuid "$storage_part")"
+
+		# fstab: root on the target, /boot from the eMMC boot partition, and the
+		# eMMC data partition at /emmc_storage (nofail - never block boot on it).
+		install_gen_fstab "$root_uuid" "$fs" "$boot_uuid" ext4 "" "" >"$mp/etc/fstab" \
+			|| { rc=$INSTALL_EX_BOOTCFG; break; }
+		if [[ -n "$storage_uuid" ]]; then
+			mkdir -p "$mp/emmc_storage"
+			printf '%s\t/emmc_storage\text4\tdefaults,nofail\t0\t2\n' "$storage_uuid" >>"$mp/etc/fstab"
+		fi
+
+		# Point the eMMC boot env at the root that now lives on the target device.
+		local env_file="$mp/boot/armbianEnv.txt"
+		[[ -f "$env_file" ]] && { install_rewrite_bootenv "$env_file" "$root_uuid" "$fs" \
+			|| { install_log ERR "split: failed to point $env_file at root $root_uuid"; rc=$INSTALL_EX_BOOTCFG; break; }; }
+
+		# Module root fs (btrfs/f2fs) needs its driver in the eMMC /boot initramfs.
+		install_update_initramfs "$mp" "$fs"
+
+		echo 95
+		# u-boot goes to the eMMC whole device (raw sectors), never the target.
+		install_write_bootloader emmc "$boot_disk" "$mp" "$uboot_dir" \
+			|| { rc=$INSTALL_EX_BOOTLOADER; break; }
+
+		echo 99
+		install_verify_boot_dir "$mp/boot" || { rc=$INSTALL_EX_VERIFY; break; }
+		install_verify_fstab "$mp/etc/fstab" || { rc=$INSTALL_EX_VERIFY; break; }
+		echo 100
+		break
+	done 2>>"$INSTALL_LOG"
+
+	# Teardown (best effort).
+	sync
+	mountpoint -q "$mp/boot" && umount "$mp/boot" 2>/dev/null
+	umount "$mp" 2>/dev/null
+	rmdir "$mp" 2>/dev/null
+
+	[[ "$rc" == 0 ]] && install_log INFO "split: boot on $boot_disk, root on $root_disk completed"
 	return "$rc"
 }
 

--- a/tools/modules/system/module_partitioner.sh
+++ b/tools/modules/system/module_partitioner.sh
@@ -57,6 +57,21 @@ partitioner_disk_label() {
 	printf '%-10s %8s  %s' "/dev/$name" "$human" "$info"
 }
 
+# Echo the eMMC whole-disk device (empty if none). eMMC exposes a boot0 hardware
+# boot partition and/or reports device type MMC; SD cards report type SD and have
+# no boot0. Used to offer "boot from eMMC, root on NVMe/SATA/USB" only when an
+# eMMC actually exists.
+partitioner_emmc_device() {
+	local d n
+	for d in /dev/mmcblk[0-9]; do
+		[[ -b "$d" ]] || continue
+		n="${d#/dev/}"
+		if [[ -b "${d}boot0" || "$(cat "/sys/block/$n/device/type" 2>/dev/null)" == "MMC" ]]; then
+			echo "$d"; return 0
+		fi
+	done
+}
+
 # Boot modes that actually work on this system for a given target, gated by
 # capability so we never offer a mode whose bootloader cannot be written:
 #   * UEFI firmware present            -> GRUB EFI (uefi, +dualboot with Windows)
@@ -77,7 +92,13 @@ partitioner_modes_for() {
 	if [[ "$have_uboot" -eq 1 ]]; then
 		case "$role" in
 			mmc)           m+=(emmc sd) ;;   # eMMC: full install or just root
-			nvme|sata|usb) m+=(sd) ;;        # boot on removable media, root here
+			nvme|sata|usb)
+				m+=(sd)                       # boot on current media, root here
+				# The SoC bootrom can't load u-boot from NVMe/SATA/USB, so offer
+				# booting from an internal eMMC (if present and not the target).
+				local emmc; emmc="$(partitioner_emmc_device)"
+				[[ -n "$emmc" && "/dev/$disk" != "$emmc" ]] && m+=(split-emmc)
+				;;
 			mtd)           m+=(mtd) ;;
 			ufs)           m+=(ufs) ;;
 		esac
@@ -99,6 +120,7 @@ partitioner_mode_desc() {
 		bios) echo "Legacy BIOS install with GRUB (ERASES the disk)" ;;
 		emmc) echo "Full install to this device (boot + system)" ;;
 		sd)   echo "Keep boot on current media, system on this disk" ;;
+		split-emmc) echo "Boot from eMMC, system on this disk (+ /emmc_storage)" ;;
 		mtd)  echo "Boot from SPI/MTD flash, system on this disk" ;;
 		ufs)  echo "Boot idblock on UFS boot LUN, system on UFS" ;;
 		*)    echo "$1" ;;
@@ -197,6 +219,11 @@ partitioner_tui() {
 		if ! dialog_yesno " WARNING " "\nThis will SHRINK Windows on /dev/$disk and install Armbian ($fs, ${gib}GiB) alongside it.\n\nBack up first. Proceed?" "Shrink and install" "Cancel" 11 72; then
 			return "$INSTALL_EX_OK"
 		fi
+	elif [[ "$boot" == split-emmc ]]; then
+		local emmc; emmc="$(partitioner_emmc_device)"
+		if ! dialog_yesno " WARNING " "\nThis will ERASE BOTH devices:\n  $emmc (eMMC) -> u-boot + /boot + /emmc_storage\n  /dev/$disk -> Armbian root ($fs)\n\nProceed?" "Erase and install" "Cancel" 12 74; then
+			return "$INSTALL_EX_OK"
+		fi
 	else
 		if ! dialog_yesno " WARNING " "\nThis will ERASE /dev/$disk and install Armbian ($boot, $fs).\n\nProceed?" "Erase and install" "Cancel" 10 70; then
 			return "$INSTALL_EX_OK"
@@ -208,6 +235,8 @@ partitioner_tui() {
 	{
 		if [[ "$boot" == uefi-dualboot ]]; then
 			install_run_dualboot "/dev/$disk" "$fs" "$INSTALL_EXCLUDE" "$want_bytes"
+		elif [[ "$boot" == split-emmc ]]; then
+			install_run_split "$(partitioner_emmc_device)" "/dev/$disk" "$fs" "$INSTALL_EXCLUDE"
 		else
 			install_run_scenario "$boot" "/dev/$disk" "$fs" "$INSTALL_EXCLUDE"
 		fi
@@ -241,7 +270,7 @@ partitioner_cli_install() {
 	done
 
 	[[ -b "$target" ]] || { echo "armbian-install: --target must be a block device" >&2; return "$INSTALL_EX_NODEV"; }
-	case "$boot" in uefi|uefi-dualboot|bios|emmc|sd|mtd|ufs) ;; *) echo "armbian-install: --boot must be one of uefi|uefi-dualboot|bios|emmc|sd|mtd|ufs" >&2; return "$INSTALL_EX_USAGE" ;; esac
+	case "$boot" in uefi|uefi-dualboot|bios|emmc|sd|mtd|ufs|split-emmc) ;; *) echo "armbian-install: --boot must be one of uefi|uefi-dualboot|bios|emmc|sd|mtd|ufs|split-emmc" >&2; return "$INSTALL_EX_USAGE" ;; esac
 	case "$fs"   in ext4|btrfs|f2fs) ;;     *) echo "armbian-install: --fs must be one of ext4|btrfs|f2fs" >&2; return "$INSTALL_EX_USAGE" ;; esac
 	[[ -f "$INSTALL_EXCLUDE" ]] || { echo "armbian-install: exclude list $INSTALL_EXCLUDE missing" >&2; return "$INSTALL_EX_TRANSFER"; }
 
@@ -258,6 +287,12 @@ partitioner_cli_install() {
 		[[ "$size_gib" =~ ^[0-9]+$ && "$size_gib" -gt 0 ]] || { echo "armbian-install: --size <GiB> is required for uefi-dualboot" >&2; return "$INSTALL_EX_USAGE"; }
 		echo "Installing Armbian alongside Windows on $target (${size_gib}GiB, $fs)..."
 		install_run_dualboot "$target" "$fs" "$INSTALL_EXCLUDE" $(( size_gib * 1024 * 1024 * 1024 ))
+	elif [[ "$boot" == split-emmc ]]; then
+		local emmc; emmc="$(partitioner_emmc_device)"
+		[[ -n "$emmc" ]] || { echo "armbian-install: --boot split-emmc needs an eMMC, none detected" >&2; return "$INSTALL_EX_NODEV"; }
+		[[ "$emmc" != "$target" ]] || { echo "armbian-install: --boot split-emmc target must differ from the eMMC ($emmc)" >&2; return "$INSTALL_EX_USAGE"; }
+		echo "Installing Armbian: boot on $emmc (eMMC), root on $target ($fs), data at /emmc_storage..."
+		install_run_split "$emmc" "$target" "$fs" "$INSTALL_EXCLUDE"
 	else
 		echo "Installing Armbian to $target ($boot, $fs)..."
 		install_run_scenario "$boot" "$target" "$fs" "$INSTALL_EXCLUDE"
@@ -307,7 +342,9 @@ partitioner_help() {
 
 	Non-interactive:
 	  armbian-install --target /dev/sdX --boot <mode> --fs <fs> --yes
-	    --boot   uefi | uefi-dualboot | bios | emmc | sd | mtd | ufs
+	    --boot   uefi | uefi-dualboot | bios | emmc | sd | mtd | ufs | split-emmc
+	             split-emmc: boot from eMMC, root on --target (NVMe/SATA/USB),
+	                         eMMC remainder mounted at /emmc_storage
 	    --fs     ext4 | btrfs | f2fs
 	    --size   GiB for Armbian (uefi-dualboot only; shrinks Windows)
 	    --yes    required to actually modify the target


### PR DESCRIPTION
> **Stacked on #963** (uses its `install_source_table_type`). Base is the #963 branch so the diff shows only this feature; retarget to `main` once #963 merges.

## What

Restores the classic installer's "Boot from eMMC – system on SATA/USB/NVMe". RK3588 and similar SoCs can't load u-boot from NVMe/SATA/USB, so a root on those needs the bootloader on internal storage. The new engine only offered `sd` mode (boot stays on the current removable media) for such targets — no way to pick an internal eMMC.

Adds a **`split-emmc`** scenario:
- **eMMC (boot device):** u-boot in the 16 MiB gap + a dedicated ext4 `/boot` the board's u-boot can always read + the remainder as a data partition auto-mounted at **`/emmc_storage`**.
- **target (NVMe/SATA/USB):** rootfs only. Its fstab mounts `/boot` from the eMMC boot partition; the eMMC boot env points `rootdev` at the target.

## Changes
- **engine:** new `emmc-boot` planner layout (`boot:512MiB:ext4` + `storage:100%:ext4`, 16 MiB start, source table type) and `install_run_split` composing the existing primitives across two devices.
- **frontend:** `split-emmc` offered **only** for nvme/sata/usb targets **when an eMMC is present** (`partitioner_emmc_device` detects it via boot0 / device type) and isn't the target; TUI warns *both* devices are erased; CLI `--boot split-emmc` (auto-detects the eMMC).
- **tests:** `emmc-boot` planner layout + table-type; loopback apply yields `/boot` + `/emmc_storage`.

## Validation
Local: `plan.bats` 25/25, `detect.bats` 7/7, `bootconfig.bats` 26/26; no shellcheck warnings on new code.

On a Banana Pi M7 (RK3588):
- menu offers `[sd split-emmc]` for the NVMe target (eMMC/SD targets still `[emmc sd]`);
- eMMC auto-detected (`/dev/mmcblk0`), source table `gpt`;
- real `parted` apply of the `emmc-boot` plan → p1 `16.0–528MiB` (512 MiB, legacy_boot) `/boot`, p2 `528MiB–end` `/emmc_storage`, GPT.

**Pending:** the full destructive `install_run_split` (rsync + u-boot write + actual boot from eMMC→NVMe) still needs a hardware run — requires wiping eMMC+NVMe and setting boot order / removing the SD to confirm.

## Follow-up
SPI/MTD-boot for a root-on-NVMe install: the engine's existing `mtd` mode already covers it; only the menu wiring (offer `mtd` as a boot choice for nvme/sata/usb targets, gated on an MTD device) is needed. Left out here to keep scope tight.