### PR TITLE
Fix module_wireguard.sh allowed characters to match docker image

### DIFF
--- a/tools/modules/software/module_wireguard.sh
+++ b/tools/modules/software/module_wireguard.sh
@@ -156,7 +156,7 @@ function module_wireguard () {
 
 			local dialog_rc
 			if [[ -z $2 ]]; then
-				NUMBER_OF_PEERS=$(dialog_inputbox "Enter comma delimited peer keywords" "Valid characters: letters, numbers, hyphens, underscores" "laptop" 9 70)
+				NUMBER_OF_PEERS=$(dialog_inputbox "Enter comma delimited peer keywords" "Valid characters: letters and numbers" "laptop" 9 70)
 				dialog_rc=$?
 			else
 				NUMBER_OF_PEERS="$2"
@@ -182,8 +182,8 @@ function module_wireguard () {
 					# Skip empty peer names
 					[[ -z "$peer" ]] && continue
 					# Check for invalid characters (spaces, special chars except hyphen and underscore)
-					if [[ ! "$peer" =~ ^[a-zA-Z0-9_-]+$ ]]; then
-						dialog_msgbox "Error" "Invalid peer name: '$peer'\n\nPeer names must contain only:\n  - Letters (a-z, A-Z)\n  - Numbers (0-9)\n  - Hyphens (-)\n  - Underscores (_)\n\nSpaces, newlines and special characters are not allowed." 11 60
+					if [[ ! "$peer" =~ ^[a-zA-Z0-9]+$ ]]; then
+						dialog_msgbox "Error" "Invalid peer name: '$peer'\n\nPeer names must contain only:\n  - Letters (a-z, A-Z)\n  - Numbers (0-9)\n\nSpaces, newlines, hyphens, underscores, and special characters are not allowed." 11 60
 						exit 1
 					fi
 				done
@@ -278,8 +278,8 @@ function module_wireguard () {
 		fi
 			if [[ -n ${SELECTED_PEER} ]]; then
 				# Validate peer name to prevent command injection
-				if [[ ! "${SELECTED_PEER}" =~ ^[a-zA-Z0-9_-]+$ ]]; then
-					dialog_msgbox "Error" "Invalid peer name: '${SELECTED_PEER}'\n\nPeer names must contain only letters, numbers, hyphens, and underscores." 10 60
+				if [[ ! "${SELECTED_PEER}" =~ ^[a-zA-Z0-9]+$ ]]; then
+					dialog_msgbox "Error" "Invalid peer name: '${SELECTED_PEER}'\n\nPeer names must contain only letters and numbers" 10 60
 					return 1
 				fi
 				clear


### PR DESCRIPTION
# Description

Issue reference:  https://github.com/armbian/configng/issues/1000
Related documentation: https://github.com/linuxserver/docker-wireguard#parameters

# Implementation Details

- Key changes introduced by this PR
  - Only alphanumeric character will be allowed for wireguard peers
- Justification for the changes
  - Trying to create peers with hyphens and underscores (as initially thought to be allowed) silently fails, and is not supported by the docker image

# Documentation Summary

- [ ] **Metadata Included:**  
  _Did you include the metadata (associative arrays) in the code? Ensure that metadata for modules, jobs, and runtime has been updated appropriately._

- [ ] **Document Generated:**  
  _Did you generate the updated documentation using `armbian-configng --doc`? Confirm if the command was run to update `README.md` and provide any relevant details._

# Testing Procedure

_Describe the tests you ran to verify your changes. Provide relevant details about your test configuration._

- [ ] Test 1: Description and results
- [ ] Test 2: Description and results

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have ensured that my changes do not introduce new warnings or errors
- [ ] No new external dependencies are included
- [ ] Changes have been tested and verified
- [ ] I have included necessary metadata in the code, including associative arrays
