### PR TITLE
install-engine: silence null-byte warnings from the Rockchip probe

### DIFF
--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -298,9 +298,12 @@ install_apply_partitions() {
 	# serial) tagged "DVKR" at 7168, secure storage (HDCP/DRM keys) tagged
 	# "SSKR" at 8192. Nothing recreates either. Keep that window only when it
 	# is in use, so any other target is cleared exactly as before.
+	# tr -d '\0' only strips what bash would discard anyway: on a device without
+	# the magics those 4 bytes are usually NULs, and the bare substitution makes
+	# bash print "ignored null byte in input" over the installer dialog.
 	local keep_window="no"
-	[[ "$(dd if="$device" bs=1 skip=$(( 7168 * 512 )) count=4 2>/dev/null)" == "DVKR" ]] && keep_window="yes"
-	[[ "$(dd if="$device" bs=1 skip=$(( 8192 * 512 )) count=4 2>/dev/null)" == "SSKR" ]] && keep_window="yes"
+	[[ "$(dd if="$device" bs=1 skip=$(( 7168 * 512 )) count=4 2>/dev/null | tr -d '\0')" == "DVKR" ]] && keep_window="yes"
+	[[ "$(dd if="$device" bs=1 skip=$(( 8192 * 512 )) count=4 2>/dev/null | tr -d '\0')" == "SSKR" ]] && keep_window="yes"
 
 	wipefs -aq "$device" >>"$INSTALL_LOG" 2>&1 || true
 	if [[ "$keep_window" == "yes" ]]; then


### PR DESCRIPTION
## Problem

`install_apply_partitions` probes for the Rockchip vendor-storage (`DVKR` @ sector 7168) and secure-storage (`SSKR` @ 8192) magics by reading 4 raw bytes in a command substitution. On any device that does not carry them — an NVMe, a plain SD — those bytes are NULs, and bash prints:

```
config.functions.sh: line NNNN: warning: command substitution: ignored null byte in input
```

twice, once per probe, painted over the `Installing to /dev/nvme0n1 - please wait...` dialog. Reported from a SpacemiT MUSE Book install; reproducible on any non-Rockchip target.

## Fix

Pipe both probes through `tr -d '\\0'`. Bash already discarded those bytes, so the comparison result is unchanged — a device carrying the magic still yields exactly `DVKR`/`SSKR`.

Verified against loopback images for all three states: no magic → `keep_window=no`; `DVKR` present → `yes`; `SSKR` present → `yes`.

Cosmetic only, but it reads as an installer failure. Independent of #985.