### PR TITLE
fix(system): make overlayfs work out of the box

### DIFF
--- a/tools/modules/system/module_overlayfs.sh
+++ b/tools/modules/system/module_overlayfs.sh
@@ -25,7 +25,7 @@ function module_overlayfs() {
 
 	case "$1" in
 		"${commands[0]}")
-			pkg_install --reinstall -o Dpkg::Options::="--force-confold" overlayroot
+			pkg_install --reinstall -o Dpkg::Options::="--force-confold" overlayroot busybox-static
 			cat > /etc/overlayroot.conf <<-EOT
 			# overlayroot config - managed by configng
 			overlayroot_cfgdisk="disabled"


### PR DESCRIPTION
busybox-static is missing in minimal install, enabling ROFS won't work without it[1]. initramfs.conf already defaults to BUSYBOX=auto so merely installing the package suffices to actually make ROFS work.

[1] https://forum.armbian.com/topic/16469-overlayroot-not-working-as-expected/#comment-172291
