### PR TITLE
armbian-config: make sure LC_ALL is consistent

### DIFF
--- a/bin/armbian-config
+++ b/bin/armbian-config
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Ensure consistent regex and sorting behavior globally while preserving UTF-8
+export LC_ALL=C.UTF-8
+
 # initializes the terminal from TERM if stdin is a terminal
 unset UXMODE
 [[ -t 0 && "$1" =~ ^(|--cmd|--help)$ ]] && UXMODE="true" && tput init


### PR DESCRIPTION
# Description

This PR fixes some modules including i, I like `module_partitioner` give Invalid argument error because of REGEX errors in module_dialog_ui because of Turkish conversion of i -> İ and ı -> I by overriding LC_ALL
Issue reference:  
Related documentation:

# Implementation Details

_Provide a detailed description of the implementation. Include the following:_

- [ ] Key changes introduced by this PR
- [ ] Justification for the changes
- [ ] Confirmation that no new external dependencies or modules have been introduced

# Documentation Summary

- [ ] **Metadata Included:**  
  _Did you include the metadata (associative arrays) in the code? Ensure that metadata for modules, jobs, and runtime has been updated appropriately._

- [ ] **Document Generated:**  
  _Did you generate the updated documentation using `armbian-configng --doc`? Confirm if the command was run to update `README.md` and provide any relevant details._

# Testing Procedure

_Describe the tests you ran to verify your changes. Provide relevant details about your test configuration._

- [ ] Test 1: Description and results
- [ ] Test 2: Description and results

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have ensured that my changes do not introduce new warnings or errors
- [ ] No new external dependencies are included
- [ ] Changes have been tested and verified
- [ ] I have included necessary metadata in the code, including associative arrays
