### PR TITLE
armbian-install: harden Windows detection (pipefail-safe + fs-probe race)

### DIFF
--- a/tests/bats/integration_dualboot.bats
+++ b/tests/bats/integration_dualboot.bats
@@ -71,6 +71,12 @@ teardown() {
 		echo "# lsblk: $(lsblk -b -po NAME,FSTYPE,PARTTYPENAME,SIZE --json "$LOOP" 2>&1 | tr '\n' ' ')" >&3
 		echo "# parted: $(parted -sm "$LOOP" print 2>&1 | tr '\n' '|')" >&3
 		echo "# blkid: p1=[$(blkid "${LOOP}p1" 2>&1)] p2=[$(blkid "${LOOP}p2" 2>&1)]" >&3
+		# Reproduce the function's auto-detect steps under the SAME pipefail so the
+		# log shows exactly where it bails (parted-gpt check vs. the lsblk parse).
+		parted -sm "$LOOP" print 2>/dev/null | grep -q '^/dev/.*:gpt:'
+		echo "# diag: parted|grep-q rc=$?" >&3
+		local _j; _j="$(lsblk -b -po NAME,FSTYPE,PARTTYPENAME,SIZE --json "$LOOP" 2>/dev/null)"
+		echo "# diag: parts=[$(_install_windows_parts "$_j" | tr '\n' ' ')]" >&3
 	fi
 	[ "$status" -eq 0 ]
 	[[ "$output" == *"esp=${LOOP}p1"* ]]

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -764,6 +764,13 @@ _install_windows_parts() {
 	# size is sorted with tonumber (lsblk may emit it as a string, and a string
 	# sort would rank 781MB above 63GB). Emits two lines: esp=<dev|> windows=<dev|>
 	local json="$1" esp win
+	# The Windows volume is matched by fstype "ntfs" OR, when lsblk could not
+	# probe the filesystem (empty fstype - a real risk on freshly-attached or
+	# just-formatted disks where the udev/blkid cache has not caught up), by the
+	# GPT partition type "Microsoft basic data", which is read from the partition
+	# table and is therefore reliable when the fs probe is not. A genuinely
+	# encrypted volume (BitLocker) has a NON-empty, non-ntfs fstype, so it is not
+	# swept in here - it falls through to the BitLocker branch in the caller.
 	# editorconfig-checker-disable
 	esp="$(printf '%s' "$json" | jq -r '
 		[ .blockdevices[]?.children[]?
@@ -771,7 +778,9 @@ _install_windows_parts() {
 		  | .name ] | first // empty')"
 	win="$(printf '%s' "$json" | jq -r '
 		[ .blockdevices[]?.children[]?
-		  | select(.fstype == "ntfs")
+		  | select((.fstype == "ntfs")
+		           or (((.parttypename // "") | test("basic data"; "i"))
+		               and ((.fstype // "") == "")))
 		  | select(((.parttypename // "") | test("recovery"; "i")) | not) ]
 		| sort_by(.size | tonumber) | reverse | (.[0].name // empty)')"
 	# editorconfig-checker-enable
@@ -787,8 +796,14 @@ install_detect_windows() {
 	local disk="$1" json="${2:-}"
 	if [[ -z "$json" ]]; then
 		[[ -b "$disk" ]] || return "$INSTALL_EX_NODEV"
-		# GPT is required for a UEFI Windows install.
-		parted -sm "$disk" print 2>/dev/null | grep -q '^/dev/.*:gpt:' || return "$INSTALL_EX_NODEV"
+		# GPT is required for a UEFI Windows install. Capture parted's output and
+		# grep it separately rather than `parted | grep -q`: under `set -o pipefail`
+		# (which strict callers, and the bats suite, set) `grep -q` can exit on the
+		# first match while parted is still writing, leaving parted killed by
+		# SIGPIPE (141) and the pipeline failing on an otherwise valid GPT disk.
+		local ptbl
+		ptbl="$(parted -sm "$disk" print 2>/dev/null)" || true
+		grep -q '^/dev/.*:gpt:' <<<"$ptbl" || return "$INSTALL_EX_NODEV"
 		json="$(lsblk -b -po NAME,FSTYPE,PARTTYPENAME,SIZE --json "$disk" 2>/dev/null)"
 	fi
 


### PR DESCRIPTION
## What

`install_detect_windows`'s auto-detect path had **two independent bugs** that
combined to fail the loopback dual-boot integration test
(`tests/bats/integration_dualboot.bats :: detect_windows`) with
`status=65 output=[]` — on a disk whose post-mortem `lsblk`/`parted`/`blkid`
dump is perfectly valid. **Pre-existing and unrelated to any kernel/firmware
work — reproduces on `main`.**

Each showed up only after the other was fixed, which is why it took two rounds:

### 1. `pipefail` + `parted | grep -q`
The bats `setup()` runs `set -o pipefail` (to catch masked exit codes).
`grep -q` exits on the first matching line while `parted` is still writing, so
`parted` can be killed by SIGPIPE and `pipefail` fails the whole pipeline —
returning `NODEV` **before the disk is ever parsed**.
→ Capture parted's output, then grep the string; grep's early exit can no
longer take parted (or the pipeline) down.

### 2. Windows volume identified only by `fstype == "ntfs"`
lsblk reads `fstype` from a filesystem probe (udev/blkid cache) that isn't
always populated on a just-formatted / freshly-attached disk, so the NTFS
volume can show an **empty `fstype`** and go unmatched (the ESP is still found,
because it's matched by its GPT type, not the fs probe).
→ Also accept a `Microsoft basic data` partition with **empty** `fstype` as the
Windows candidate — that type comes from the partition table and is reliable
when the fs probe is not. **BitLocker** (non-empty, non-ntfs `fstype`) is still
not matched and routes to the BitLocker branch.

Also adds a diagnostic to the test's failure branch that reproduces the
auto-detect steps under the same `pipefail`, so any future failure shows
exactly where it bails (parted-gpt check vs. the lsblk parse).

## Verified — CI green

`ok 12 dualboot: detect_windows finds the ESP and the NTFS volume` now passes,
the full **Installer engine bats** job is green, and the BitLocker unit test
(`ok 38 detect_windows: a BitLocker C: yields no target and a clear hint`)
still passes. Local checks against normal / raced (null-fstype) / BitLocker
JSON all behave correctly; editorconfig clean.