### PR TITLE
runners: authenticate the release lookup and verify before removing anything

### DIFF
--- a/tools/modules/system/module_armbian_runners.sh
+++ b/tools/modules/system/module_armbian_runners.sh
@@ -107,10 +107,45 @@ function module_armbian_runners () {
 			local temp_dir=$(mktemp -d)
 			trap '{ rm -rf -- "$temp_dir"; }' EXIT
 			[[ "$ARCH" == "x86_64" ]] && local arch=x64 || local arch=arm64
-			local LATEST=$(curl -sL https://api.github.com/repos/actions/runner/tags | jq -r '.[0].zipball_url' | rev | cut -d"/" -f1 | rev | sed "s/v//g")
-			curl --progress-bar --create-dirs --output-dir ${temp_dir} -o \
-			actions-runner-linux-${ARCH}-${LATEST}.tar.gz -L \
-			https://github.com/actions/runner/releases/download/v${LATEST}/actions-runner-linux-${arch}-${LATEST}.tar.gz
+			# Ask GitHub for the latest runner release, authenticated with the
+			# same token the registration calls use: unauthenticated api.github.com
+			# allows 60 requests an hour per IP, and once that is spent the reply
+			# is an error object rather than the expected array, which used to end
+			# as `jq: Cannot index object with number` and an empty LATEST.
+			#
+			# releases/latest rather than tags[0]: it states which release is
+			# current instead of trusting the order tags come back in.
+			local LATEST
+			LATEST=$(curl -fsSL \
+				-H "Accept: application/vnd.github+json" \
+				${gh_token:+-H "Authorization: Bearer ${gh_token}"} \
+				-H "X-GitHub-Api-Version: 2022-11-28" \
+				https://api.github.com/repos/actions/runner/releases/latest | jq -r '.tag_name // empty' | sed "s/^v//")
+
+			# Everything below removes the running runners before reinstalling
+			# them, so refuse to start when the version lookup failed - otherwise
+			# a rate-limited API call deletes the fleet and cannot rebuild it.
+			if [[ ! "${LATEST}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+				echo "Could not determine the latest actions/runner release (got '${LATEST:-<empty>}')." >&2
+				echo "Pass a GitHub token if you are being rate limited; no runners were touched." >&2
+				return 1
+			fi
+
+			local runner_tarball="${temp_dir}/actions-runner-linux-${ARCH}-${LATEST}.tar.gz"
+			# --fail, or curl writes the 404 body to the file, reports 100% and
+			# leaves tar to complain that stdin is not in gzip format.
+			if ! curl --fail --progress-bar --create-dirs --output-dir ${temp_dir} -o \
+				actions-runner-linux-${ARCH}-${LATEST}.tar.gz -L \
+				https://github.com/actions/runner/releases/download/v${LATEST}/actions-runner-linux-${arch}-${LATEST}.tar.gz; then
+				echo "Download of actions-runner ${LATEST} (${arch}) failed; no runners were touched." >&2
+				return 1
+			fi
+
+			# Verify the archive before anything is removed.
+			if ! tar tzf "${runner_tarball}" >/dev/null 2>&1; then
+				echo "Downloaded actions-runner ${LATEST} archive is not a valid tarball; no runners were touched." >&2
+				return 1
+			fi
 
 			# make runners each under its own user
 			for i in $(seq -w $start $stop)
@@ -141,7 +176,7 @@ function module_armbian_runners () {
 					echo "actions-runner-${i} ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 				fi
 				usermod -aG docker actions-runner-${i}
-				tar xzf ${temp_dir}/actions-runner-linux-${ARCH}-${LATEST}.tar.gz -C /home/actions-runner-${i}
+				tar xzf "${runner_tarball}" -C /home/actions-runner-${i}
 				chown -R actions-runner-${i}:actions-runner-${i} /home/actions-runner-${i}
 
 				# 1st runner has different labels

--- a/tools/modules/system/module_armbian_runners.sh
+++ b/tools/modules/system/module_armbian_runners.sh
@@ -106,6 +106,12 @@ function module_armbian_runners () {
 			# download latest runner package
 			local temp_dir=$(mktemp -d)
 			trap '{ rm -rf -- "$temp_dir"; }' EXIT
+
+			# That trap is shell-scoped, not function-scoped: it fires when
+			# armbian-config exits, not when this returns. Without an explicit
+			# call the directory survives every early return, and on success the
+			# ~200MB runner tarball sits there for the rest of the session.
+			runner_temp_cleanup() { rm -rf -- "${temp_dir}"; trap - EXIT; }
 			[[ "$ARCH" == "x86_64" ]] && local arch=x64 || local arch=arm64
 			# Ask GitHub for the latest runner release, authenticated with the
 			# same token the registration calls use: unauthenticated api.github.com
@@ -128,6 +134,7 @@ function module_armbian_runners () {
 			if [[ ! "${LATEST}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
 				echo "Could not determine the latest actions/runner release (got '${LATEST:-<empty>}')." >&2
 				echo "Pass a GitHub token if you are being rate limited; no runners were touched." >&2
+				runner_temp_cleanup
 				return 1
 			fi
 
@@ -138,12 +145,14 @@ function module_armbian_runners () {
 				actions-runner-linux-${ARCH}-${LATEST}.tar.gz -L \
 				https://github.com/actions/runner/releases/download/v${LATEST}/actions-runner-linux-${arch}-${LATEST}.tar.gz; then
 				echo "Download of actions-runner ${LATEST} (${arch}) failed; no runners were touched." >&2
+				runner_temp_cleanup
 				return 1
 			fi
 
 			# Verify the archive before anything is removed.
 			if ! tar tzf "${runner_tarball}" >/dev/null 2>&1; then
 				echo "Downloaded actions-runner ${LATEST} archive is not a valid tarball; no runners were touched." >&2
+				runner_temp_cleanup
 				return 1
 			fi
 
@@ -290,6 +299,8 @@ function module_armbian_runners () {
 			else
 				echo "Warning: runner-cleanup assets not found in source tree next to module or at /usr/share/armbian-config/runner-cleanup; skipping maintenance helper install" >&2
 			fi
+
+			runner_temp_cleanup
 
 		;;
 		"${commands[1]}")


### PR DESCRIPTION
Explains and fixes:

```
jq: error (at <stdin>:1): Cannot index object with number
########################################################################## 100.0%
Removing runner insa-trixie-01 on GitHub
Removing runner 01 locally
gzip: stdin: not in gzip format
tar: Child returned status 1
-bash: line 1: ./config.sh: No such file or directory
```

## The chain

`module_armbian_runners.sh` looked up the runner version with an **unauthenticated** call:

```bash
LATEST=$(curl -sL https://api.github.com/repos/actions/runner/tags | jq -r '.[0].zipball_url' | ...)
```

api.github.com allows 60 requests an hour per IP unauthenticated. Past that, the reply is an error *object*, not the expected *array*:

| step | result |
|---|---|
| `jq -r '.[0].zipball_url'` on an object | `Cannot index object with number`, `LATEST` empty |
| URL becomes `…/download/v/actions-runner-linux-x64-.tar.gz` | 404 |
| `curl` without `--fail` | writes the 9-byte `Not Found` body, shows **100%** |
| `tar xzf` | `gzip: stdin: not in gzip format` |
| nothing extracted | `./config.sh: No such file or directory` |

Reproduced end to end locally; every line of the reported output is accounted for.

## Why it was worse than a failed install

The loop removes each runner **from GitHub and locally before extracting**. So a rate-limit blip doesn't just fail — it deletes the fleet and then cannot rebuild it. That is what the marching `Removing runner … 01 … 02 … 03` lines are.

## Change

1. **Authenticate** with the same token the registration-token calls already use, when one is supplied (`${gh_token:+-H "Authorization: Bearer …"}` — still works unauthenticated for a one-off run).
2. **`releases/latest` → `.tag_name`** instead of `tags[0]`, which relied on the order tags come back in.
3. **Verify before destroying**: the version must match `^[0-9]+\.[0-9]+\.[0-9]+$`, the download must succeed (`--fail`), and the archive must pass `tar tzf` — all before the first runner is touched. Each failure returns with *no runners were touched*.

## Verification

| `LATEST` value | outcome |
|---|---|
| the jq error text | refused, nothing touched |
| empty | refused, nothing touched |
| `Not Found` | refused, nothing touched |
| `2.330.0` | accepted |

Live check of the new endpoint returns `2.336.0`.