### PR TITLE
armbian-install: wire up "boot from SPI/MTD, root on NVMe/SATA/USB"

### DIFF
--- a/tests/bats/detect.bats
+++ b/tests/bats/detect.bats
@@ -95,6 +95,16 @@ setup() {
 	[ "$output" = "msdos" ]
 }
 
+@test "detect: excludes SPI/MTD flash (mtdblockN) - a boot device, not a target" {
+	# Odroid M1: 5 tiny mtdblock SPI partitions + one NVMe. Only the NVMe is a
+	# valid root destination; the SPI is offered later via the mtd boot mode.
+	run install_detect_targets "" "$(cat "$FIX/lsblk_mtd.json")"
+	[ "$status" -eq 0 ]
+	[ "${#lines[@]}" -eq 1 ]
+	[[ "$output" != *"mtdblock"* ]]
+	echo "$output" | grep -qP '^nvme0n1\tnvme\t'
+}
+
 @test "detect: surfaces sector size and model" {
 	run install_detect_targets "" "$(cat "$FIX/lsblk_4kn_large.json")"
 	# 4Kn NVMe reports phy-sec 4096 in field 4.

--- a/tests/bats/fixtures/lsblk_mtd.json
+++ b/tests/bats/fixtures/lsblk_mtd.json
@@ -1,0 +1,10 @@
+{
+    "blockdevices": [
+        {"name":"mtdblock0","type":"disk","size":917504,"phy-sec":512,"tran":null,"rota":false,"model":null},
+        {"name":"mtdblock1","type":"disk","size":131072,"phy-sec":512,"tran":null,"rota":false,"model":null},
+        {"name":"mtdblock2","type":"disk","size":2097152,"phy-sec":512,"tran":null,"rota":false,"model":null},
+        {"name":"mtdblock3","type":"disk","size":1048576,"phy-sec":512,"tran":null,"rota":false,"model":null},
+        {"name":"mtdblock4","type":"disk","size":12582912,"phy-sec":512,"tran":null,"rota":false,"model":null},
+        {"name":"nvme0n1","type":"disk","size":256060514304,"phy-sec":512,"tran":"nvme","rota":false,"model":"PM981 NVMe Samsung 256GB"}
+    ]
+}

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -122,8 +122,10 @@ install_detect_targets() {
 	# install_detect_targets [root_disk] [lsblk_json]
 	# Emit one TAB-separated record per candidate whole disk:
 	#   name <TAB> role <TAB> size_bytes <TAB> sector_size <TAB> bus <TAB> rota <TAB> model
-	# role in {nvme,mmc,mtd,usb,sata,disk}. The disk hosting the running rootfs
-	# (root_disk, a bare kernel name such as "mmcblk0") is excluded.
+	# role in {nvme,mmc,usb,sata,disk}. The disk hosting the running rootfs
+	# (root_disk, a bare kernel name such as "mmcblk0") is excluded, as is SPI/MTD
+	# flash (mtdblockN) - a boot device, not a target; it is offered as the mtd
+	# boot mode once a real target is picked (see INSTALL_MTD_LIST).
 	local root_disk="${1:-}"
 	local json="${2:-}"
 	[[ -z "$json" ]] && json="$(_install_lsblk_raw)"
@@ -964,11 +966,20 @@ install_run_scenario() {
 	# The scenario is a terminal operation, so exporting here is fine.
 	export LC_ALL=C LANG=C
 	[[ -b "$disk" ]] || { install_log ERR "scenario: '$disk' is not a block device"; return "$INSTALL_EX_NODEV"; }
+	# SPI/MTD flash (mtdblockN) is a boot device, never a root target. Detection
+	# filters it from the menu, but refuse it here too so an explicit
+	# --target /dev/mtdblockN (or a TUI selection) can't repartition the SPI.
+	[[ "$disk" != /dev/mtdblock* ]] || { install_log ERR "scenario: '$disk' is SPI/MTD flash, not a valid install target"; return "$INSTALL_EX_NODEV"; }
 	[[ -f "$exclude" ]] || { install_log ERR "scenario: exclude file '$exclude' missing"; return "$INSTALL_EX_TRANSFER"; }
 	# Pre-flight: confirm we can make the target bootable AND format it BEFORE
 	# wiping anything - never destroy a disk we cannot finish installing to.
 	install_bootloader_available "$boot_mode" \
 		|| { install_log ERR "scenario: no bootloader method for '$boot_mode' on this system (u-boot hooks or grub-install missing) - refusing to modify $disk"; return "$INSTALL_EX_BOOTLOADER"; }
+	# mtd mode flashes u-boot to the SPI/MTD device list; refuse before wiping the
+	# target if the frontend handed us an empty list (e.g. the device vanished
+	# between menu and run) rather than failing after partitioning.
+	[[ "$boot_mode" != mtd || -n "${INSTALL_MTD_LIST:-}" ]] \
+		|| { install_log ERR "scenario: mtd boot but no MTD/SPI device (INSTALL_MTD_LIST empty) - refusing to modify $disk"; return "$INSTALL_EX_NODEV"; }
 	install_check_fs_tools "$fs" >/dev/null \
 		|| { install_log ERR "scenario: mkfs.$fs not installed (need $(_install_fs_pkg "$fs")) - refusing to modify $disk"; return "$INSTALL_EX_TOOL"; }
 	install_fs_kernel_supported "$fs" \
@@ -1131,6 +1142,7 @@ install_run_split() {
 	export LC_ALL=C LANG=C
 	[[ -b "$boot_disk" ]] || { install_log ERR "split: boot device '$boot_disk' is not a block device"; return "$INSTALL_EX_NODEV"; }
 	[[ -b "$root_disk" ]] || { install_log ERR "split: root device '$root_disk' is not a block device"; return "$INSTALL_EX_NODEV"; }
+	[[ "$root_disk" != /dev/mtdblock* ]] || { install_log ERR "split: root device '$root_disk' is SPI/MTD flash, not a valid install target"; return "$INSTALL_EX_NODEV"; }
 	[[ "$boot_disk" != "$root_disk" ]] || { install_log ERR "split: boot and root device must differ ('$boot_disk')"; return "$INSTALL_EX_USAGE"; }
 	[[ -f "$exclude" ]] || { install_log ERR "split: exclude file '$exclude' missing"; return "$INSTALL_EX_TRANSFER"; }
 	# Pre-flight: u-boot hook + filesystem tooling must exist BEFORE we wipe.

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -978,13 +978,14 @@ install_run_scenario() {
 	[[ "$boot_mode" == uefi ]] && is_uefi=1
 	grep -q swap /etc/fstab 2>/dev/null && has_swap=1
 
-	# eMMC/SD installs must use the same partition-table type as the running
+	# eMMC/SD/MTD installs must use the same partition-table type as the running
 	# image so the board's u-boot can read the result (Rockchip vendor u-boot
-	# reads GPT only; Allwinner needs MBR). Replicate the source; the planner
-	# still upgrades to GPT when capacity/sector size demand it.
+	# reads GPT only; Allwinner needs MBR). For mtd the /boot lands on the target
+	# and is read by the SPI u-boot, so it matters there too. Replicate the
+	# source; the planner still upgrades to GPT when capacity/sector size demand.
 	local table_pref=""
 	case "$boot_mode" in
-		emmc|sd) table_pref="$(install_source_table_type)"
+		emmc|sd|mtd) table_pref="$(install_source_table_type)"
 			[[ -n "$table_pref" ]] && install_log INFO "scenario: inheriting source partition table '$table_pref' for $boot_mode" ;;
 	esac
 

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -145,11 +145,14 @@ install_detect_targets() {
 		# not writable as normal storage, and never valid install targets, so
 		# drop them - only the main mmcblkX user-data device is a candidate.
 		| select(.name | test("^mmcblk[0-9]+(boot[0-9]+|rpmb)$") | not)
+		# SPI/MTD flash (mtdblockN) holds the bootloader, not a root filesystem -
+		# it is a *boot* device (offered via the mtd boot mode after picking a
+		# real target), never an install destination, so keep it out of the list.
+		| select(.name | test("^mtdblock[0-9]+$") | not)
 		| { n: .name, t: (.tran // ""), sz: (.size // 0),
 			ps: (."phy-sec" // 512), ro: (.rota // false), md: ((.model // "") | gsub("\t"; " ")) }
 		| .role = ( if   (.n | test("^nvme"))     then "nvme"
 			elif (.n | test("^mmcblk"))   then "mmc"
-			elif (.n | test("^mtdblock")) then "mtd"
 			elif (.t == "usb")            then "usb"
 			elif (.t == "sata" or .t == "ata") then "sata"
 			else "disk" end )

--- a/tools/modules/system/module_partitioner.sh
+++ b/tools/modules/system/module_partitioner.sh
@@ -72,6 +72,22 @@ partitioner_emmc_device() {
 	done
 }
 
+# Echo the SPI/MTD device+partition list the board's u-boot lives on (empty if
+# none), space-separated, in the format write_uboot_platform_mtd expects: the
+# mtdblock whole-devices first, then any char-device SPL/boot partitions as
+# "mtdN:label" (e.g. "mtdblock0 mtd0:uboot"). Mirrors the classic installer's
+# mtdcheck. Used to offer "boot from SPI/MTD, root on NVMe/SATA/USB" and to feed
+# INSTALL_MTD_LIST to the engine.
+partitioner_mtd_list() {
+	local list chr
+	list="$(grep 'mtdblock' /proc/partitions 2>/dev/null | awk '{print $NF}' | xargs)"
+	if [[ -f /proc/mtd ]]; then
+		chr="$(grep -iE '^mtd[0-9]+:.*(spl|boot|uboot).*' /proc/mtd 2>/dev/null | awk '{print $1$NF}' | sed 's/"//g' | xargs)"
+		list="${list}${list:+ }${chr}"
+	fi
+	echo "$list" | xargs 2>/dev/null   # trim
+}
+
 # Boot modes that actually work on this system for a given target, gated by
 # capability so we never offer a mode whose bootloader cannot be written:
 #   * UEFI firmware present            -> GRUB EFI (uefi, +dualboot with Windows)
@@ -98,8 +114,10 @@ partitioner_modes_for() {
 				# booting from an internal eMMC (if present and not the target).
 				local emmc; emmc="$(partitioner_emmc_device)"
 				[[ -n "$emmc" && "/dev/$disk" != "$emmc" ]] && m+=(split-emmc)
+				# ...or from SPI/MTD flash, when the board can write u-boot there
+				# and an MTD device is present (e.g. Odroid M1 SPI + NVMe root).
+				[[ "$(type -t write_uboot_platform_mtd)" == function && -n "$(partitioner_mtd_list)" ]] && m+=(mtd)
 				;;
-			mtd)           m+=(mtd) ;;
 			ufs)           m+=(ufs) ;;
 		esac
 	fi
@@ -224,6 +242,10 @@ partitioner_tui() {
 		if ! dialog_yesno " WARNING " "\nThis will ERASE BOTH devices:\n  $emmc (eMMC) -> u-boot + /boot + /emmc_storage\n  /dev/$disk -> Armbian root ($fs)\n\nProceed?" "Erase and install" "Cancel" 12 74; then
 			return "$INSTALL_EX_OK"
 		fi
+	elif [[ "$boot" == mtd ]]; then
+		if ! dialog_yesno " WARNING " "\nThis will ERASE /dev/$disk (Armbian root, $fs) AND overwrite the bootloader on SPI/MTD flash:\n  [ $(partitioner_mtd_list) ]\n\nProceed?" "Erase and install" "Cancel" 12 74; then
+			return "$INSTALL_EX_OK"
+		fi
 	else
 		if ! dialog_yesno " WARNING " "\nThis will ERASE /dev/$disk and install Armbian ($boot, $fs).\n\nProceed?" "Erase and install" "Cancel" 10 70; then
 			return "$INSTALL_EX_OK"
@@ -238,6 +260,8 @@ partitioner_tui() {
 		elif [[ "$boot" == split-emmc ]]; then
 			install_run_split "$(partitioner_emmc_device)" "/dev/$disk" "$fs" "$INSTALL_EXCLUDE"
 		else
+			# mtd mode writes u-boot to SPI/MTD; hand the engine the device list.
+			[[ "$boot" == mtd ]] && export INSTALL_MTD_LIST="$(partitioner_mtd_list)"
 			install_run_scenario "$boot" "/dev/$disk" "$fs" "$INSTALL_EXCLUDE"
 		fi
 		echo "$?" >"$rc_file"
@@ -294,7 +318,13 @@ partitioner_cli_install() {
 		echo "Installing Armbian: boot on $emmc (eMMC), root on $target ($fs), data at /emmc_storage..."
 		install_run_split "$emmc" "$target" "$fs" "$INSTALL_EXCLUDE"
 	else
-		echo "Installing Armbian to $target ($boot, $fs)..."
+		if [[ "$boot" == mtd ]]; then
+			export INSTALL_MTD_LIST="$(partitioner_mtd_list)"
+			[[ -n "$INSTALL_MTD_LIST" ]] || { echo "armbian-install: --boot mtd but no MTD/SPI device found (need mtdblock or /proc/mtd spl/boot)" >&2; return "$INSTALL_EX_NODEV"; }
+			echo "Installing Armbian: boot on MTD/SPI [$INSTALL_MTD_LIST], root on $target ($fs)..."
+		else
+			echo "Installing Armbian to $target ($boot, $fs)..."
+		fi
 		install_run_scenario "$boot" "$target" "$fs" "$INSTALL_EXCLUDE"
 	fi
 	local rc=$?

--- a/tools/modules/system/module_partitioner.sh
+++ b/tools/modules/system/module_partitioner.sh
@@ -78,6 +78,14 @@ partitioner_emmc_device() {
 # "mtdN:label" (e.g. "mtdblock0 mtd0:uboot"). Mirrors the classic installer's
 # mtdcheck. Used to offer "boot from SPI/MTD, root on NVMe/SATA/USB" and to feed
 # INSTALL_MTD_LIST to the engine.
+#
+# Contract for board-provided write_uboot_platform_mtd (in /usr/lib/u-boot/
+# platform_install.sh): the engine calls it as
+#   write_uboot_platform_mtd "$DIR" "/dev/<first-entry>" "$LOG" "$INSTALL_MTD_LIST"
+# i.e. the FIRST list entry (with any ":label" stripped) is the primary boot
+# device, and the FULL list is passed as the last argument. Implementations
+# should accept both the "mtdblockN" and "mtdN:label" forms and pick the right
+# partition(s) to flash from the full list.
 partitioner_mtd_list() {
 	local list chr
 	list="$(grep 'mtdblock' /proc/partitions 2>/dev/null | awk '{print $NF}' | xargs)"


### PR DESCRIPTION
## What

Makes the engine's existing `mtd` boot mode (u-boot on SPI/MTD flash, rootfs on the target) actually reachable — for boards like the **Odroid M1 (RK3568 SPI + NVMe)** that boot from SPI NOR.

## Why it didn't work before
- The boot-device menu only offered `mtd` when the **target itself** was an mtd device — never valid for a root target — so it never appeared for an NVMe/SATA/USB target.
- **`INSTALL_MTD_LIST`** (which the engine passes to `write_uboot_platform_mtd` to know where to flash u-boot) was **never populated** by the frontend, so even `--boot mtd` on the CLI would flash to an empty device.

## Changes
- **`partitioner_mtd_list()`** — detects the SPI/MTD device+partition list (`mtdblock*` whole devices + `/proc/mtd` `spl|boot|uboot` partitions as `mtdN:label`), mirroring the classic installer's `mtdcheck`.
- **Menu** — offer `mtd` for nvme/sata/usb targets when `write_uboot_platform_mtd` exists **and** an MTD device is present (removed the dead `role==mtd` case).
- **Dispatch** — export `INSTALL_MTD_LIST` for mtd installs in both TUI and CLI (CLI errors clearly if no MTD device found); TUI warns the SPI bootloader will be overwritten.
- **Engine** — `mtd` now also inherits the source partition-table type (its `/boot` lands on the target and is read by the SPI u-boot; Rockchip vendor u-boot is GPT-only).

## Validation
- Syntax + `plan.bats`/`detect.bats`/`bootconfig.bats` green; MTD detection produces the expected `mtdblock0 mtd0:uboot` → writes to `/dev/mtdblock0`; menu gate offers `mtd` only when hook + device present.
- **Hardware test pending on the Odroid M1** (below).