### PR TITLE
package: heal interrupted dpkg state + stop masking apt failures

### DIFF
--- a/.github/workflows/maintenance-bats.yml
+++ b/.github/workflows/maintenance-bats.yml
@@ -31,7 +31,7 @@ jobs:
         run: sudo apt-get update -qq && sudo apt-get install -y -qq bats jq parted dosfstools ntfs-3g
 
       - name: Unit tests (pure functions, no privileges)
-        run: bats tests/bats/plan.bats tests/bats/detect.bats tests/bats/detect_windows.bats tests/bats/bootconfig.bats tests/bats/dualboot.bats tests/bats/transfer.bats
+        run: bats tests/bats/plan.bats tests/bats/detect.bats tests/bats/detect_windows.bats tests/bats/bootconfig.bats tests/bats/dualboot.bats tests/bats/transfer.bats tests/bats/package.bats
 
       - name: Integration tests (loopback block device + Windows dual-boot, needs root)
         run: sudo bats tests/bats/integration_loopback.bats tests/bats/integration_dualboot.bats

--- a/tests/bats/package.bats
+++ b/tests/bats/package.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+#
+# Regression tests for apt_operation_progress() exit-code propagation.
+#
+# The dialog/whiptail progress path runs apt inside `( ... ) | dialog_gauge`, so
+# a naive `exit_code=$?` captures dialog_gauge (which succeeds) and masks a
+# failed apt operation - pkg_install then treats a failed install as success and
+# appends to ACTUALLY_INSTALLED. These lock the real apt rc down.
+
+setup() {
+	declare -A module_options
+	source "${BATS_TEST_DIRNAME}/../../tools/modules/functions/module_package.sh"
+
+	# apt-get stub on PATH; its exit code is driven by FAKE_APT_RC.
+	STUB="$BATS_TEST_TMPDIR/bin"
+	mkdir -p "$STUB"
+	cat > "$STUB/apt-get" <<-'STUBEOF'
+		#!/usr/bin/env bash
+		echo "E: stub apt-get $*"
+		exit "${FAKE_APT_RC:-0}"
+	STUBEOF
+	chmod +x "$STUB/apt-get"
+	PATH="$STUB:$PATH"
+
+	# A non-"read" DIALOG exercises the dialog_gauge progress pipeline.
+	DIALOG="dialog"
+
+	# Neutralise the UI + preflight so the test is deterministic and unprivileged.
+	# dialog_gauge MUST succeed - the whole point is that its success must not be
+	# mistaken for apt's result.
+	dialog_gauge()  { cat > /dev/null; return 0; }
+	dialog_msgbox() { return 0; }
+	dpkg()          { return 0; }
+}
+
+@test "apt_operation_progress: progress path propagates an apt failure" {
+	export FAKE_APT_RC=100
+	run apt_operation_progress install stub-pkg
+	[ "$status" -ne 0 ]
+}
+
+@test "apt_operation_progress: progress path reports apt success" {
+	export FAKE_APT_RC=0
+	run apt_operation_progress install stub-pkg
+	[ "$status" -eq 0 ]
+}

--- a/tools/modules/functions/module_package.sh
+++ b/tools/modules/functions/module_package.sh
@@ -20,6 +20,7 @@ apt_operation_progress() {
 	local args=("$@")
 	local title="APT Operation"
 	local error_file=$(mktemp)
+	local rc_file=$(mktemp)
 	local exit_code
 
 	# Pre-flight self-heal: a previous apt/dpkg run cut short (power loss or a
@@ -94,8 +95,11 @@ apt_operation_progress() {
 				apt_cmd="DEBIAN_FRONTEND=noninteractive apt-get -y $operation ${args[*]}"
 			fi
 
-			# Run apt command and capture output
-			eval "$apt_cmd" 2>&1 | while IFS= read -r line; do
+			# Run apt command. tee preserves apt's output for the error dialog;
+			# ${PIPESTATUS[0]} preserves apt's own exit code, which the outer
+			# `... | dialog_gauge` pipeline would otherwise hide behind
+			# dialog_gauge's (always-success) status - masking a failed apt run.
+			eval "$apt_cmd" 2>&1 | tee "$error_file" | while IFS= read -r line; do
 				# Parse apt output for progress indicators
 				if [[ "$line" =~ ^(Hit|Get|Reading|Download|Fetch|Hit|Preparing|Unpacking|Setting|Selecting|Processing) ]]; then
 					echo "XXX"
@@ -109,6 +113,7 @@ apt_operation_progress() {
 					echo "XXX"
 				fi
 			done
+			echo "${PIPESTATUS[0]}" > "$rc_file"
 
 			echo "XXX"
 			echo "100"
@@ -116,7 +121,11 @@ apt_operation_progress() {
 			echo "XXX"
 		) | dialog_gauge "$title" "Processing $operation..." 8 80
 
-		exit_code=$?
+		# Recover apt's real exit code (written inside the subshell); the outer
+		# pipe makes $? reflect dialog_gauge, not apt. A missing/garbled value
+		# (e.g. the dialog was cancelled) counts as a failure.
+		exit_code="$(cat "$rc_file" 2>/dev/null)"
+		[[ "$exit_code" =~ ^[0-9]+$ ]] || exit_code=1
 	fi
 
 	# Show any errors
@@ -126,7 +135,7 @@ apt_operation_progress() {
 		fi
 	fi
 
-	rm -f "$error_file"
+	rm -f "$error_file" "$rc_file"
 	return $exit_code
 }
 

--- a/tools/modules/functions/module_package.sh
+++ b/tools/modules/functions/module_package.sh
@@ -113,11 +113,16 @@ apt_operation_progress() {
 					echo "XXX"
 				fi
 			done
-			echo "${PIPESTATUS[0]}" > "$rc_file"
+			local apt_exit_code=${PIPESTATUS[0]}
+			echo "$apt_exit_code" > "$rc_file"
 
 			echo "XXX"
 			echo "100"
-			echo "$operation complete!"
+			if [[ $apt_exit_code -eq 0 ]]; then
+				echo "$operation complete!"
+			else
+				echo "$operation failed."
+			fi
 			echo "XXX"
 		) | dialog_gauge "$title" "Processing $operation..." 8 80
 

--- a/tools/modules/functions/module_package.sh
+++ b/tools/modules/functions/module_package.sh
@@ -22,6 +22,23 @@ apt_operation_progress() {
 	local error_file=$(mktemp)
 	local exit_code
 
+	# Pre-flight self-heal: a previous apt/dpkg run cut short (power loss or a
+	# reboot mid-upgrade) leaves dpkg half-configured, and apt then refuses EVERY
+	# mutating operation with "dpkg was interrupted ... run 'dpkg --configure -a'".
+	# Repair it up front so install/upgrade/remove recover a board that is only
+	# in an interrupted state instead of failing on it. The exit-100 retry in
+	# pkg_install/pkg_remove can't cover this: the dialog_gauge path masks apt's
+	# real rc, so it never fires non-interactively (DIALOG=word). Cheap no-op when
+	# nothing is pending; read-only operations (update/clean) can't hit this.
+	case "$operation" in
+		install|upgrade|full-upgrade|remove|autopurge|fix-broken)
+			if [[ -n "$(ls -A /var/lib/dpkg/updates/ 2>/dev/null)" ]] \
+				|| dpkg --audit 2>/dev/null | grep -q .; then
+				DEBIAN_FRONTEND=noninteractive dpkg --configure -a >/dev/null 2>&1 || true
+			fi
+			;;
+	esac
+
 	case "$operation" in
 		update)
 			title="Package Update"


### PR DESCRIPTION
This PR does two related things to make `armbian-config`'s apt operations reliable on boards that were left in a bad state.

---

## 1. Heal an interrupted dpkg state before apt operations

**Problem.** A board whose apt/dpkg run was cut short — power loss or a reboot mid-upgrade — is left half-configured. apt then refuses **every** mutating operation with:

> E: dpkg was interrupted, you must manually run 'dpkg --configure -a'

So `armbian-config`'s own upgrade and repository-switch fail on a board that is otherwise recoverable. It showed up in fleet testing: `restore-stable` could not switch a board back to the stable repository, and logging in confirmed the board just needed `dpkg --configure -a`.

**Fix.** Repair proactively at the single chokepoint every mutating apt op passes through (`apt_operation_progress`). Before `install`/`upgrade`/`full-upgrade`/`remove`/`autopurge`/`fix-broken`, run `dpkg --configure -a` when dpkg has pending updates or fails an audit. Cheap no-op on a healthy system; read-only ops (`update`/`clean`) can't hit this state.

This benefits every user recovering from an interrupted upgrade, and the test fleet gets it for free since reconcile only calls `armbian-config`.

## 2. Stop the progress dialog from masking apt failures

**Problem (pre-existing, surfaced in review).** In the non-`read` DIALOG path, apt runs inside `( … ) | dialog_gauge`, so `exit_code=$?` captured **`dialog_gauge`**'s status (effectively always success) instead of apt's. A failed `install`/`upgrade`/`remove` therefore returned `0`, and callers such as `pkg_install` treated it as success and appended the packages to `ACTUALLY_INSTALLED`. It's also why the existing exit-100 `dpkg --configure -a` retry in `pkg_install`/`pkg_remove` never fired non-interactively — the real apt rc never reached it.

**Fix.** Capture apt's own status via `${PIPESTATUS[0]}` inside the subshell (before the outer `| dialog_gauge` overwrites `$?`), stash it in a temp file, and read it back after the pipe; a missing/garbled value (e.g. the dialog was cancelled) counts as a failure. Also `tee` apt's output into the error file on this path so the existing failure msgbox has content.

## Tests

Adds `tests/bats/package.bats` locking the exit-code behaviour down (apt failure → nonzero, apt success → zero) and wires it into `maintenance-bats.yml`. Verified the test **fails** against the pre-fix code (rc `0` on a failed apt) and **passes** with the fix.