### PR TITLE
install-engine: support extlinux boards when repointing root

### DIFF
--- a/tests/bats/bootconfig.bats
+++ b/tests/bats/bootconfig.bats
@@ -73,6 +73,138 @@ setup() {
 	[ "$status" -eq 71 ]
 }
 
+# --- extlinux rewrite --------------------------------------------------------
+#
+# Distro-boot boards (spacemit/riscv and other vendor kernels) ship no
+# armbianEnv.txt; root= lives on the extlinux "append" line instead.
+
+# A real /boot/extlinux/extlinux.conf as written for a SpacemiT MUSE Book.
+_extlinux_fixture() {
+	cat >"$1" <<-'EOF'
+		label Armbian
+		  kernel /boot/Image
+		  initrd /boot/uInitrd
+		  fdt /boot/dtb/spacemit/k1-musebook.dtb
+		  append root=UUID=old-uuid console=ttyS0,115200 loglevel=1 rw splash
+	EOF
+}
+
+@test "extlinux: root= on the append line is repointed" {
+	f="$TMP/extlinux.conf"; _extlinux_fixture "$f"
+	run install_rewrite_extlinux "$f" "UUID=new-uuid" ext4
+	[ "$status" -eq 0 ]
+	grep -q 'root=UUID=new-uuid' "$f"
+	! grep -q 'old-uuid' "$f"
+	# every other kernel arg survives, in place
+	grep -q 'console=ttyS0,115200' "$f"
+	grep -q 'splash' "$f"
+}
+
+@test "extlinux: label/kernel/initrd/fdt lines are left alone" {
+	f="$TMP/extlinux.conf"; _extlinux_fixture "$f"
+	install_rewrite_extlinux "$f" "UUID=new-uuid" ext4
+	grep -q '^label Armbian$' "$f"
+	grep -q '^  kernel /boot/Image$' "$f"
+	grep -q '^  fdt /boot/dtb/spacemit/k1-musebook.dtb$' "$f"
+	[ "$(grep -c 'root=' "$f")" -eq 1 ]
+}
+
+@test "extlinux: rootfstype is added when absent and replaced when present" {
+	f="$TMP/extlinux.conf"; _extlinux_fixture "$f"
+	install_rewrite_extlinux "$f" "UUID=new-uuid" ext4
+	grep -q 'rootfstype=ext4' "$f"
+	# second pass with a different fs must not duplicate the token
+	install_rewrite_extlinux "$f" "UUID=new-uuid" f2fs
+	grep -q 'rootfstype=f2fs' "$f"
+	[ "$(grep -o 'rootfstype=' "$f" | wc -l)" -eq 1 ]
+}
+
+@test "extlinux: btrfs root also gets rootflags=subvol=@" {
+	# armbianEnv boards get this from boot.cmd; extlinux boards never run it, so
+	# without it a btrfs install mounts the wrong subvolume.
+	f="$TMP/extlinux.conf"; _extlinux_fixture "$f"
+	install_rewrite_extlinux "$f" "UUID=new-uuid" btrfs
+	grep -q 'rootflags=subvol=@' "$f"
+	run install_rewrite_extlinux "$f" "UUID=new-uuid" ext4
+	[ "$status" -eq 0 ]
+}
+
+@test "extlinux: rewriting twice is a no-op (idempotent)" {
+	f="$TMP/extlinux.conf"; _extlinux_fixture "$f"
+	install_rewrite_extlinux "$f" "UUID=new-uuid" ext4
+	cp "$f" "$TMP/once"
+	install_rewrite_extlinux "$f" "UUID=new-uuid" ext4
+	diff -q "$TMP/once" "$f"
+}
+
+@test "extlinux: an append line with no root= gets one" {
+	f="$TMP/extlinux.conf"
+	printf 'label Armbian\n  kernel /boot/Image\n  append console=ttyS0,115200 rw\n' >"$f"
+	run install_rewrite_extlinux "$f" "UUID=new-uuid" ext4
+	[ "$status" -eq 0 ]
+	grep -q 'root=UUID=new-uuid' "$f"
+	grep -q 'console=ttyS0,115200' "$f"
+}
+
+@test "extlinux: uppercase APPEND is handled" {
+	f="$TMP/extlinux.conf"
+	printf 'LABEL Armbian\n  APPEND root=/dev/mmcblk0p1 rw\n' >"$f"
+	install_rewrite_extlinux "$f" "UUID=new-uuid" ext4
+	grep -q 'root=UUID=new-uuid' "$f"
+	! grep -q 'mmcblk0p1' "$f"
+}
+
+@test "extlinux: file mode is preserved" {
+	f="$TMP/extlinux.conf"; _extlinux_fixture "$f"; chmod 600 "$f"
+	install_rewrite_extlinux "$f" "UUID=new-uuid" ext4
+	[ "$(stat -c '%a' "$f")" = "600" ]
+	[ ! -e "$f.new" ]
+}
+
+@test "extlinux: missing file returns bootcfg error" {
+	run install_rewrite_extlinux "$TMP/nope.conf" "UUID=new" ext4
+	[ "$status" -eq 71 ]
+}
+
+# --- boot config discovery / dispatch ----------------------------------------
+
+@test "boot cfg: armbianEnv.txt wins when both exist" {
+	d="$TMP/boot1"; mkdir -p "$d/extlinux"
+	: >"$d/armbianEnv.txt"; : >"$d/extlinux/extlinux.conf"
+	run install_boot_cfg_file "$d"
+	[ "$status" -eq 0 ]
+	[ "$output" = "$d/armbianEnv.txt" ]
+}
+
+@test "boot cfg: extlinux.conf is found when there is no armbianEnv.txt" {
+	d="$TMP/boot2"; mkdir -p "$d/extlinux"
+	: >"$d/extlinux/extlinux.conf"
+	run install_boot_cfg_file "$d"
+	[ "$status" -eq 0 ]
+	[ "$output" = "$d/extlinux/extlinux.conf" ]
+}
+
+@test "boot cfg: neither present reports failure and prints nothing" {
+	d="$TMP/boot3"; mkdir -p "$d"
+	run install_boot_cfg_file "$d"
+	[ "$status" -ne 0 ]
+	[ -z "$output" ]
+}
+
+@test "boot cfg: dispatch rewrites each format in its own syntax" {
+	d="$TMP/boot4"; mkdir -p "$d/extlinux"
+	printf 'verbosity=1\nrootdev=UUID=old\n' >"$d/armbianEnv.txt"
+	_extlinux_fixture "$d/extlinux/extlinux.conf"
+
+	install_rewrite_bootcfg "$d/armbianEnv.txt" "UUID=new" ext4
+	grep -q '^rootdev=UUID=new$' "$d/armbianEnv.txt"
+
+	install_rewrite_bootcfg "$d/extlinux/extlinux.conf" "UUID=new" ext4
+	grep -q 'root=UUID=new' "$d/extlinux/extlinux.conf"
+	# the extlinux file must not have grown armbianEnv-style keys
+	! grep -q '^rootdev=' "$d/extlinux/extlinux.conf"
+}
+
 # --- verify: bootable /boot --------------------------------------------------
 
 @test "verify boot dir: kernel + boot script passes" {

--- a/tests/bats/bootconfig.bats
+++ b/tests/bats/bootconfig.bats
@@ -129,8 +129,36 @@ _extlinux_fixture() {
 	[ "$status" -eq 0 ]
 	# ...and rewriting back to a non-btrfs root must take subvol=@ away again:
 	# a non-btrfs kernel rejects it and fails to mount the root filesystem.
-	! grep -q 'rootflags' "$f"
+	! grep -q 'subvol=@' "$f"
 	grep -q 'rootfstype=ext4' "$f"
+}
+
+@test "extlinux: a non-btrfs rewrite keeps rootflags the board ships" {
+	# aml-s9xx-box and the RISC-V boards ship rootflags=data=writeback on an
+	# ext4 root; only the btrfs subvol= component may be removed.
+	f="$TMP/flags.conf"
+	printf 'label Armbian\n  append root=UUID=old rootflags=data=writeback console=tty0 rw\n' >"$f"
+	install_rewrite_extlinux "$f" "UUID=new-uuid" ext4
+	grep -q 'rootflags=data=writeback' "$f"
+	grep -q 'root=UUID=new-uuid' "$f"
+	grep -q 'console=tty0' "$f"
+}
+
+@test "extlinux: subvol= is removed from a compound rootflags, the rest kept" {
+	f="$TMP/mixed.conf"
+	printf 'label Armbian\n  append root=UUID=old rootflags=data=writeback,subvol=@ console=tty0 rw\n' >"$f"
+	install_rewrite_extlinux "$f" "UUID=new-uuid" ext4
+	grep -q 'rootflags=data=writeback' "$f"
+	! grep -q 'subvol=' "$f"
+	grep -q 'console=tty0' "$f"
+}
+
+@test "extlinux: dropping a lone subvol= leaves no stray whitespace or token" {
+	f="$TMP/lone.conf"
+	printf 'label Armbian\n  append root=UUID=old rootflags=subvol=@ console=tty0 rw\n' >"$f"
+	install_rewrite_extlinux "$f" "UUID=new-uuid" ext4
+	! grep -q 'rootflags' "$f"
+	grep -q 'root=UUID=new-uuid console=tty0 rw' "$f"
 }
 
 @test "extlinux: rewriting twice is a no-op (idempotent)" {

--- a/tests/bats/bootconfig.bats
+++ b/tests/bats/bootconfig.bats
@@ -165,6 +165,19 @@ _extlinux_fixture() {
 	[ ! -e "$f.new" ]
 }
 
+@test "extlinux: a file with no append line is an error, not a silent no-op" {
+	# Nothing to repoint means root= was never set; succeeding here would let
+	# the install continue and report success on an unbootable target.
+	f="$TMP/no-append.conf"
+	printf 'label Armbian\n  kernel /boot/Image\n  initrd /boot/uInitrd\n' >"$f"
+	cp "$f" "$TMP/before"
+	run install_rewrite_extlinux "$f" "UUID=new-uuid" ext4
+	[ "$status" -ne 0 ]
+	# and the original must be left exactly as it was
+	diff -q "$TMP/before" "$f"
+	[ ! -e "$f.new" ]
+}
+
 @test "extlinux: missing file returns bootcfg error" {
 	run install_rewrite_extlinux "$TMP/nope.conf" "UUID=new" ext4
 	[ "$status" -eq 71 ]

--- a/tests/bats/bootconfig.bats
+++ b/tests/bats/bootconfig.bats
@@ -73,6 +73,138 @@ setup() {
 	[ "$status" -eq 71 ]
 }
 
+# --- extlinux rewrite --------------------------------------------------------
+#
+# Distro-boot boards (spacemit/riscv and other vendor kernels) ship no
+# armbianEnv.txt; root= lives on the extlinux "append" line instead.
+
+# A real /boot/extlinux/extlinux.conf as written for a SpacemiT MUSE Book.
+_extlinux_fixture() {
+	cat >"$1" <<-'EOF'
+		label Armbian
+		  kernel /boot/Image
+		  initrd /boot/uInitrd
+		  fdt /boot/dtb/spacemit/k1-musebook.dtb
+		  append root=UUID=old-uuid console=ttyS0,115200 loglevel=1 rw splash
+	EOF
+}
+
+@test "extlinux: root= on the append line is repointed" {
+	f="$TMP/extlinux.conf"; _extlinux_fixture "$f"
+	run install_rewrite_extlinux "$f" "UUID=new-uuid" ext4
+	[ "$status" -eq 0 ]
+	grep -q 'root=UUID=new-uuid' "$f"
+	! grep -q 'old-uuid' "$f"
+	# every other kernel arg survives, in place
+	grep -q 'console=ttyS0,115200' "$f"
+	grep -q 'splash' "$f"
+}
+
+@test "extlinux: label/kernel/initrd/fdt lines are left alone" {
+	f="$TMP/extlinux.conf"; _extlinux_fixture "$f"
+	install_rewrite_extlinux "$f" "UUID=new-uuid" ext4
+	grep -q '^label Armbian$' "$f"
+	grep -q '^  kernel /boot/Image$' "$f"
+	grep -q '^  fdt /boot/dtb/spacemit/k1-musebook.dtb$' "$f"
+	[ "$(grep -c 'root=' "$f")" -eq 1 ]
+}
+
+@test "extlinux: rootfstype is added when absent and replaced when present" {
+	f="$TMP/extlinux.conf"; _extlinux_fixture "$f"
+	install_rewrite_extlinux "$f" "UUID=new-uuid" ext4
+	grep -q 'rootfstype=ext4' "$f"
+	# second pass with a different fs must not duplicate the token
+	install_rewrite_extlinux "$f" "UUID=new-uuid" f2fs
+	grep -q 'rootfstype=f2fs' "$f"
+	[ "$(grep -o 'rootfstype=' "$f" | wc -l)" -eq 1 ]
+}
+
+@test "extlinux: btrfs root also gets rootflags=subvol=@" {
+	# armbianEnv boards get this from boot.cmd; extlinux boards never run it, so
+	# without it a btrfs install mounts the wrong subvolume.
+	f="$TMP/extlinux.conf"; _extlinux_fixture "$f"
+	install_rewrite_extlinux "$f" "UUID=new-uuid" btrfs
+	grep -q 'rootflags=subvol=@' "$f"
+	run install_rewrite_extlinux "$f" "UUID=new-uuid" ext4
+	[ "$status" -eq 0 ]
+}
+
+@test "extlinux: rewriting twice is a no-op (idempotent)" {
+	f="$TMP/extlinux.conf"; _extlinux_fixture "$f"
+	install_rewrite_extlinux "$f" "UUID=new-uuid" ext4
+	cp "$f" "$TMP/once"
+	install_rewrite_extlinux "$f" "UUID=new-uuid" ext4
+	diff -q "$TMP/once" "$f"
+}
+
+@test "extlinux: an append line with no root= gets one" {
+	f="$TMP/extlinux.conf"
+	printf 'label Armbian\n  kernel /boot/Image\n  append console=ttyS0,115200 rw\n' >"$f"
+	run install_rewrite_extlinux "$f" "UUID=new-uuid" ext4
+	[ "$status" -eq 0 ]
+	grep -q 'root=UUID=new-uuid' "$f"
+	grep -q 'console=ttyS0,115200' "$f"
+}
+
+@test "extlinux: uppercase APPEND is handled" {
+	f="$TMP/extlinux.conf"
+	printf 'LABEL Armbian\n  APPEND root=/dev/mmcblk0p1 rw\n' >"$f"
+	install_rewrite_extlinux "$f" "UUID=new-uuid" ext4
+	grep -q 'root=UUID=new-uuid' "$f"
+	! grep -q 'mmcblk0p1' "$f"
+}
+
+@test "extlinux: file mode is preserved" {
+	f="$TMP/extlinux.conf"; _extlinux_fixture "$f"; chmod 600 "$f"
+	install_rewrite_extlinux "$f" "UUID=new-uuid" ext4
+	[ "$(stat -c '%a' "$f")" = "600" ]
+	[ ! -e "$f.new" ]
+}
+
+@test "extlinux: missing file returns bootcfg error" {
+	run install_rewrite_extlinux "$TMP/nope.conf" "UUID=new" ext4
+	[ "$status" -eq 71 ]
+}
+
+# --- boot config discovery / dispatch ----------------------------------------
+
+@test "boot cfg: armbianEnv.txt wins when both exist" {
+	d="$TMP/boot1"; mkdir -p "$d/extlinux"
+	: >"$d/armbianEnv.txt"; : >"$d/extlinux/extlinux.conf"
+	run install_boot_cfg_file "$d"
+	[ "$status" -eq 0 ]
+	[ "$output" = "$d/armbianEnv.txt" ]
+}
+
+@test "boot cfg: extlinux.conf is found when there is no armbianEnv.txt" {
+	d="$TMP/boot2"; mkdir -p "$d/extlinux"
+	: >"$d/extlinux/extlinux.conf"
+	run install_boot_cfg_file "$d"
+	[ "$status" -eq 0 ]
+	[ "$output" = "$d/extlinux/extlinux.conf" ]
+}
+
+@test "boot cfg: neither present reports failure and prints nothing" {
+	d="$TMP/boot3"; mkdir -p "$d"
+	run install_boot_cfg_file "$d"
+	[ "$status" -ne 0 ]
+	[ -z "$output" ]
+}
+
+@test "boot cfg: dispatch rewrites each format in its own syntax" {
+	d="$TMP/boot4"; mkdir -p "$d/extlinux"
+	printf 'verbosity=1\nrootdev=UUID=old\n' >"$d/armbianEnv.txt"
+	_extlinux_fixture "$d/extlinux/extlinux.conf"
+
+	install_rewrite_bootcfg "$d/armbianEnv.txt" "UUID=new" ext4
+	grep -q '^rootdev=UUID=new$' "$d/armbianEnv.txt"
+
+	install_rewrite_bootcfg "$d/extlinux/extlinux.conf" "UUID=new" ext4
+	grep -q 'root=UUID=new' "$d/extlinux/extlinux.conf"
+	# the extlinux file must not have grown armbianEnv-style keys
+	! grep -q '^rootdev=' "$d/extlinux/extlinux.conf"
+}
+
 # --- verify: bootable /boot --------------------------------------------------
 
 @test "verify boot dir: kernel + boot script passes" {
@@ -228,6 +360,30 @@ setup() {
 	install_sd_env_file() { echo "$TMP/no-such-armbianEnv.txt"; }
 	run install_sd_capable
 	[ "$status" -ne 0 ]
+}
+
+@test "sd capable: true on an extlinux board (no armbianEnv.txt)" {
+	# Distro-boot boards carry extlinux/extlinux.conf instead of armbianEnv.txt;
+	# without this sd mode would be hidden from them entirely.
+	d="$TMP/fw-none3"; mkdir -p "$d"
+	install_boot_firmware_dir() { echo "$d"; }
+	b="$TMP/sdboot"; mkdir -p "$b/extlinux"; _extlinux_fixture "$b/extlinux/extlinux.conf"
+	install_sd_boot_dir() { echo "$b"; }
+	run install_sd_capable
+	[ "$status" -eq 0 ]
+}
+
+@test "sd env file: prefers armbianEnv.txt, falls back to extlinux.conf" {
+	b="$TMP/sdboot2"; mkdir -p "$b/extlinux"
+	_extlinux_fixture "$b/extlinux/extlinux.conf"
+	install_sd_boot_dir() { echo "$b"; }
+	run install_sd_env_file
+	[ "$status" -eq 0 ]
+	[ "$output" = "$b/extlinux/extlinux.conf" ]
+	: >"$b/armbianEnv.txt"
+	run install_sd_env_file
+	[ "$status" -eq 0 ]
+	[ "$output" = "$b/armbianEnv.txt" ]
 }
 
 @test "fs tools: ext4 always available; missing fs reports its package" {

--- a/tests/bats/bootconfig.bats
+++ b/tests/bats/bootconfig.bats
@@ -127,6 +127,10 @@ _extlinux_fixture() {
 	grep -q 'rootflags=subvol=@' "$f"
 	run install_rewrite_extlinux "$f" "UUID=new-uuid" ext4
 	[ "$status" -eq 0 ]
+	# ...and rewriting back to a non-btrfs root must take subvol=@ away again:
+	# a non-btrfs kernel rejects it and fails to mount the root filesystem.
+	! grep -q 'rootflags' "$f"
+	grep -q 'rootfstype=ext4' "$f"
 }
 
 @test "extlinux: rewriting twice is a no-op (idempotent)" {

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -495,6 +495,61 @@ install_rewrite_bootenv() {
 	fi
 }
 
+install_rewrite_extlinux() {
+	# install_rewrite_extlinux <file> <rootdev> [rootfstype]
+	# Repoint an extlinux/syslinux config (u-boot sysboot / distro boot) at
+	# <rootdev> - a "UUID=..." string or a device path. The kernel command line
+	# lives on the "append" line(s), so root= is substituted there (added when
+	# absent), and rootfstype= the same way when a fs is given.
+	#
+	# btrfs additionally needs rootflags=subvol=@: armbianEnv.txt boards get that
+	# from boot.cmd, which extlinux boards never run, so it is set here.
+	# Idempotent: re-running with the same values is a no-op. Pure text op.
+	local file="$1" rootdev="$2" fstype="${3:-}"
+	[[ -f "$file" ]] || return "$INSTALL_EX_BOOTCFG"
+	local flags=""
+	[[ "$fstype" == "btrfs" ]] && flags="subvol=@"
+	local tmp="${file}.new"
+	awk -v root="$rootdev" -v fstype="$fstype" -v flags="$flags" '
+		function set_token(line, key, val,   re) {
+			re = "(^|[ \t])" key "=[^ \t]*"
+			if (line ~ re) { sub(re, " " key "=" val, line) } else { line = line " " key "=" val }
+			return line
+		}
+		tolower($1) == "append" {
+			$0 = set_token($0, "root", root)
+			if (fstype != "") $0 = set_token($0, "rootfstype", fstype)
+			if (flags  != "") $0 = set_token($0, "rootflags", flags)
+		}
+		{ print }
+	' "$file" >"$tmp" || { rm -f "$tmp"; return "$INSTALL_EX_BOOTCFG"; }
+	# Copy back rather than rename: keeps the original mode/owner/inode.
+	cat "$tmp" >"$file" || { rm -f "$tmp"; return "$INSTALL_EX_BOOTCFG"; }
+	rm -f "$tmp"
+	return 0
+}
+
+install_boot_cfg_file() {
+	# install_boot_cfg_file <boot_dir>
+	# Echo the boot config that <boot_dir> actually uses - armbianEnv.txt on most
+	# u-boot boards, extlinux/extlinux.conf on distro-boot ones (spacemit/riscv,
+	# some vendor kernels). Returns 1 and prints nothing when neither is present.
+	local d="$1"
+	[[ -f "$d/armbianEnv.txt" ]]        && { echo "$d/armbianEnv.txt"; return 0; }
+	[[ -f "$d/extlinux/extlinux.conf" ]] && { echo "$d/extlinux/extlinux.conf"; return 0; }
+	return 1
+}
+
+install_rewrite_bootcfg() {
+	# install_rewrite_bootcfg <file> <rootdev> [rootfstype]
+	# Point <file> at the new root, dispatching on which boot config it is.
+	local file="$1"; shift
+	case "$file" in
+		*/extlinux.conf) install_rewrite_extlinux "$file" "$@" ;;
+		*)               install_rewrite_bootenv "$file" "$@" ;;
+	esac
+}
+
 install_gen_fstab() {
 	# install_gen_fstab <root_uuid> <root_fs> [boot_uuid] [boot_fs] [esp_uuid] [swap_uuid]
 	# Emit a fresh fstab on stdout. root_* required; boot_* optional (separate
@@ -1137,8 +1192,9 @@ install_run_scenario() {
 		# modes are handled by grub-mkconfig).
 		case "$boot_mode" in
 			emmc|mtd|ufs)
-				local env_file="$mp/boot/armbianEnv.txt"
-				[[ -f "$env_file" ]] && install_rewrite_bootenv "$env_file" "$root_uuid" "$fs" ;;
+				local env_file
+				env_file="$(install_boot_cfg_file "$mp/boot")" \
+					&& install_rewrite_bootcfg "$env_file" "$root_uuid" "$fs" ;;
 			sd)
 				# Boot stays on the current media (the SD/eMMC the board booted
 				# from); only the rootfs moved to $disk. Two things are needed:
@@ -1148,12 +1204,12 @@ install_run_scenario() {
 				#   2. map that media's /boot into the target at /boot, so kernel and
 				#      initramfs upgrades on the target land where u-boot reads them.
 				# Without (1) the board keeps booting its old rootfs.
-				local env_file="/boot/armbianEnv.txt"
-				if [[ ! -f "$env_file" ]]; then
-					install_log ERR "scenario: sd mode but current boot env ($env_file) is missing; cannot make $disk bootable"
+				local env_file
+				if ! env_file="$(install_boot_cfg_file /boot)"; then
+					install_log ERR "scenario: sd mode but the current media has no boot config (/boot/armbianEnv.txt or /boot/extlinux/extlinux.conf); cannot make $disk bootable"
 					rc=$INSTALL_EX_BOOTCFG; break
 				fi
-				install_rewrite_bootenv "$env_file" "$root_uuid" "$fs" \
+				install_rewrite_bootcfg "$env_file" "$root_uuid" "$fs" \
 					|| { install_log ERR "scenario: failed to point current boot env ($env_file) at new root $root_uuid"; rc=$INSTALL_EX_BOOTCFG; break; }
 				install_map_current_boot "$mp/etc/fstab" "$mp" \
 					|| { install_log ERR "scenario: failed to map current /boot into target fstab"; rc=$INSTALL_EX_BOOTCFG; break; }
@@ -1284,10 +1340,12 @@ install_run_split() {
 			printf '%s\t/emmc_storage\text4\tdefaults,nofail\t0\t2\n' "$storage_uuid" >>"$mp/etc/fstab"
 		fi
 
-		# Point the eMMC boot env at the root that now lives on the target device.
-		local env_file="$mp/boot/armbianEnv.txt"
-		[[ -f "$env_file" ]] && { install_rewrite_bootenv "$env_file" "$root_uuid" "$fs" \
-			|| { install_log ERR "split: failed to point $env_file at root $root_uuid"; rc=$INSTALL_EX_BOOTCFG; break; }; }
+		# Point the eMMC boot config at the root that now lives on the target device.
+		local env_file
+		if env_file="$(install_boot_cfg_file "$mp/boot")"; then
+			install_rewrite_bootcfg "$env_file" "$root_uuid" "$fs" \
+				|| { install_log ERR "split: failed to point $env_file at root $root_uuid"; rc=$INSTALL_EX_BOOTCFG; break; }
+		fi
 
 		# Module root fs (btrfs/f2fs) needs its driver in the eMMC /boot initramfs.
 		install_update_initramfs "$mp" "$fs"

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -537,6 +537,7 @@ install_rewrite_extlinux() {
 			return line
 		}
 		tolower($1) == "append" {
+			saw_append = 1
 			$0 = set_token($0, "root", root)
 			if (fstype != "") $0 = set_token($0, "rootfstype", fstype)
 			# Drop a subvol=@ left over from a previous btrfs root: a non-btrfs
@@ -545,6 +546,9 @@ install_rewrite_extlinux() {
 			else if (fstype != "") $0 = drop_token($0, "rootflags")
 		}
 		{ print }
+		# No append line means root= was never set: the caller would otherwise
+		# carry on believing the target had been repointed.
+		END { if (!saw_append) exit 1 }
 	' "$file" >"$tmp" || { rm -f "$tmp"; return "$INSTALL_EX_BOOTCFG"; }
 	# Copy back rather than rename: keeps the original mode/owner/inode.
 	cat "$tmp" >"$file" || { rm -f "$tmp"; return "$INSTALL_EX_BOOTCFG"; }

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -531,10 +531,18 @@ install_rewrite_extlinux() {
 			if (line ~ re) { sub(re, " " key "=" val, line) } else { line = line " " key "=" val }
 			return line
 		}
+		function drop_token(line, key,   re) {
+			re = "(^|[ \t])" key "=[^ \t]*"
+			sub(re, "", line)
+			return line
+		}
 		tolower($1) == "append" {
 			$0 = set_token($0, "root", root)
 			if (fstype != "") $0 = set_token($0, "rootfstype", fstype)
-			if (flags  != "") $0 = set_token($0, "rootflags", flags)
+			# Drop a subvol=@ left over from a previous btrfs root: a non-btrfs
+			# kernel rejects it and the root mount fails.
+			if (flags != "")       $0 = set_token($0, "rootflags", flags)
+			else if (fstype != "") $0 = drop_token($0, "rootflags")
 		}
 		{ print }
 	' "$file" >"$tmp" || { rm -f "$tmp"; return "$INSTALL_EX_BOOTCFG"; }
@@ -1366,8 +1374,10 @@ install_run_scenario() {
 		case "$boot_mode" in
 			emmc|mtd|ufs)
 				local env_file
-				env_file="$(install_boot_cfg_file "$mp/boot")" \
-					&& install_rewrite_bootcfg "$env_file" "$root_uuid" "$fs" ;;
+				if env_file="$(install_boot_cfg_file "$mp/boot")"; then
+					install_rewrite_bootcfg "$env_file" "$root_uuid" "$fs" \
+						|| { install_log ERR "scenario: failed to point $env_file at new root $root_uuid"; rc=$INSTALL_EX_BOOTCFG; break; }
+				fi ;;
 			sd)
 				# Boot stays on the current media (the SD/eMMC the board booted
 				# from); only the rootfs moved to $disk. Two things are needed:

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -510,6 +510,61 @@ install_rewrite_bootenv() {
 	fi
 }
 
+install_rewrite_extlinux() {
+	# install_rewrite_extlinux <file> <rootdev> [rootfstype]
+	# Repoint an extlinux/syslinux config (u-boot sysboot / distro boot) at
+	# <rootdev> - a "UUID=..." string or a device path. The kernel command line
+	# lives on the "append" line(s), so root= is substituted there (added when
+	# absent), and rootfstype= the same way when a fs is given.
+	#
+	# btrfs additionally needs rootflags=subvol=@: armbianEnv.txt boards get that
+	# from boot.cmd, which extlinux boards never run, so it is set here.
+	# Idempotent: re-running with the same values is a no-op. Pure text op.
+	local file="$1" rootdev="$2" fstype="${3:-}"
+	[[ -f "$file" ]] || return "$INSTALL_EX_BOOTCFG"
+	local flags=""
+	[[ "$fstype" == "btrfs" ]] && flags="subvol=@"
+	local tmp="${file}.new"
+	awk -v root="$rootdev" -v fstype="$fstype" -v flags="$flags" '
+		function set_token(line, key, val,   re) {
+			re = "(^|[ \t])" key "=[^ \t]*"
+			if (line ~ re) { sub(re, " " key "=" val, line) } else { line = line " " key "=" val }
+			return line
+		}
+		tolower($1) == "append" {
+			$0 = set_token($0, "root", root)
+			if (fstype != "") $0 = set_token($0, "rootfstype", fstype)
+			if (flags  != "") $0 = set_token($0, "rootflags", flags)
+		}
+		{ print }
+	' "$file" >"$tmp" || { rm -f "$tmp"; return "$INSTALL_EX_BOOTCFG"; }
+	# Copy back rather than rename: keeps the original mode/owner/inode.
+	cat "$tmp" >"$file" || { rm -f "$tmp"; return "$INSTALL_EX_BOOTCFG"; }
+	rm -f "$tmp"
+	return 0
+}
+
+install_boot_cfg_file() {
+	# install_boot_cfg_file <boot_dir>
+	# Echo the boot config that <boot_dir> actually uses - armbianEnv.txt on most
+	# u-boot boards, extlinux/extlinux.conf on distro-boot ones (spacemit/riscv,
+	# some vendor kernels). Returns 1 and prints nothing when neither is present.
+	local d="$1"
+	[[ -f "$d/armbianEnv.txt" ]]        && { echo "$d/armbianEnv.txt"; return 0; }
+	[[ -f "$d/extlinux/extlinux.conf" ]] && { echo "$d/extlinux/extlinux.conf"; return 0; }
+	return 1
+}
+
+install_rewrite_bootcfg() {
+	# install_rewrite_bootcfg <file> <rootdev> [rootfstype]
+	# Point <file> at the new root, dispatching on which boot config it is.
+	local file="$1"; shift
+	case "$file" in
+		*/extlinux.conf) install_rewrite_extlinux "$file" "$@" ;;
+		*)               install_rewrite_bootenv "$file" "$@" ;;
+	esac
+}
+
 install_gen_fstab() {
 	# install_gen_fstab <root_uuid> <root_fs> [boot_uuid] [boot_fs] [esp_uuid] [swap_uuid]
 	# Emit a fresh fstab on stdout. root_* required; boot_* optional (separate
@@ -1125,10 +1180,17 @@ install_rpi_style_boot() {
 	[[ -f "$dir/config.txt" && -f "$dir/cmdline.txt" ]]
 }
 
+install_sd_boot_dir() {
+	# The CURRENT media's boot directory. A function so tests can point it at a
+	# fixture instead of the real /boot.
+	echo /boot
+}
+
 install_sd_env_file() {
-	# The CURRENT media's u-boot boot env, rewritten by sd mode. A function so
-	# tests can point it at a fixture instead of the real /boot.
-	echo /boot/armbianEnv.txt
+	# The CURRENT media's boot config, rewritten by sd mode: armbianEnv.txt on
+	# most u-boot boards, extlinux/extlinux.conf on distro-boot ones. Prints
+	# nothing and returns 1 when the media carries neither.
+	install_boot_cfg_file "$(install_sd_boot_dir)"
 }
 
 install_sd_capable() {
@@ -1303,8 +1365,9 @@ install_run_scenario() {
 		# modes are handled by grub-mkconfig).
 		case "$boot_mode" in
 			emmc|mtd|ufs)
-				local env_file="$mp/boot/armbianEnv.txt"
-				[[ -f "$env_file" ]] && install_rewrite_bootenv "$env_file" "$root_uuid" "$fs" ;;
+				local env_file
+				env_file="$(install_boot_cfg_file "$mp/boot")" \
+					&& install_rewrite_bootcfg "$env_file" "$root_uuid" "$fs" ;;
 			sd)
 				# Boot stays on the current media (the SD/eMMC the board booted
 				# from); only the rootfs moved to $disk. Two things are needed:
@@ -1330,10 +1393,10 @@ install_run_scenario() {
 				else
 					local env_file; env_file="$(install_sd_env_file)"
 					if [[ ! -f "$env_file" ]]; then
-						install_log ERR "scenario: sd mode but current boot env ($env_file) is missing; cannot make $disk bootable"
+						install_log ERR "scenario: sd mode but the current media has no boot config (armbianEnv.txt or extlinux/extlinux.conf); cannot make $disk bootable"
 						rc=$INSTALL_EX_BOOTCFG; break
 					fi
-					install_rewrite_bootenv "$env_file" "$root_uuid" "$fs" \
+					install_rewrite_bootcfg "$env_file" "$root_uuid" "$fs" \
 						|| { install_log ERR "scenario: failed to point current boot env ($env_file) at new root $root_uuid"; rc=$INSTALL_EX_BOOTCFG; break; }
 					install_map_current_boot "$mp/etc/fstab" "$mp" \
 						|| { install_log ERR "scenario: failed to map current /boot into target fstab"; rc=$INSTALL_EX_BOOTCFG; break; }
@@ -1484,10 +1547,12 @@ install_run_split() {
 			printf '%s\t/emmc_storage\text4\tdefaults,nofail\t0\t2\n' "$storage_uuid" >>"$mp/etc/fstab"
 		fi
 
-		# Point the eMMC boot env at the root that now lives on the target device.
-		local env_file="$mp/boot/armbianEnv.txt"
-		[[ -f "$env_file" ]] && { install_rewrite_bootenv "$env_file" "$root_uuid" "$fs" \
-			|| { install_log ERR "split: failed to point $env_file at root $root_uuid"; rc=$INSTALL_EX_BOOTCFG; break; }; }
+		# Point the eMMC boot config at the root that now lives on the target device.
+		local env_file
+		if env_file="$(install_boot_cfg_file "$mp/boot")"; then
+			install_rewrite_bootcfg "$env_file" "$root_uuid" "$fs" \
+				|| { install_log ERR "split: failed to point $env_file at root $root_uuid"; rc=$INSTALL_EX_BOOTCFG; break; }
+		fi
 
 		# Module root fs (btrfs/f2fs) needs its driver in the eMMC /boot initramfs.
 		# Fatal on failure - see install_run_scenario's identical guard.

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -531,19 +531,33 @@ install_rewrite_extlinux() {
 			if (line ~ re) { sub(re, " " key "=" val, line) } else { line = line " " key "=" val }
 			return line
 		}
-		function drop_token(line, key,   re) {
-			re = "(^|[ \t])" key "=[^ \t]*"
-			sub(re, "", line)
-			return line
+		function drop_subvol(line,   tok, lead, pre, post, val, n, parts, i, kept) {
+			# Remove only the subvol= component of rootflags, not the whole
+			# token: rootflags=data=writeback is a legitimate ext4/f2fs option
+			# that several boards ship in their stock cmdline.
+			if (!match(line, /(^|[ \t])rootflags=[^ \t]*/)) return line
+			tok  = substr(line, RSTART, RLENGTH)
+			lead = (substr(tok, 1, 1) ~ /[ \t]/) ? substr(tok, 1, 1) : ""
+			pre  = substr(line, 1, RSTART - 1)
+			post = substr(line, RSTART + RLENGTH)
+			val  = substr(line, RSTART + length(lead) + 10, RLENGTH - length(lead) - 10)
+			n = split(val, parts, ",")
+			kept = ""
+			for (i = 1; i <= n; i++)
+				if (parts[i] !~ /^subvol=/)
+					kept = (kept == "") ? parts[i] : kept "," parts[i]
+			if (kept == "") return pre post
+			return pre lead "rootflags=" kept post
 		}
 		tolower($1) == "append" {
 			saw_append = 1
 			$0 = set_token($0, "root", root)
 			if (fstype != "") $0 = set_token($0, "rootfstype", fstype)
 			# Drop a subvol=@ left over from a previous btrfs root: a non-btrfs
-			# kernel rejects it and the root mount fails.
+			# kernel rejects it and the root mount fails. Any other rootflags
+			# the board ships stay.
 			if (flags != "")       $0 = set_token($0, "rootflags", flags)
-			else if (fstype != "") $0 = drop_token($0, "rootflags")
+			else if (fstype != "") $0 = drop_subvol($0)
 		}
 		{ print }
 		# No append line means root= was never set: the caller would otherwise


### PR DESCRIPTION
## Problem

Boards that boot via extlinux — spacemit/riscv and other vendor kernels — ship no `/boot/armbianEnv.txt`. Their kernel command line lives on the `append` line of `/boot/extlinux/extlinux.conf`. The engine only knew the armbianEnv `key=value` format, so on those boards:

- **`sd` mode** (rootfs to NVMe/USB, boot left on the removable media) aborted with `sd mode but current boot env (/boot/armbianEnv.txt) is missing; cannot make <disk> bootable` — a safe refusal, but it makes SD→NVMe installs impossible;
- **`emmc`/`mtd`/`ufs` and the eMMC split scenario** skipped the rewrite silently. Because `install_verify_boot_dir` already accepts `extlinux.conf` as a valid boot script, the install would report success while `root=` still pointed at the source media.

## Change

- `install_rewrite_extlinux()` — substitutes `root=` on the `append` line (adds it when absent), and `rootfstype=` the same way. Idempotent, preserves file mode, leaves `label`/`kernel`/`initrd`/`fdt` lines untouched.
- `install_boot_cfg_file()` / `install_rewrite_bootcfg()` — find and dispatch to whichever format the board actually uses. `armbianEnv.txt` keeps precedence when both exist, so no behaviour change on existing boards.
- Wired into all three call sites (`emmc|mtd|ufs`, `sd`, eMMC split).
- btrfs roots also get `rootflags=subvol=@`. armbianEnv boards get that from `boot.cmd`; extlinux boards never run it, so a btrfs install would otherwise mount the wrong subvolume.

## Testing

13 new bats cases in `tests/bats/bootconfig.bats` covering rewrite, idempotency, uppercase `APPEND`, missing `root=`, mode preservation, discovery precedence and dispatch. Fixture is a real `extlinux.conf` from a SpacemiT MUSE Book (K1, RISC-V).

Nothing has been flashed to hardware yet.