### PR TITLE
docs(markdown): tag app-page logos with .app-logo for uniform sizing

### DIFF
--- a/tools/config-markdown.py
+++ b/tools/config-markdown.py
@@ -375,7 +375,7 @@ def _image_md(item):
             rel = f"tools/include/images/{item['id']}.{ext}"
             alt = item.get('short', item.get('description', ''))
             return (f"\n<!--- section image START from {rel} --->\n"
-                    f"![{alt}](/images/{item['id']}.{ext})\n"
+                    f"![{alt}](/images/{item['id']}.{ext}){{ .app-logo }}\n"
                     f"<!--- section image STOP from {rel} --->\n")
     return ""
 


### PR DESCRIPTION
App-page logos come from source images that vary wildly (square icons ~200×200 up to wide banners like 1033×200 and 1920×1080 screenshots), so they render at very different sizes.

This tags the generated logo with a `{ .app-logo }` attribute; the matching CSS rule (armbian/documentation) boxes every logo to one consistent visual size (max 260×88, aspect preserved).

Pairs with the armbian/documentation CSS PR — merge together. The regenerated app pages (with the class) arrive via the automated "Pull from Armbian config" PR once this lands.