### PR TITLE
style: fix editorconfig violations so 'Coding style check' passes

### DIFF
--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -842,8 +842,8 @@ install_dualboot_blocker() {
 	json="$(lsblk -b -po NAME,FSTYPE,PARTTYPENAME,SIZE --json "$disk" 2>/dev/null)"
 	winpart="$(printf '%s' "$json" | jq -r '
 		[ .blockdevices[]?.children[]?
-		  | select(((.parttypename // "") | test("basic data"; "i")))
-		  | select(((.parttypename // "") | test("recovery"; "i")) | not) ]
+		| select(((.parttypename // "") | test("basic data"; "i")))
+		| select(((.parttypename // "") | test("recovery"; "i")) | not) ]
 		| sort_by(.size | tonumber) | reverse | (.[0].name // empty)' 2>/dev/null)"
 	# BitLocker FIRST (an encrypted volume also fails the ntfsresize probe below and
 	# must not be reported as "dirty"), scoped to THAT partition only: its lsblk/blkid

--- a/tools/modules/software/module_cockpit.sh
+++ b/tools/modules/software/module_cockpit.sh
@@ -92,6 +92,7 @@ function module_cockpit() {
 			# left untouched.
 			if [[ "${host_arch}" == amd64 ]]; then
 				mkdir -p /etc/libvirt/hooks
+				# editorconfig-checker-disable
 				cat > /etc/libvirt/hooks/qemu <<'HOOK'
 #!/usr/bin/env python3
 # Managed by Armbian config (module_cockpit) - changes may be overwritten.
@@ -124,6 +125,7 @@ if arch in ("x86_64", "i686") and not already:
 else:
     sys.stdout.write(data)
 HOOK
+				# editorconfig-checker-enable
 				chmod +x /etc/libvirt/hooks/qemu
 				systemctl restart libvirtd 2>/dev/null || systemctl restart libvirt 2>/dev/null || true
 			fi

--- a/tools/modules/system/module_partitioner.sh
+++ b/tools/modules/system/module_partitioner.sh
@@ -492,7 +492,7 @@ partitioner_cli_flash() {
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 			--target) [[ $# -ge 2 ]] || { echo "armbian-install bootloader: --target requires a value" >&2; return "$INSTALL_EX_USAGE"; }
-			          target="$2"; shift 2 ;;
+				target="$2"; shift 2 ;;
 			--yes|-y) assume_yes=1; shift ;;
 			*) echo "armbian-install bootloader: unknown option '$1'" >&2; return "$INSTALL_EX_USAGE" ;;
 		esac


### PR DESCRIPTION
The **Coding style check** (`editorconfig-checker`) fails on **every** PR — it's a whole-tree check and there were 8 pre-existing *"spaces instead of tabs"* violations across three modules (unrelated to any one PR, which is why it kept bumping up red).

Ran the checker locally (`ec v3.11.2`) and fixed each at the source:

| File | Was | Fix |
|---|---|---|
| `module_install_engine.sh` (845–846) | `\t\t␣␣\|` inside a multi-line `jq` filter | align to `\t\t\|` like the neighbouring line — jq ignores the whitespace, no behavior change |
| `module_cockpit.sh` (libvirt qemu hook) | a **Python heredoc** legitimately 4-space indented | wrap it in `# editorconfig-checker-disable` / `-enable` so the tool skips the embedded Python rather than demanding tabs |
| `module_partitioner.sh` (495) | a `case`-branch continuation space-aligned | indent with a tab |

Verified: **`editorconfig-checker` now exits 0** on the whole tree, and `bash -n` is clean on all three files. This unblocks the style check for all future PRs.