### PR TITLE
armbian-install: eMMC/NVMe boot fixes + boot-from-eMMC split install

### DIFF
--- a/tests/bats/detect.bats
+++ b/tests/bats/detect.bats
@@ -69,6 +69,32 @@ setup() {
 	[[ "$output" != *"rpmb"* ]]
 }
 
+@test "source table: selects the /boot device's type, not /'s, when they differ" {
+	# SD /boot (gpt) + NVMe root (msdos): u-boot reads /boot, so the target must
+	# replicate the /boot device's table (gpt), not the root device's.
+	findmnt() { case "$*" in *' /boot'*) echo /dev/mmcblk0p1 ;; *) echo /dev/nvme0n1p1 ;; esac; }
+	lsblk()   {
+		local a="$*"
+		if [[ "$a" == *PKNAME* ]]; then
+			[[ "$a" == *mmcblk0p1* ]] && echo mmcblk0
+			[[ "$a" == *nvme0n1p1* ]] && echo nvme0n1
+		elif [[ "$a" == *PTTYPE* ]]; then
+			[[ "$a" == *mmcblk0* ]] && echo gpt
+			[[ "$a" == *nvme0n1* ]] && echo dos
+		fi
+	}
+	run install_source_table_type
+	[ "$output" = "gpt" ]
+}
+
+@test "source table: falls back to / when /boot is not a separate mount" {
+	# /boot is a dir on / (no mount) -> use the root device's table.
+	findmnt() { case "$*" in *' /boot'*) echo "" ;; *) echo /dev/mmcblk0p1 ;; esac; }
+	lsblk()   { case "$*" in *PKNAME*) echo mmcblk0 ;; *PTTYPE*) echo dos ;; esac; }
+	run install_source_table_type
+	[ "$output" = "msdos" ]
+}
+
 @test "detect: surfaces sector size and model" {
 	run install_detect_targets "" "$(cat "$FIX/lsblk_4kn_large.json")"
 	# 4Kn NVMe reports phy-sec 4096 in field 4.

--- a/tests/bats/integration_loopback.bats
+++ b/tests/bats/integration_loopback.bats
@@ -47,6 +47,9 @@ teardown() {
 	LC_ALL=C parted -sm "$LOOP" print | grep -q 'boot'
 	[ -b "${LOOP}p1" ]
 	[ ! -b "${LOOP}p2" ]
+	# p1 must start at 16MiB so it clears the on-device u-boot region
+	# (idbloader@32KiB + u-boot.itb@8MiB); starting at 1MiB corrupts boot.
+	LC_ALL=C parted -sm "$LOOP" unit MiB print | grep -qE '^1:16\.0MiB:'
 }
 
 @test "loopback: apply_partitions echoes role->device for each partition" {

--- a/tests/bats/integration_loopback.bats
+++ b/tests/bats/integration_loopback.bats
@@ -52,6 +52,18 @@ teardown() {
 	LC_ALL=C parted -sm "$LOOP" unit MiB print | grep -qE '^1:16\.0MiB:'
 }
 
+@test "loopback: emmc-boot plan yields /boot + /emmc_storage, p1 at 16MiB" {
+	local plan; plan="$(install_plan_layout emmc-boot ext4 0 $((8*1024*1024*1024)) 512 0 gpt)"
+	run install_apply_partitions "$LOOP" "$plan"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"boot ${LOOP}p1"* ]]
+	[[ "$output" == *"storage ${LOOP}p2"* ]]
+	[ -b "${LOOP}p1" ]
+	[ -b "${LOOP}p2" ]
+	# boot partition clears the u-boot region and is ~512MiB; storage fills the rest
+	LC_ALL=C parted -sm "$LOOP" unit MiB print | grep -qE '^1:16\.0MiB:528'
+}
+
 @test "loopback: apply_partitions echoes role->device for each partition" {
 	local plan; plan="$(install_plan_layout uefi ext4 1 $((8*1024*1024*1024)) 512 0)"
 	run install_apply_partitions "$LOOP" "$plan"

--- a/tests/bats/plan.bats
+++ b/tests/bats/plan.bats
@@ -143,6 +143,28 @@ setup() {
 	[[ "$output" != *"part=swap:"* ]]
 }
 
+# --- split install: eMMC boot device (root lives on NVMe/SATA/USB) -----------
+
+@test "plan emmc-boot: u-boot gap + ext4 /boot + /emmc_storage data partition" {
+	run install_plan_layout emmc-boot ext4 0 $(( 58 * GIB )) 512 0 gpt
+	[ "$status" -eq 0 ]
+	# 16MiB reserve so u-boot (raw sectors) clears the first partition
+	[[ "$output" == *"start=16"* ]]
+	# a small boot-flagged ext4 /boot the board's u-boot can read...
+	[[ "$output" == *"part=boot:512MiB:ext4:boot"* ]]
+	# ...and the rest as an ext4 data partition (mounted at /emmc_storage)
+	[[ "$output" == *"part=storage:100%:ext4:"* ]]
+	# root does NOT live on the eMMC in this mode
+	[[ "$output" != *"part=root:"* ]]
+}
+
+@test "plan emmc-boot: replicates the source table type (gpt for Rockchip vendor u-boot)" {
+	run install_plan_layout emmc-boot ext4 0 $(( 58 * GIB )) 512 0 gpt
+	[[ "$output" == *"table=gpt"* ]]
+	run install_plan_layout emmc-boot ext4 0 $(( 58 * GIB )) 512 0 msdos
+	[[ "$output" == *"table=msdos"* ]]
+}
+
 # --- rootfs-only layouts (boot lives elsewhere) ------------------------------
 
 @test "plan sd: single boot-flagged root partition" {

--- a/tests/bats/plan.bats
+++ b/tests/bats/plan.bats
@@ -76,6 +76,23 @@ setup() {
 	[[ "$output" != *"part=boot:"* ]]
 }
 
+@test "plan emmc: reserves 16MiB before the first partition for on-device u-boot" {
+	# emmc dd's idbloader (32KiB) + u-boot.itb (8MiB) to raw sectors of this same
+	# device, so the first partition must start at 16MiB (classic FIRSTSECTOR=32768)
+	# or the filesystem and the bootloader clobber each other and the board won't boot.
+	run install_plan_layout emmc ext4 0 $(( 16 * GIB )) 512 0
+	[[ "$output" == *"start=16"* ]]
+}
+
+@test "plan: non-emmc modes keep the 1MiB start (u-boot lives off this device)" {
+	run install_plan_layout uefi ext4 1 $(( 16 * GIB )) 512 0
+	[[ "$output" == *"start=1"* ]]
+	run install_plan_layout sd ext4 0 $(( 500 * GIB )) 512 0
+	[[ "$output" == *"start=1"* ]]
+	run install_plan_layout bios ext4 0 $(( 20 * GIB )) 512 0
+	[[ "$output" == *"start=1"* ]]
+}
+
 @test "plan emmc btrfs: separate ext4 boot + btrfs root (u-boot can't read btrfs)" {
 	run install_plan_layout emmc btrfs 0 $(( 16 * GIB )) 512 0
 	[[ "$output" == *"part=boot:512MiB:ext4:boot"* ]]

--- a/tests/bats/plan.bats
+++ b/tests/bats/plan.bats
@@ -33,6 +33,25 @@ setup() {
 	[ "$output" = "gpt" ]
 }
 
+@test "table: honours a gpt preference when nothing forces the choice" {
+	# eMMC/SD installs replicate the running image's table so the board's u-boot
+	# can read it - Rockchip vendor u-boot (2017.09) parses GPT only.
+	run install_table_type 0 $(( 16 * GIB )) 512 gpt
+	[ "$output" = "gpt" ]
+}
+
+@test "table: honours an msdos preference (Allwinner: SPL at 8KiB clashes with GPT)" {
+	run install_table_type 0 $(( 16 * GIB )) 512 msdos
+	[ "$output" = "msdos" ]
+}
+
+@test "table: hard requirements override the preference (4Kn / >2TiB still gpt)" {
+	run install_table_type 0 $(( 16 * GIB )) 4096 msdos
+	[ "$output" = "gpt" ]
+	run install_table_type 0 $(( 4 * TIB )) 512 msdos
+	[ "$output" = "gpt" ]
+}
+
 # --- uefi layout -------------------------------------------------------------
 
 @test "plan uefi: gpt, ESP first with esp+boot flags, root fills rest" {
@@ -74,6 +93,19 @@ setup() {
 	[[ "$output" == *"part=root:100%:ext4:boot"* ]]
 	# ext4 keeps /boot as a directory: no separate boot partition.
 	[[ "$output" != *"part=boot:"* ]]
+}
+
+@test "plan emmc: replicates a gpt source table so Rockchip vendor u-boot can read it" {
+	# Regression: an MBR eMMC made the RK3588 vendor u-boot loop on
+	# "Invalid GPT" and never find the kernel. Passing the source's gpt through
+	# must yield a gpt target.
+	run install_plan_layout emmc ext4 0 $(( 16 * GIB )) 512 0 gpt
+	[[ "$output" == *"table=gpt"* ]]
+}
+
+@test "plan emmc: an msdos source stays msdos (Allwinner)" {
+	run install_plan_layout emmc ext4 0 $(( 16 * GIB )) 512 0 msdos
+	[[ "$output" == *"table=msdos"* ]]
 }
 
 @test "plan emmc: reserves 16MiB before the first partition for on-device u-boot" {

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -66,17 +66,44 @@ install_log() {
 readonly INSTALL_TWO_TIB=$(( 2 * 1024 * 1024 * 1024 * 1024 ))
 
 install_table_type() {
-	# install_table_type <is_uefi> <capacity_bytes> <sector_size>
+	# install_table_type <is_uefi> <capacity_bytes> <sector_size> [preferred]
 	# GPT when firmware is UEFI, the disk is larger than the MBR ceiling, or the
-	# medium is 4Kn; msdos otherwise. Pure - no device access.
-	local is_uefi="$1" cap="${2:-0}" sec="${3:-512}"
+	# medium is 4Kn - these are hard requirements and override everything. When
+	# none of those force the choice, honour <preferred> (gpt|msdos) if given -
+	# this is how an eMMC/SD install replicates the running image's table type so
+	# the board's u-boot can actually read it. Falls back to msdos. Pure - no
+	# device access.
+	local is_uefi="$1" cap="${2:-0}" sec="${3:-512}" preferred="${4:-}"
 	if [[ "$is_uefi" == "1" || "$is_uefi" == "uefi" ]] \
 		|| (( cap > INSTALL_TWO_TIB )) \
 		|| (( sec == 4096 )); then
 		echo "gpt"
-	else
-		echo "msdos"
+		return 0
 	fi
+	case "$preferred" in
+		gpt|msdos) echo "$preferred" ;;
+		*)         echo "msdos" ;;
+	esac
+}
+
+install_source_table_type() {
+	# Echo the partition-table type (gpt|msdos) of the disk the running system
+	# boots from, or nothing if it can't be determined. An eMMC/SD install must
+	# replicate this so the board's bootloader can read the result: Rockchip
+	# vendor u-boot (2017.09) parses GPT only - an MBR eMMC gives endless
+	# "Invalid GPT" and never finds the kernel - while Allwinner needs MBR
+	# because its SPL at sector 16 (8KiB) overlaps a GPT partition-entry array.
+	# Impure: reads the live block layout.
+	local rootsrc disk ptt
+	rootsrc="$(findmnt -no SOURCE / 2>/dev/null)" || return 0
+	[[ -n "$rootsrc" ]] || return 0
+	disk="$(lsblk -no PKNAME "$rootsrc" 2>/dev/null | head -1)"
+	[[ -n "$disk" ]] || return 0
+	ptt="$(lsblk -ndo PTTYPE "/dev/$disk" 2>/dev/null | head -1)"
+	case "$ptt" in
+		gpt) echo "gpt" ;;
+		dos) echo "msdos" ;;
+	esac
 }
 
 # ---- detection --------------------------------------------------------------
@@ -132,7 +159,11 @@ install_detect_targets() {
 # ---- partition planning (pure) ---------------------------------------------
 
 install_plan_layout() {
-	# install_plan_layout <boot_mode> <fs> <is_uefi> <capacity_bytes> <sector_size> [has_swap]
+	# install_plan_layout <boot_mode> <fs> <is_uefi> <capacity_bytes> <sector_size> [has_swap] [table_pref]
+	#
+	# table_pref (gpt|msdos): preferred partition table when capacity/sector/uefi
+	# don't force GPT - used to replicate the running image's table type on an
+	# eMMC/SD target so the board's u-boot can read it. Empty = default (msdos).
 	#
 	# boot_mode: uefi | emmc | sd | mtd | ufs
 	#   uefi  - full install to an internal disk with an ESP + GRUB
@@ -146,9 +177,9 @@ install_plan_layout() {
 	#   part=<role>:<size>:<fstype>:<flags>       (one line per partition, in order)
 	# where size is an absolute "<N>MiB" or "100%" (fill), and flags is a
 	# comma-separated subset of {esp,boot,bios_grub} ("" for none). Pure: no device I/O.
-	local boot_mode="$1" fs="$2" is_uefi="$3" cap="${4:-0}" sec="${5:-512}" has_swap="${6:-0}"
+	local boot_mode="$1" fs="$2" is_uefi="$3" cap="${4:-0}" sec="${5:-512}" has_swap="${6:-0}" table_pref="${7:-}"
 	local table
-	table="$(install_table_type "$is_uefi" "$cap" "$sec")"
+	table="$(install_table_type "$is_uefi" "$cap" "$sec" "$table_pref")"
 
 	local -a parts=()
 	case "$boot_mode" in
@@ -932,7 +963,17 @@ install_run_scenario() {
 	[[ "$boot_mode" == uefi ]] && is_uefi=1
 	grep -q swap /etc/fstab 2>/dev/null && has_swap=1
 
-	local plan; plan="$(install_plan_layout "$boot_mode" "$fs" "$is_uefi" "$cap" "$sec" "$has_swap")" \
+	# eMMC/SD installs must use the same partition-table type as the running
+	# image so the board's u-boot can read the result (Rockchip vendor u-boot
+	# reads GPT only; Allwinner needs MBR). Replicate the source; the planner
+	# still upgrades to GPT when capacity/sector size demand it.
+	local table_pref=""
+	case "$boot_mode" in
+		emmc|sd) table_pref="$(install_source_table_type)"
+			[[ -n "$table_pref" ]] && install_log INFO "scenario: inheriting source partition table '$table_pref' for $boot_mode" ;;
+	esac
+
+	local plan; plan="$(install_plan_layout "$boot_mode" "$fs" "$is_uefi" "$cap" "$sec" "$has_swap" "$table_pref")" \
 		|| { install_log ERR "scenario: planning failed"; return "$INSTALL_EX_PARTITION"; }
 	install_log INFO "scenario: $boot_mode on $disk (${cap}B, ${sec}B sectors) fs=$fs"$'\n'"$plan"
 

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -87,17 +87,22 @@ install_table_type() {
 }
 
 install_source_table_type() {
-	# Echo the partition-table type (gpt|msdos) of the disk the running system
+	# Echo the partition-table type (gpt|msdos) of the disk the board actually
 	# boots from, or nothing if it can't be determined. An eMMC/SD install must
 	# replicate this so the board's bootloader can read the result: Rockchip
 	# vendor u-boot (2017.09) parses GPT only - an MBR eMMC gives endless
 	# "Invalid GPT" and never finds the kernel - while Allwinner needs MBR
 	# because its SPL at sector 16 (8KiB) overlaps a GPT partition-entry array.
-	# Impure: reads the live block layout.
-	local rootsrc disk ptt
-	rootsrc="$(findmnt -no SOURCE / 2>/dev/null)" || return 0
-	[[ -n "$rootsrc" ]] || return 0
-	disk="$(lsblk -no PKNAME "$rootsrc" 2>/dev/null | head -1)"
+	#
+	# Prefer the device that holds /boot: that is the one u-boot reads, and it can
+	# be a different disk with a different table than / (e.g. SD /boot + NVMe root).
+	# Fall back to / when /boot is not its own mount. --nofsroot strips any bind or
+	# subvolume suffix so lsblk gets a bare device. Impure: reads the live layout.
+	local src disk ptt
+	src="$(findmnt -no SOURCE --nofsroot /boot 2>/dev/null)"
+	[[ "$src" == /dev/* ]] || src="$(findmnt -no SOURCE --nofsroot / 2>/dev/null)"
+	[[ "$src" == /dev/* ]] || return 0
+	disk="$(lsblk -no PKNAME "$src" 2>/dev/null | head -1)"
 	[[ -n "$disk" ]] || return 0
 	ptt="$(lsblk -ndo PTTYPE "/dev/$disk" 2>/dev/null | head -1)"
 	case "$ptt" in

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -190,6 +190,17 @@ install_plan_layout() {
 			;;
 	esac
 
+	# First-partition start offset, in MiB. emmc is the only mode that writes
+	# u-boot to raw sectors of this same device (idbloader at 32KiB, u-boot.itb
+	# at 8MiB on Rockchip et al.), so its first partition must clear that region
+	# or the filesystem and the bootloader overwrite each other and the board
+	# won't boot. 16MiB matches the classic installer's FIRSTSECTOR=32768 and
+	# covers every SoC's bootloader area. All other modes keep u-boot off this
+	# device (SPI/UFS) or on removable media, so 1MiB alignment is fine.
+	local start_mib=1
+	[[ "$boot_mode" == emmc ]] && start_mib=16
+
+	echo "start=$start_mib"
 	echo "table=$table"
 	local p
 	for p in "${parts[@]}"; do
@@ -221,11 +232,12 @@ install_apply_partitions() {
 	[[ -z "$plan" ]] && plan="$(cat)"
 	[[ -b "$device" ]] || { install_log ERR "apply_partitions: '$device' is not a block device"; return "$INSTALL_EX_NODEV"; }
 
-	local table="" ; local -a parts=()
+	local table="" start_override="" ; local -a parts=()
 	local line
 	while IFS= read -r line; do
 		case "$line" in
 			table=*) table="${line#table=}" ;;
+			start=*) start_override="${line#start=}" ;;
 			part=*)  parts+=("${line#part=}") ;;
 		esac
 	done <<<"$plan"
@@ -236,7 +248,9 @@ install_apply_partitions() {
 	parted -s "$device" mklabel "$table" >>"$INSTALL_LOG" 2>&1 \
 		|| { install_log ERR "apply_partitions: mklabel $table failed"; return "$INSTALL_EX_PARTITION"; }
 
-	local start_mib=1 idx=0
+	# Honour the plan's start offset (emmc reserves 16MiB for on-device u-boot);
+	# default to 1MiB when a plan predates the directive.
+	local start_mib="${start_override:-1}" idx=0
 	local spec role size fstype flags hint end
 	for spec in "${parts[@]}"; do
 		IFS=':' read -r role size fstype flags <<<"$spec"

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -216,6 +216,16 @@ install_plan_layout() {
 				parts+=("root:100%:ext4:boot")
 			fi
 			;;
+		emmc-boot)
+			# eMMC used as the BOOT device in a split install: the root filesystem
+			# lives on another disk (e.g. NVMe, which the SoC bootrom cannot load
+			# u-boot from). eMMC carries u-boot in the 16MiB gap, a dedicated ext4
+			# /boot the board's u-boot can always read, and the remainder as a data
+			# partition auto-mounted at /emmc_storage (the fs is fixed to ext4 here;
+			# the <fs> argument applies to the root device, planned separately).
+			parts+=("boot:512MiB:ext4:boot")
+			parts+=("storage:100%:ext4:")
+			;;
 		sd|mtd|ufs)
 			# Only the rootfs lands here; boot lives elsewhere.
 			parts+=("root:100%:${fs}:boot")
@@ -234,7 +244,7 @@ install_plan_layout() {
 	# covers every SoC's bootloader area. All other modes keep u-boot off this
 	# device (SPI/UFS) or on removable media, so 1MiB alignment is fine.
 	local start_mib=1
-	[[ "$boot_mode" == emmc ]] && start_mib=16
+	[[ "$boot_mode" == emmc || "$boot_mode" == emmc-boot ]] && start_mib=16
 
 	echo "start=$start_mib"
 	echo "table=$table"
@@ -1100,6 +1110,124 @@ install_run_scenario() {
 	rmdir "$mp" 2>/dev/null
 
 	[[ "$rc" == 0 ]] && install_log INFO "scenario: $boot_mode install to $disk completed"
+	return "$rc"
+}
+
+install_run_split() {
+	# install_run_split <boot_disk> <root_disk> <fs> <exclude_file> [uboot_dir]
+	#
+	# "Split" ARM install: the SoC bootrom cannot load u-boot from NVMe/SATA/USB,
+	# so boot lives on an internal eMMC while the root filesystem lives on the
+	# fast/large target. The eMMC gets u-boot (raw sectors) + a dedicated ext4
+	# /boot that the board's u-boot can always read + the remaining space as a
+	# data partition auto-mounted at /emmc_storage. The target disk gets only the
+	# rootfs; its fstab mounts /boot from the eMMC boot partition. Restores the
+	# classic installer's "Boot from eMMC - system on SATA/USB/NVMe".
+	local boot_disk="$1" root_disk="$2" fs="$3" exclude="$4" uboot_dir="${5:-${DIR:-}}"
+	export LC_ALL=C LANG=C
+	[[ -b "$boot_disk" ]] || { install_log ERR "split: boot device '$boot_disk' is not a block device"; return "$INSTALL_EX_NODEV"; }
+	[[ -b "$root_disk" ]] || { install_log ERR "split: root device '$root_disk' is not a block device"; return "$INSTALL_EX_NODEV"; }
+	[[ "$boot_disk" != "$root_disk" ]] || { install_log ERR "split: boot and root device must differ ('$boot_disk')"; return "$INSTALL_EX_USAGE"; }
+	[[ -f "$exclude" ]] || { install_log ERR "split: exclude file '$exclude' missing"; return "$INSTALL_EX_TRANSFER"; }
+	# Pre-flight: u-boot hook + filesystem tooling must exist BEFORE we wipe.
+	[[ "$(type -t write_uboot_platform)" == function ]] \
+		|| { install_log ERR "split: write_uboot_platform hook missing - refusing to modify $boot_disk"; return "$INSTALL_EX_BOOTLOADER"; }
+	install_check_fs_tools "$fs" >/dev/null \
+		|| { install_log ERR "split: mkfs.$fs not installed (need $(_install_fs_pkg "$fs")) - refusing to modify $root_disk"; return "$INSTALL_EX_TOOL"; }
+	install_fs_kernel_supported "$fs" \
+		|| { install_log ERR "split: running kernel cannot mount $fs - refusing to modify $root_disk"; return "$INSTALL_EX_TOOL"; }
+
+	# Geometry for each device feeds the pure planner.
+	local bcap bsec rcap rsec
+	bcap="$(blockdev --getsize64 "$boot_disk" 2>/dev/null || echo 0)"
+	bsec="$(cat "/sys/block/$(basename "$boot_disk")/queue/physical_block_size" 2>/dev/null || echo 512)"
+	rcap="$(blockdev --getsize64 "$root_disk" 2>/dev/null || echo 0)"
+	rsec="$(cat "/sys/block/$(basename "$root_disk")/queue/physical_block_size" 2>/dev/null || echo 512)"
+	# eMMC must carry a table its u-boot can read (Rockchip vendor = GPT only);
+	# replicate the running image's table type.
+	local table_pref; table_pref="$(install_source_table_type)"
+
+	local bplan rplan
+	bplan="$(install_plan_layout emmc-boot ext4 0 "$bcap" "$bsec" 0 "$table_pref")" \
+		|| { install_log ERR "split: eMMC boot planning failed"; return "$INSTALL_EX_PARTITION"; }
+	rplan="$(install_plan_layout sd "$fs" 0 "$rcap" "$rsec" 0 "$table_pref")" \
+		|| { install_log ERR "split: root planning failed"; return "$INSTALL_EX_PARTITION"; }
+	install_log INFO "split: boot device $boot_disk"$'\n'"$bplan"$'\n'"split: root device $root_disk"$'\n'"$rplan"
+
+	# Partition both devices before formatting anything.
+	local bpartmap rpartmap
+	bpartmap="$(install_apply_partitions "$boot_disk" "$bplan")" || return "$INSTALL_EX_PARTITION"
+	rpartmap="$(install_apply_partitions "$root_disk" "$rplan")" || return "$INSTALL_EX_PARTITION"
+
+	local boot_part="" storage_part="" root_part="" role dev mkfs_map=""
+	while read -r role dev; do
+		[[ -n "$dev" ]] || continue
+		case "$role" in
+			boot)    boot_part="$dev";    mkfs_map+="boot $dev ext4"$'\n' ;;
+			storage) storage_part="$dev"; mkfs_map+="storage $dev ext4"$'\n' ;;
+		esac
+	done <<<"$bpartmap"
+	while read -r role dev; do
+		[[ -n "$dev" ]] || continue
+		[[ "$role" == root ]] && { root_part="$dev"; mkfs_map+="root $dev $fs"$'\n'; }
+	done <<<"$rpartmap"
+	[[ -b "$boot_part" && -b "$root_part" ]] || { install_log ERR "split: expected boot+root partitions not created"; return "$INSTALL_EX_PARTITION"; }
+	install_make_filesystems "$mkfs_map" || return "$INSTALL_EX_FORMAT"
+
+	local mp; mp="$(mktemp -d /mnt/armbian-install.XXXXXX)" || return "$INSTALL_EX_TRANSFER"
+	mount "$root_part" "$mp" || { install_log ERR "split: mount root $root_part failed"; rmdir "$mp"; return "$INSTALL_EX_TRANSFER"; }
+
+	local rc=0
+	while :; do
+		install_transfer_rootfs "$mp" "$exclude" 1 / 0 90 || { rc=$INSTALL_EX_TRANSFER; break; }
+		echo 92
+		# The eMMC boot partition carries /boot (kernel, dtb, boot script); mount it
+		# before populating or the files land on the rootfs and u-boot never sees them.
+		mkdir -p "$mp/boot"
+		mount "$boot_part" "$mp/boot" || { install_log ERR "split: mount boot $boot_part failed"; rc=$INSTALL_EX_BOOTCFG; break; }
+		install_populate_boot "$mp" 1 || { rc=$INSTALL_EX_BOOTCFG; break; }
+
+		local root_uuid boot_uuid storage_uuid
+		root_uuid="$(install_uuid "$root_part")"
+		boot_uuid="$(install_uuid "$boot_part")"
+		storage_uuid="$(install_uuid "$storage_part")"
+
+		# fstab: root on the target, /boot from the eMMC boot partition, and the
+		# eMMC data partition at /emmc_storage (nofail - never block boot on it).
+		install_gen_fstab "$root_uuid" "$fs" "$boot_uuid" ext4 "" "" >"$mp/etc/fstab" \
+			|| { rc=$INSTALL_EX_BOOTCFG; break; }
+		if [[ -n "$storage_uuid" ]]; then
+			mkdir -p "$mp/emmc_storage"
+			printf '%s\t/emmc_storage\text4\tdefaults,nofail\t0\t2\n' "$storage_uuid" >>"$mp/etc/fstab"
+		fi
+
+		# Point the eMMC boot env at the root that now lives on the target device.
+		local env_file="$mp/boot/armbianEnv.txt"
+		[[ -f "$env_file" ]] && { install_rewrite_bootenv "$env_file" "$root_uuid" "$fs" \
+			|| { install_log ERR "split: failed to point $env_file at root $root_uuid"; rc=$INSTALL_EX_BOOTCFG; break; }; }
+
+		# Module root fs (btrfs/f2fs) needs its driver in the eMMC /boot initramfs.
+		install_update_initramfs "$mp" "$fs"
+
+		echo 95
+		# u-boot goes to the eMMC whole device (raw sectors), never the target.
+		install_write_bootloader emmc "$boot_disk" "$mp" "$uboot_dir" \
+			|| { rc=$INSTALL_EX_BOOTLOADER; break; }
+
+		echo 99
+		install_verify_boot_dir "$mp/boot" || { rc=$INSTALL_EX_VERIFY; break; }
+		install_verify_fstab "$mp/etc/fstab" || { rc=$INSTALL_EX_VERIFY; break; }
+		echo 100
+		break
+	done 2>>"$INSTALL_LOG"
+
+	# Teardown (best effort).
+	sync
+	mountpoint -q "$mp/boot" && umount "$mp/boot" 2>/dev/null
+	umount "$mp" 2>/dev/null
+	rmdir "$mp" 2>/dev/null
+
+	[[ "$rc" == 0 ]] && install_log INFO "split: boot on $boot_disk, root on $root_disk completed"
 	return "$rc"
 }
 

--- a/tools/modules/system/module_partitioner.sh
+++ b/tools/modules/system/module_partitioner.sh
@@ -57,6 +57,21 @@ partitioner_disk_label() {
 	printf '%-10s %8s  %s' "/dev/$name" "$human" "$info"
 }
 
+# Echo the eMMC whole-disk device (empty if none). eMMC exposes a boot0 hardware
+# boot partition and/or reports device type MMC; SD cards report type SD and have
+# no boot0. Used to offer "boot from eMMC, root on NVMe/SATA/USB" only when an
+# eMMC actually exists.
+partitioner_emmc_device() {
+	local d n
+	for d in /dev/mmcblk[0-9]; do
+		[[ -b "$d" ]] || continue
+		n="${d#/dev/}"
+		if [[ -b "${d}boot0" || "$(cat "/sys/block/$n/device/type" 2>/dev/null)" == "MMC" ]]; then
+			echo "$d"; return 0
+		fi
+	done
+}
+
 # Boot modes that actually work on this system for a given target, gated by
 # capability so we never offer a mode whose bootloader cannot be written:
 #   * UEFI firmware present            -> GRUB EFI (uefi, +dualboot with Windows)
@@ -77,7 +92,13 @@ partitioner_modes_for() {
 	if [[ "$have_uboot" -eq 1 ]]; then
 		case "$role" in
 			mmc)           m+=(emmc sd) ;;   # eMMC: full install or just root
-			nvme|sata|usb) m+=(sd) ;;        # boot on removable media, root here
+			nvme|sata|usb)
+				m+=(sd)                       # boot on current media, root here
+				# The SoC bootrom can't load u-boot from NVMe/SATA/USB, so offer
+				# booting from an internal eMMC (if present and not the target).
+				local emmc; emmc="$(partitioner_emmc_device)"
+				[[ -n "$emmc" && "/dev/$disk" != "$emmc" ]] && m+=(split-emmc)
+				;;
 			mtd)           m+=(mtd) ;;
 			ufs)           m+=(ufs) ;;
 		esac
@@ -99,6 +120,7 @@ partitioner_mode_desc() {
 		bios) echo "Legacy BIOS install with GRUB (ERASES the disk)" ;;
 		emmc) echo "Full install to this device (boot + system)" ;;
 		sd)   echo "Keep boot on current media, system on this disk" ;;
+		split-emmc) echo "Boot from eMMC, system on this disk (+ /emmc_storage)" ;;
 		mtd)  echo "Boot from SPI/MTD flash, system on this disk" ;;
 		ufs)  echo "Boot idblock on UFS boot LUN, system on UFS" ;;
 		*)    echo "$1" ;;
@@ -197,6 +219,11 @@ partitioner_tui() {
 		if ! dialog_yesno " WARNING " "\nThis will SHRINK Windows on /dev/$disk and install Armbian ($fs, ${gib}GiB) alongside it.\n\nBack up first. Proceed?" "Shrink and install" "Cancel" 11 72; then
 			return "$INSTALL_EX_OK"
 		fi
+	elif [[ "$boot" == split-emmc ]]; then
+		local emmc; emmc="$(partitioner_emmc_device)"
+		if ! dialog_yesno " WARNING " "\nThis will ERASE BOTH devices:\n  $emmc (eMMC) -> u-boot + /boot + /emmc_storage\n  /dev/$disk -> Armbian root ($fs)\n\nProceed?" "Erase and install" "Cancel" 12 74; then
+			return "$INSTALL_EX_OK"
+		fi
 	else
 		if ! dialog_yesno " WARNING " "\nThis will ERASE /dev/$disk and install Armbian ($boot, $fs).\n\nProceed?" "Erase and install" "Cancel" 10 70; then
 			return "$INSTALL_EX_OK"
@@ -208,6 +235,8 @@ partitioner_tui() {
 	{
 		if [[ "$boot" == uefi-dualboot ]]; then
 			install_run_dualboot "/dev/$disk" "$fs" "$INSTALL_EXCLUDE" "$want_bytes"
+		elif [[ "$boot" == split-emmc ]]; then
+			install_run_split "$(partitioner_emmc_device)" "/dev/$disk" "$fs" "$INSTALL_EXCLUDE"
 		else
 			install_run_scenario "$boot" "/dev/$disk" "$fs" "$INSTALL_EXCLUDE"
 		fi
@@ -241,7 +270,7 @@ partitioner_cli_install() {
 	done
 
 	[[ -b "$target" ]] || { echo "armbian-install: --target must be a block device" >&2; return "$INSTALL_EX_NODEV"; }
-	case "$boot" in uefi|uefi-dualboot|bios|emmc|sd|mtd|ufs) ;; *) echo "armbian-install: --boot must be one of uefi|uefi-dualboot|bios|emmc|sd|mtd|ufs" >&2; return "$INSTALL_EX_USAGE" ;; esac
+	case "$boot" in uefi|uefi-dualboot|bios|emmc|sd|mtd|ufs|split-emmc) ;; *) echo "armbian-install: --boot must be one of uefi|uefi-dualboot|bios|emmc|sd|mtd|ufs|split-emmc" >&2; return "$INSTALL_EX_USAGE" ;; esac
 	case "$fs"   in ext4|btrfs|f2fs) ;;     *) echo "armbian-install: --fs must be one of ext4|btrfs|f2fs" >&2; return "$INSTALL_EX_USAGE" ;; esac
 	[[ -f "$INSTALL_EXCLUDE" ]] || { echo "armbian-install: exclude list $INSTALL_EXCLUDE missing" >&2; return "$INSTALL_EX_TRANSFER"; }
 
@@ -258,6 +287,12 @@ partitioner_cli_install() {
 		[[ "$size_gib" =~ ^[0-9]+$ && "$size_gib" -gt 0 ]] || { echo "armbian-install: --size <GiB> is required for uefi-dualboot" >&2; return "$INSTALL_EX_USAGE"; }
 		echo "Installing Armbian alongside Windows on $target (${size_gib}GiB, $fs)..."
 		install_run_dualboot "$target" "$fs" "$INSTALL_EXCLUDE" $(( size_gib * 1024 * 1024 * 1024 ))
+	elif [[ "$boot" == split-emmc ]]; then
+		local emmc; emmc="$(partitioner_emmc_device)"
+		[[ -n "$emmc" ]] || { echo "armbian-install: --boot split-emmc needs an eMMC, none detected" >&2; return "$INSTALL_EX_NODEV"; }
+		[[ "$emmc" != "$target" ]] || { echo "armbian-install: --boot split-emmc target must differ from the eMMC ($emmc)" >&2; return "$INSTALL_EX_USAGE"; }
+		echo "Installing Armbian: boot on $emmc (eMMC), root on $target ($fs), data at /emmc_storage..."
+		install_run_split "$emmc" "$target" "$fs" "$INSTALL_EXCLUDE"
 	else
 		echo "Installing Armbian to $target ($boot, $fs)..."
 		install_run_scenario "$boot" "$target" "$fs" "$INSTALL_EXCLUDE"
@@ -307,7 +342,9 @@ partitioner_help() {
 
 	Non-interactive:
 	  armbian-install --target /dev/sdX --boot <mode> --fs <fs> --yes
-	    --boot   uefi | uefi-dualboot | bios | emmc | sd | mtd | ufs
+	    --boot   uefi | uefi-dualboot | bios | emmc | sd | mtd | ufs | split-emmc
+	             split-emmc: boot from eMMC, root on --target (NVMe/SATA/USB),
+	                         eMMC remainder mounted at /emmc_storage
 	    --fs     ext4 | btrfs | f2fs
 	    --size   GiB for Armbian (uefi-dualboot only; shrinks Windows)
 	    --yes    required to actually modify the target


### PR DESCRIPTION
Combines #963 and #970 into one unstacked PR (GitHub's stacked-PR feature blocked merging them via API). All four commits, all hardware-validated on a Banana Pi M7 (RK3588). Supersedes and closes #963 and #970.

## Commits
1. **reserve 16 MiB for u-boot on eMMC** — first partition started at 1 MiB and overlapped `u-boot.itb` at 8 MiB → no boot. Now 16 MiB (classic `FIRSTSECTOR=32768`).
2. **replicate source partition-table type on eMMC/SD** — the RK3588 vendor u-boot reads GPT only; the engine wrote MBR → endless "Invalid GPT". Now inherits the running image's table (GPT for Rockchip, MBR for Allwinner where its 8 KiB SPL would clash with a GPT array).
3. **derive source table type from the /boot device, not /** — when `/boot` and `/` are on different disks (SD boot + NVMe root, or the split install), the table that matters is the boot device's. Queries `/boot` first, falls back to `/`.
4. **boot from eMMC, root on NVMe/SATA/USB (split install)** — restores "Boot from eMMC – system on SATA/USB/NVMe": eMMC gets u-boot + a dedicated ext4 `/boot` + the rest as `/emmc_storage`; the target holds only the rootfs. Offered only when an eMMC is present and isn't the target.

## Validation
- Unit/integration: `plan.bats`, `detect.bats`, `bootconfig.bats`, `integration_loopback.bats` green; no shellcheck warnings on new code.
- Hardware (Banana Pi M7, RK3588): full eMMC install (ext4/btrfs/f2fs), SD-boot/eMMC-root, and **boot-from-eMMC / root-on-NVMe with btrfs** — all boot standalone in ~5–6 s with the correct layout (root=NVMe, /boot=eMMC, /emmc_storage=eMMC).

## Note
The two failing CI checks on the superseded PRs (`Rolling/Stable repository`, `Portainer install`) are external-service install jobs unrelated to this change.