### PR TITLE
installer: default to SPI/MTD boot for NVMe/SATA/USB installs

### DIFF
--- a/tools/modules/system/module_partitioner.sh
+++ b/tools/modules/system/module_partitioner.sh
@@ -128,14 +128,17 @@ partitioner_modes_for() {
 		case "$role" in
 			mmc)           m+=(emmc sd) ;;   # eMMC: full install or just root
 			nvme|sata|usb)
-				m+=(sd)                       # boot on current media, root here
-				# The SoC bootrom can't load u-boot from NVMe/SATA/USB, so offer
-				# booting from an internal eMMC (if present and not the target).
+				# The SoC bootrom can't load u-boot from NVMe/SATA/USB, so boot
+				# lives elsewhere. Prefer SPI/MTD flash when the board can write
+				# u-boot there and an MTD device is present (e.g. Odroid M1 SPI +
+				# NVMe root): the board then boots straight from internal flash,
+				# independent of the removable media staying inserted — so offer
+				# it FIRST (top / default).
+				[[ "$(type -t write_uboot_platform_mtd)" == function && -n "$(partitioner_mtd_list)" ]] && m+=(mtd)
+				m+=(sd)                       # keep boot on current media, root here
+				# ...or from an internal eMMC (if present and not the target).
 				local emmc; emmc="$(partitioner_emmc_device)"
 				[[ -n "$emmc" && "/dev/$disk" != "$emmc" ]] && m+=(split-emmc)
-				# ...or from SPI/MTD flash, when the board can write u-boot there
-				# and an MTD device is present (e.g. Odroid M1 SPI + NVMe root).
-				[[ "$(type -t write_uboot_platform_mtd)" == function && -n "$(partitioner_mtd_list)" ]] && m+=(mtd)
 				;;
 			ufs)           m+=(ufs) ;;
 		esac


### PR DESCRIPTION
## What
When installing to an **NVMe/SATA/USB** disk on a u-boot board that can flash the bootloader to **SPI/MTD**, make **"Boot from SPI/MTD flash" the top / default** option instead of "Keep boot on current media".

## Why
Booting from internal SPI/MTD is the more robust choice for an NVMe root: the board boots **straight from internal flash**, independent of the SD/eMMC card staying inserted. So when an MTD device is present, it should be the default rather than buried below `sd`.

## Change
In `partitioner_modes_for` for `nvme|sata|usb`, the mode order is now:

```
mtd (if the board can write u-boot to SPI/MTD and a device is present)
sd  (keep boot on current media)
split-emmc (boot from an internal eMMC, if present and not the target)
```

The menu renders in array order and the first item is the dialog default, so `mtd` now leads. Boards **without** an MTD device are unchanged — `sd` stays the default.

Example: Odroid M1 (SPI + NVMe) now defaults to booting from SPI/MTD.

syntax + shellcheck clean.