### PR TITLE
armbian-install: tell the user why dual-boot can't proceed (BitLocker vs dirty NTFS)

### DIFF
--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -809,6 +809,50 @@ install_disk_has_bitlocker() {
 	printf '%s' "$json" | jq -e 'any(.blockdevices[]?.children[]?; (.fstype // "") | test("bitlocker"; "i"))' >/dev/null 2>&1
 }
 
+install_dualboot_blocker() {
+	# install_dualboot_blocker <disk>
+	# If the disk's Windows volume cannot be shrunk for a dual-boot install, echo
+	# a plain, user-facing reason AND the exact fix, and return non-zero. Prints
+	# nothing and returns 0 when the disk is ready. The frontends show this text
+	# directly (dialog / message) so the user is told what to do without reading
+	# the install log.
+	local disk="$1" wi win
+	wi="$(install_detect_windows "$disk")" || {
+		echo "No Windows/UEFI install was found on $disk - there is nothing to dual-boot alongside. Use a normal (erase) install instead, or pick the disk that has Windows on it."
+		return 1
+	}
+	win="$(sed -n 's/^windows=//p' <<<"$wi")"
+	# BitLocker vs merely-dirty are different fixes, so distinguish them and check
+	# BitLocker FIRST (an encrypted volume also fails the ntfsresize probe below,
+	# and must not be reported as "dirty"). Detect it two ways: lsblk/blkid fstype,
+	# and the volume boot sector's "-FVE-FS-" signature at offset 3 (a plain NTFS
+	# volume has "NTFS" there) - so a locked volume is caught even if lsblk didn't
+	# tag it.
+	if install_disk_has_bitlocker "$disk" \
+		|| dd if="$win" bs=512 count=1 2>/dev/null | tr -d '\0' | grep -qa 'FVE-FS'; then
+		printf '%s\n' \
+			"The Windows partition on $disk is BitLocker-encrypted and cannot be resized." \
+			"" \
+			"Fix it in Windows, then run the installer again:" \
+			"  1. Turn off Device Encryption / BitLocker:  manage-bde -off C:" \
+			"  2. Wait until it reports fully decrypted."
+		return 1
+	fi
+	# Not BitLocker: ntfsresize refuses a hibernated / Fast-Startup / unclean
+	# volume ("NTFS is inconsistent"). This is the most common blocker.
+	if ! ntfsresize -f --info "$win" >/dev/null 2>&1; then
+		printf '%s\n' \
+			"The Windows partition on $disk is not clean (hibernated, Fast Startup, or an unclean shutdown), so it cannot be shrunk." \
+			"" \
+			"Fix it in Windows, then run the installer again:" \
+			"  1. Disable Fast Startup:  powercfg /h off   (admin Command Prompt)" \
+			"  2. Check the disk:        chkdsk /f C:       (reboot when it asks)" \
+			"  3. Shut Windows down fully (not restart)."
+		return 1
+	fi
+	return 0
+}
+
 install_windows_min_bytes() {
 	# install_windows_min_bytes <ntfs_partition>
 	# Smallest size ntfsresize will shrink the volume to, in bytes (0 on failure).
@@ -1270,6 +1314,11 @@ install_run_dualboot() {
 	esp="$(sed -n 's/^esp=//p' <<<"$wi")"
 	win="$(sed -n 's/^windows=//p' <<<"$wi")"
 	install_log INFO "dualboot: ESP=$esp Windows=$win on $disk"
+	# Backstop for direct engine callers (the TUI/CLI already surface this to the
+	# user before we get here): refuse - before any change - if Windows can't be
+	# shrunk (BitLocker / unclean NTFS), logging the actionable reason.
+	local blocker; blocker="$(install_dualboot_blocker "$disk")" \
+		|| { install_log ERR "dualboot: cannot shrink Windows on $disk"$'\n'"$blocker"; return "$INSTALL_EX_PARTITION"; }
 
 	# 2) plan how far to shrink Windows to free <want> bytes.
 	local wsize wmin new_win plan

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -816,20 +816,24 @@ install_dualboot_blocker() {
 	# nothing and returns 0 when the disk is ready. The frontends show this text
 	# directly (dialog / message) so the user is told what to do without reading
 	# the install log.
-	local disk="$1" wi win
-	wi="$(install_detect_windows "$disk")" || {
-		echo "No Windows/UEFI install was found on $disk - there is nothing to dual-boot alongside. Use a normal (erase) install instead, or pick the disk that has Windows on it."
-		return 1
-	}
-	win="$(sed -n 's/^windows=//p' <<<"$wi")"
-	# BitLocker vs merely-dirty are different fixes, so distinguish them and check
-	# BitLocker FIRST (an encrypted volume also fails the ntfsresize probe below,
-	# and must not be reported as "dirty"). Detect it two ways: lsblk/blkid fstype,
-	# and the volume boot sector's "-FVE-FS-" signature at offset 3 (a plain NTFS
-	# volume has "NTFS" there) - so a locked volume is caught even if lsblk didn't
-	# tag it.
-	if install_disk_has_bitlocker "$disk" \
-		|| dd if="$win" bs=512 count=1 2>/dev/null | tr -d '\0' | grep -qa 'FVE-FS'; then
+	local disk="$1" wi win json winpart
+	# Identify the Windows system partition INDEPENDENTLY OF FILESYSTEM TYPE first:
+	# a BitLocker volume's fstype is "BitLocker", not "ntfs", so install_detect_
+	# windows (which keys on ntfs) fails on it - and we must still report BitLocker,
+	# not "no Windows". Pick the largest "Microsoft basic data" partition, minus the
+	# WinRE recovery one.
+	json="$(lsblk -b -po NAME,FSTYPE,PARTTYPENAME,SIZE --json "$disk" 2>/dev/null)"
+	winpart="$(printf '%s' "$json" | jq -r '
+		[ .blockdevices[]?.children[]?
+		  | select(((.parttypename // "") | test("basic data"; "i")))
+		  | select(((.parttypename // "") | test("recovery"; "i")) | not) ]
+		| sort_by(.size | tonumber) | reverse | (.[0].name // empty)' 2>/dev/null)"
+	# BitLocker FIRST (an encrypted volume also fails the ntfsresize probe below and
+	# must not be reported as "dirty"), scoped to THAT partition only: its lsblk/blkid
+	# fstype, or its boot sector's "-FVE-FS-" signature (a plain NTFS volume has
+	# "NTFS" there) - so a locked volume is caught even if lsblk didn't tag it.
+	if [[ -n "$winpart" ]] && { [[ "$(lsblk -no FSTYPE "$winpart" 2>/dev/null)" == *[Bb]it[Ll]ocker* ]] \
+		|| dd if="$winpart" bs=512 count=1 2>/dev/null | tr -d '\0' | grep -qa 'FVE-FS'; }; then
 		printf '%s\n' \
 			"The Windows volume on $disk is BitLocker-encrypted, so it cannot be resized for dual-boot." \
 			"" \
@@ -838,8 +842,14 @@ install_dualboot_blocker() {
 			"2) Wait until it reports fully decrypted."
 		return 1
 	fi
-	# Not BitLocker: ntfsresize refuses a hibernated / Fast-Startup / unclean
-	# volume ("NTFS is inconsistent"). This is the most common blocker.
+	# Not BitLocker: need a real (shrinkable) Windows/UEFI layout to proceed.
+	wi="$(install_detect_windows "$disk")" || {
+		echo "No Windows/UEFI install was found on $disk - there is nothing to dual-boot alongside. Use a normal (erase) install instead, or pick the disk that has Windows on it."
+		return 1
+	}
+	win="$(sed -n 's/^windows=//p' <<<"$wi")"
+	# ntfsresize refuses a hibernated / Fast-Startup / unclean volume ("NTFS is
+	# inconsistent"). This is the most common blocker.
 	if ! ntfsresize -f --info "$win" >/dev/null 2>&1; then
 		printf '%s\n' \
 			"The Windows volume on $disk is hibernated or has Fast Startup enabled, so it cannot be shrunk for dual-boot." \

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -831,23 +831,23 @@ install_dualboot_blocker() {
 	if install_disk_has_bitlocker "$disk" \
 		|| dd if="$win" bs=512 count=1 2>/dev/null | tr -d '\0' | grep -qa 'FVE-FS'; then
 		printf '%s\n' \
-			"The Windows partition on $disk is BitLocker-encrypted and cannot be resized." \
+			"The Windows volume on $disk is BitLocker-encrypted, so it cannot be resized for dual-boot." \
 			"" \
 			"Fix it in Windows, then run the installer again:" \
-			"  1. Turn off Device Encryption / BitLocker:  manage-bde -off C:" \
-			"  2. Wait until it reports fully decrypted."
+			"1) Turn off BitLocker / Device Encryption: manage-bde -off C:" \
+			"2) Wait until it reports fully decrypted."
 		return 1
 	fi
 	# Not BitLocker: ntfsresize refuses a hibernated / Fast-Startup / unclean
 	# volume ("NTFS is inconsistent"). This is the most common blocker.
 	if ! ntfsresize -f --info "$win" >/dev/null 2>&1; then
 		printf '%s\n' \
-			"The Windows partition on $disk is not clean (hibernated, Fast Startup, or an unclean shutdown), so it cannot be shrunk." \
+			"The Windows volume on $disk is hibernated or has Fast Startup enabled, so it cannot be shrunk for dual-boot." \
 			"" \
 			"Fix it in Windows, then run the installer again:" \
-			"  1. Disable Fast Startup:  powercfg /h off   (admin Command Prompt)" \
-			"  2. Check the disk:        chkdsk /f C:       (reboot when it asks)" \
-			"  3. Shut Windows down fully (not restart)."
+			"1) In an admin Command Prompt, run: powercfg /h off" \
+			"2) Then run: chkdsk /f C:  (reboot if it asks)" \
+			"3) Shut Windows down fully (not Restart)."
 		return 1
 	fi
 	return 0

--- a/tools/modules/system/module_partitioner.sh
+++ b/tools/modules/system/module_partitioner.sh
@@ -238,6 +238,13 @@ partitioner_tui() {
 	# 4) dual-boot needs a size; other modes erase the whole disk.
 	local want_bytes=0
 	if [[ "$boot" == uefi-dualboot ]]; then
+		# Tell the user up-front (and before touching the disk) if Windows can't be
+		# shrunk - BitLocker or an unclean/hibernated NTFS - with the exact fix.
+		local blocker
+		if ! blocker="$(install_dualboot_blocker "/dev/$disk")"; then
+			dialog_msgbox " Cannot dual-boot yet " "\n$blocker"
+			return "$INSTALL_EX_USAGE"
+		fi
 		local gib
 		gib=$(dialog_inputbox " $title " "\nGiB to give Armbian (taken by shrinking Windows):" "32")
 		[[ "$gib" =~ ^[0-9]+$ && "$gib" -gt 0 ]] || { dialog_msgbox " $title " "\nInvalid size."; return "$INSTALL_EX_USAGE"; }
@@ -317,6 +324,12 @@ partitioner_cli_install() {
 
 	if [[ "$boot" == uefi-dualboot ]]; then
 		[[ "$size_gib" =~ ^[0-9]+$ && "$size_gib" -gt 0 ]] || { echo "armbian-install: --size <GiB> is required for uefi-dualboot" >&2; return "$INSTALL_EX_USAGE"; }
+		# Explain up-front (before touching the disk) if Windows can't be shrunk.
+		local blocker
+		if ! blocker="$(install_dualboot_blocker "$target")"; then
+			echo "$blocker" >&2
+			return "$INSTALL_EX_USAGE"
+		fi
 		echo "Installing Armbian alongside Windows on $target (${size_gib}GiB, $fs)..."
 		install_run_dualboot "$target" "$fs" "$INSTALL_EXCLUDE" $(( size_gib * 1024 * 1024 * 1024 ))
 	elif [[ "$boot" == split-emmc ]]; then

--- a/tools/modules/system/module_partitioner.sh
+++ b/tools/modules/system/module_partitioner.sh
@@ -38,11 +38,22 @@ module_options+=(
 
 # Which whole disk hosts the currently running rootfs (excluded as a target).
 partitioner_root_disk() {
-	local root_uuid root_part
+	local root_uuid root_part disk medium
 	root_uuid=$(sed -e 's/^.*root=//' -e 's/ .*$//' </proc/cmdline)
 	root_part=$(blkid | tr -d '":' | grep -w "${root_uuid#UUID=}" | awk '{print $1}' | head -1)
 	[[ -z "$root_part" ]] && root_part=$(findmnt -no SOURCE / 2>/dev/null)
-	lsblk -ndo pkname "$root_part" 2>/dev/null
+	disk=$(lsblk -ndo pkname "$root_part" 2>/dev/null | head -1)
+	# Live ISO: / is an overlay over a squashfs, with no backing disk, so the above
+	# is empty. Exclude the boot MEDIUM instead - the USB/disk the ISO is running
+	# from - so we never offer to wipe the device we booted from.
+	if [[ -z "$disk" ]]; then
+		medium=$(findmnt -no SOURCE /run/live/medium 2>/dev/null)
+		if [[ -n "$medium" ]]; then
+			disk=$(lsblk -ndo pkname "$medium" 2>/dev/null | head -1)   # medium is a partition
+			[[ -z "$disk" ]] && disk=$(lsblk -ndo name "$medium" 2>/dev/null | head -1)  # ...or a whole disk
+		fi
+	fi
+	echo "$disk"
 }
 
 # A human label for one detect record (TSV: name role size sector bus rota model).

--- a/tools/modules/system/module_partitioner.sh
+++ b/tools/modules/system/module_partitioner.sh
@@ -242,7 +242,9 @@ partitioner_tui() {
 		# shrunk - BitLocker or an unclean/hibernated NTFS - with the exact fix.
 		local blocker
 		if ! blocker="$(install_dualboot_blocker "/dev/$disk")"; then
-			dialog_msgbox " Cannot dual-boot yet " "\n$blocker"
+			# dialog honours literal "\n" but collapses real newlines - convert so
+			# the numbered steps render on separate lines.
+			dialog_msgbox " Cannot dual-boot yet " "\n${blocker//$'\n'/\\n}"
 			return "$INSTALL_EX_USAGE"
 		fi
 		local gib


### PR DESCRIPTION
## Problem

A `uefi-dualboot` install against a Windows volume that can't be shrunk — **BitLocker-encrypted** or **unclean** (hibernated / Fast Startup / unclean shutdown) — failed at the `ntfsresize` step with the reason buried in `/var/log/armbian-install.log`. The TUI just showed "Installation FAILED, see log", so the user had no idea what to do.

## Fix

`install_dualboot_blocker()` runs **before anything is touched** and, if Windows can't be shrunk, echoes a plain user-facing reason **plus the exact fix** — and distinguishes the two cases (BitLocker is checked **first**, since an encrypted volume also fails the ntfsresize probe and must not be mislabeled "dirty"):

- **BitLocker** — detected via lsblk/blkid fstype **or** the `-FVE-FS-` boot-sector signature (a plain NTFS volume has `NTFS` there):
  > Turn off Device Encryption / BitLocker: `manage-bde -off C:`
- **Unclean NTFS** — `ntfsresize -f --info` reports inconsistent:
  > Disable Fast Startup: `powercfg /h off` · Check the disk: `chkdsk /f C:` · Shut down fully.

Surfaced in all three entry points, before the size prompt / any change:
- **TUI** → `dialog_msgbox` ("Cannot dual-boot yet")
- **CLI** → message to stderr
- **engine** (`install_run_dualboot`) → backstop for direct callers, logs the reason

## Validation

- syntax + `plan`/`detect`/`bootconfig`/`integration_loopback` tests green; no shellcheck warnings on the new code.
- **Real hardware** (Armbian live ISO on a UEFI box with a hibernated Windows NVMe): the helper prints the **dirty** message (correctly, not BitLocker — boot sector reads `NTFS`, not `FVE-FS`) with the actionable steps on screen, and returns non-zero before any destructive step. The install also stays fail-safe (ntfsresize runs before any partition change).

The differentiation is the key ask: BitLocker and dirty need different fixes, and the user now sees the right one without opening a log.