### PR TITLE
ci(unit-tests): PR runs only changed tests (full matrix stays on the nightly cron)

### DIFF
--- a/.github/workflows/maintenance-unit-tests.yml
+++ b/.github/workflows/maintenance-unit-tests.yml
@@ -91,9 +91,14 @@ jobs:
           )
 
           # read tests cases
-          # Run all tests on schedule, workflow_dispatch on main, or when no files changed
+          # Full matrix runs ONLY on the nightly schedule (and a manual
+          # workflow_dispatch on main). On a pull request, run just the changed
+          # tests/*.conf — and nothing at all when none changed. Previously a PR
+          # that touched no test file (e.g. a module-only change) fell through to
+          # "run everything", which is what made every PR run the whole matrix;
+          # the nightly cron is the safety net that exercises them all.
           run_all_tests=false
-          if [[ "${{ github.event_name }}" == "schedule" ]] || [[ "${{ github.ref_name }}" == "main" && "${{ github.event_name }}" == "workflow_dispatch" ]] || [[ "${{ steps.changed-files.outputs.any_changed }}" != "true" ]]; then
+          if [[ "${{ github.event_name }}" == "schedule" ]] || [[ "${{ github.ref_name }}" == "main" && "${{ github.event_name }}" == "workflow_dispatch" ]]; then
               run_all_tests=true
           fi
 


### PR DESCRIPTION
## Problem
The unit-test matrix builder runs the **entire** suite (every desktop/app test × release × arch) on a PR whenever **no `tests/*.conf` changed** — because of this fall-through:

```sh
if [[ event == schedule ]] || [[ main && workflow_dispatch ]] || [[ any_changed != "true" ]]; then
    run_all_tests=true
```

So a PR that only touches a module (or anything but a test file) triggers the whole matrix — slow and wasteful.

## Fix
Drop the `any_changed != "true"` clause. Now:

| Trigger | Runs |
|---|---|
| **Nightly `schedule`** (`0 2 * * *`) | **all** enabled tests |
| Manual `workflow_dispatch` on `main` | all |
| **Pull request** with changed `tests/*.conf` | **only those** |
| **Pull request** with no test change | **none** |

The full sweep stays on the nightly cron (the safety net); PRs only run what they touch. The `else` branch that derives changed tests from `git diff origin/main...HEAD` is unchanged and already handles the empty case (empty matrix → gradle jobs skip).