### PR TITLE
install: keep the Rockchip reserved window

### DIFF
--- a/tests/bats/integration_loopback.bats
+++ b/tests/bats/integration_loopback.bats
@@ -39,6 +39,72 @@ teardown() {
 	[ -b "${LOOP}p2" ]
 }
 
+@test "loopback: emmc plan keeps the Rockchip reserved window, clears the loaders" {
+	# Sectors 7168-16383 hold vendor storage (MACs, serial) and secure storage
+	# (HDCP/DRM keys), provisioned per unit and never recreated. The loader areas
+	# either side of them must still be cleared. Markers sit on both edges so an
+	# off-by-one cannot pass.
+	printf 'IDB'   | dd of="$LOOP" bs=512 seek=64    conv=notrunc status=none
+	printf 'LDR0'  | dd of="$LOOP" bs=512 seek=7167  conv=notrunc status=none
+	printf 'DVKR'  | dd of="$LOOP" bs=512 seek=7168  conv=notrunc status=none
+	printf 'SSKR'  | dd of="$LOOP" bs=512 seek=8192  conv=notrunc status=none
+	printf 'RVEN'  | dd of="$LOOP" bs=512 seek=16383 conv=notrunc status=none
+	printf 'UBOOT' | dd of="$LOOP" bs=512 seek=16384 conv=notrunc status=none
+	printf 'TAIL'  | dd of="$LOOP" bs=512 seek=20479 conv=notrunc status=none
+	printf 'NEXT'  | dd of="$LOOP" bs=512 seek=20480 conv=notrunc status=none
+
+	local plan; plan="$(install_plan_layout emmc ext4 0 $((8*1024*1024*1024)) 512 0)"
+	run install_apply_partitions "$LOOP" "$plan"
+	[ "$status" -eq 0 ]
+	[ -b "${LOOP}p1" ]
+
+	# preserved: the window, both edges included
+	[ "$(dd if="$LOOP" bs=1 skip=$((7168*512))  count=4 status=none)" = "DVKR" ]
+	[ "$(dd if="$LOOP" bs=1 skip=$((8192*512))  count=4 status=none)" = "SSKR" ]
+	[ "$(dd if="$LOOP" bs=1 skip=$((16383*512)) count=4 status=none)" = "RVEN" ]
+	# cleared: the loader areas, up to the last sector the old wipe reached
+	[ -z "$(dd if="$LOOP" bs=1 skip=$((64*512))    count=3 status=none | tr -d '\0')" ]
+	[ -z "$(dd if="$LOOP" bs=1 skip=$((7167*512))  count=4 status=none | tr -d '\0')" ]
+	[ -z "$(dd if="$LOOP" bs=1 skip=$((16384*512)) count=5 status=none | tr -d '\0')" ]
+	[ -z "$(dd if="$LOOP" bs=1 skip=$((20479*512)) count=4 status=none | tr -d '\0')" ]
+	# untouched: beyond the wiped region
+	[ "$(dd if="$LOOP" bs=1 skip=$((20480*512)) count=4 status=none)" = "NEXT" ]
+}
+
+@test "loopback: without the Rockchip tags the full 10MiB is still cleared" {
+	# No DVKR/SSKR present, so this must behave exactly as before the reserved
+	# window existed - nothing in the first 10MiB survives.
+	printf 'AAAA' | dd of="$LOOP" bs=512 seek=7168  conv=notrunc status=none
+	printf 'BBBB' | dd of="$LOOP" bs=512 seek=8192  conv=notrunc status=none
+	printf 'CCCC' | dd of="$LOOP" bs=512 seek=12000 conv=notrunc status=none
+	printf 'NEXT' | dd of="$LOOP" bs=512 seek=20480 conv=notrunc status=none
+
+	local plan; plan="$(install_plan_layout emmc ext4 0 $((8*1024*1024*1024)) 512 0)"
+	run install_apply_partitions "$LOOP" "$plan"
+	[ "$status" -eq 0 ]
+
+	[ -z "$(dd if="$LOOP" bs=1 skip=$((7168*512))  count=4 status=none | tr -d '\0')" ]
+	[ -z "$(dd if="$LOOP" bs=1 skip=$((8192*512))  count=4 status=none | tr -d '\0')" ]
+	[ -z "$(dd if="$LOOP" bs=1 skip=$((12000*512)) count=4 status=none | tr -d '\0')" ]
+	[ "$(dd if="$LOOP" bs=1 skip=$((20480*512)) count=4 status=none)" = "NEXT" ]
+}
+
+@test "loopback: either Rockchip tag alone keeps the reserved window" {
+	# The gate is an OR, so each tag must work on its own. A marker inside the
+	# window that is not itself a tag shows the whole range survived.
+	for tag_sector in "DVKR 7168" "SSKR 8192"; do
+		set -- $tag_sector
+		dd if=/dev/zero of="$LOOP" bs=1M count=10 conv=notrunc status=none
+		printf '%s' "$1" | dd of="$LOOP" bs=512 seek="$2"  conv=notrunc status=none
+		printf 'MARK'    | dd of="$LOOP" bs=512 seek=12000 conv=notrunc status=none
+
+		local plan; plan="$(install_plan_layout emmc ext4 0 $((8*1024*1024*1024)) 512 0)"
+		run install_apply_partitions "$LOOP" "$plan"
+		[ "$status" -eq 0 ]
+		[ "$(dd if="$LOOP" bs=1 skip=$((12000*512)) count=4 status=none)" = "MARK" ]
+	done
+}
+
 @test "loopback: emmc ext4 plan yields a single MBR boot-flagged partition" {
 	local plan; plan="$(install_plan_layout emmc ext4 0 $((8*1024*1024*1024)) 512 0)"
 	run install_apply_partitions "$LOOP" "$plan"

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -294,8 +294,22 @@ install_apply_partitions() {
 	done <<<"$plan"
 	[[ -n "$table" && ${#parts[@]} -gt 0 ]] || { install_log ERR "apply_partitions: empty plan"; return "$INSTALL_EX_PARTITION"; }
 
+	# Rockchip parks per-unit data in sectors 7168-16383: vendor storage (MACs,
+	# serial) tagged "DVKR" at 7168, secure storage (HDCP/DRM keys) tagged
+	# "SSKR" at 8192. Nothing recreates either. Keep that window only when it
+	# is in use, so any other target is cleared exactly as before.
+	local keep_window="no"
+	[[ "$(dd if="$device" bs=1 skip=$(( 7168 * 512 )) count=4 2>/dev/null)" == "DVKR" ]] && keep_window="yes"
+	[[ "$(dd if="$device" bs=1 skip=$(( 8192 * 512 )) count=4 2>/dev/null)" == "SSKR" ]] && keep_window="yes"
+
 	wipefs -aq "$device" >>"$INSTALL_LOG" 2>&1 || true
-	dd if=/dev/zero of="$device" bs=1M count=10 conv=notrunc >>"$INSTALL_LOG" 2>&1 || true
+	if [[ "$keep_window" == "yes" ]]; then
+		install_log INFO "apply_partitions: keeping Rockchip reserved sectors 7168-16383 on $device"
+		dd if=/dev/zero of="$device" bs=512 count=7168 conv=notrunc >>"$INSTALL_LOG" 2>&1 || true
+		dd if=/dev/zero of="$device" bs=512 seek=16384 count=4096 conv=notrunc >>"$INSTALL_LOG" 2>&1 || true
+	else
+		dd if=/dev/zero of="$device" bs=1M count=10 conv=notrunc >>"$INSTALL_LOG" 2>&1 || true
+	fi
 	parted -s "$device" mklabel "$table" >>"$INSTALL_LOG" 2>&1 \
 		|| { install_log ERR "apply_partitions: mklabel $table failed"; return "$INSTALL_EX_PARTITION"; }
 


### PR DESCRIPTION
`install_apply_partitions()` zeroes the first 10 MiB of the target. On Rockchip,
sectors 7168-16383 hold per-unit data that nothing recreates: vendor storage
(MACs, serial) tagged `DVKR` at 7168, secure storage (HDCP/DRM keys) tagged
`SSKR` at 8192. `rockchip64_common.inc` already names that map for SPI loader
images (`vnvm` 7168-7679, `reserved2` 8192-16383).

The loss is silent: `dwmac-rk` then finds no `LAN_MAC`, so U-Boot invents one with
`net_random_ethaddr()` and writes it back — the board keeps a stable address that
is not the one on its label.

**Implementation.** Read the two tags before wiping. If either is present, clear
the loader areas either side of the window (sectors 0-7167 and 16384-20479)
instead of the whole 10 MiB — same end sector, no temp files. If neither is
present the original `dd bs=1M count=10` runs unchanged, so this is a no-op on
any target with nothing there. A data check rather than a platform check: no
board list to maintain, and it fails safe toward current behaviour.

Three loopback tests, each checked to discriminate rather than pass trivially:

| scenario | asserts | fails when |
| --- | --- | --- |
| both tags | window survives, loaders cleared | unpatched |
| no tags | full 10 MiB wipe | — passes either way, pins unchanged behaviour |
| one tag only | window survives | gate mutated from OR to AND |

Suite is 11/11 with the fix, on an RK3528 board against a real loop device.
