### PR TITLE
ci(unit-tests): post-merge dispatch runs the tests the merge changed

### DIFF
--- a/.github/workflows/maintenance-build-debian.yml
+++ b/.github/workflows/maintenance-build-debian.yml
@@ -36,7 +36,37 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+      - name: "Determine changed test cases"
+        id: changed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT: ${{ github.event_name }}
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # On a push to main, ask the API which tests/*.conf the pushed range
+          # changed, so the dispatched unit-test run exercises exactly what the
+          # merge touched (a desktop PR -> its one desktop). A manual build
+          # (workflow_dispatch) or a first push with an all-zero before-sha can't
+          # be scoped this way, so signal "all" and let the suite run in full.
+          mode="all"
+          changed=""
+          if [[ "$EVENT" == "push" && ! "$BEFORE" =~ ^0+$ ]]; then
+              mode="changed"
+              changed="$(gh api "repos/${REPO}/compare/${BEFORE}...${AFTER}" \
+                  --jq '[.files[].filename | select(startswith("tests/") and endswith(".conf"))] | join(" ")' \
+                  2>/dev/null || true)"
+          fi
+          {
+              echo "mode=${mode}"
+              echo "changed=${changed}"
+          } >> "$GITHUB_OUTPUT"
+          echo "mode=${mode} changed_tests=[${changed}]"
+
       - name: "Run unit tests action"
         uses: peter-evans/repository-dispatch@v4
         with:
           event-type: "Unit tests"
+          client-payload: '{"mode": "${{ steps.changed.outputs.mode }}", "changed_tests": "${{ steps.changed.outputs.changed }}"}'

--- a/.github/workflows/maintenance-build-debian.yml
+++ b/.github/workflows/maintenance-build-debian.yml
@@ -49,24 +49,38 @@ jobs:
           # On a push to main, ask the API which tests/*.conf the pushed range
           # changed, so the dispatched unit-test run exercises exactly what the
           # merge touched (a desktop PR -> its one desktop). A manual build
-          # (workflow_dispatch) or a first push with an all-zero before-sha can't
-          # be scoped this way, so signal "all" and let the suite run in full.
+          # (workflow_dispatch), a first push with an all-zero before-sha, or a
+          # failed/rate-limited API call can't be scoped this way, so signal
+          # "all" and let the suite run in full rather than silently testing
+          # nothing (a failed `gh api` must never masquerade as "no tests
+          # changed" - that would report post-merge green while testing zero
+          # test cases).
           mode="all"
-          changed=""
+          changed_json="[]"
           if [[ "$EVENT" == "push" && ! "$BEFORE" =~ ^0+$ ]]; then
-              mode="changed"
-              changed="$(gh api "repos/${REPO}/compare/${BEFORE}...${AFTER}" \
-                  --jq '[.files[].filename | select(startswith("tests/") and endswith(".conf"))] | join(" ")' \
-                  2>/dev/null || true)"
+              api_err="$(mktemp)"
+              if changed_json="$(gh api "repos/${REPO}/compare/${BEFORE}...${AFTER}" \
+                  --jq '[.files[].filename | select(startswith("tests/") and endswith(".conf"))]' \
+                  2>"${api_err}")"; then
+                  mode="changed"
+              else
+                  echo "::warning::gh api compare failed, falling back to mode=all: $(cat "${api_err}")"
+                  mode="all"
+                  changed_json="[]"
+              fi
+              rm -f "${api_err}"
           fi
-          {
-              echo "mode=${mode}"
-              echo "changed=${changed}"
-          } >> "$GITHUB_OUTPUT"
-          echo "mode=${mode} changed_tests=[${changed}]"
+          # Build the whole client-payload as valid JSON here (via jq, so any
+          # filename - quotes, backslashes, spaces - is escaped correctly) and
+          # pass it through as one opaque string; the dispatch step below
+          # injects it unquoted rather than hand-interpolating fields into a
+          # JSON literal.
+          payload="$(jq -nc --arg mode "$mode" --argjson changed "$changed_json" '{mode: $mode, changed_tests: $changed}')"
+          echo "payload=${payload}" >> "$GITHUB_OUTPUT"
+          echo "mode=${mode} changed_tests=${changed_json}"
 
       - name: "Run unit tests action"
         uses: peter-evans/repository-dispatch@v4
         with:
           event-type: "Unit tests"
-          client-payload: '{"mode": "${{ steps.changed.outputs.mode }}", "changed_tests": "${{ steps.changed.outputs.changed }}"}'
+          client-payload: ${{ steps.changed.outputs.payload }}

--- a/.github/workflows/maintenance-build-debian.yml
+++ b/.github/workflows/maintenance-build-debian.yml
@@ -92,6 +92,17 @@ jobs:
           # injects it unquoted rather than hand-interpolating fields into a
           # JSON literal.
           payload="$(jq -nc --arg mode "$mode" --argjson changed "$changed_json" '{mode: $mode, changed_tests: $changed}')"
+          # GitHub caps client_payload at 64KB; a merge with enough tests/*.conf
+          # entries could exceed that, and peter-evans/repository-dispatch would
+          # then reject the dispatch outright - so the post-merge run silently
+          # never fires. Fall back to mode=all (a small, fixed-size payload)
+          # before that happens rather than losing the dispatch entirely.
+          if [[ "$(LC_ALL=C printf '%s' "${payload}" | wc -c)" -ge 60000 ]]; then
+              echo "::warning::dispatch payload is too large (>=60000 bytes); falling back to mode=all"
+              mode="all"
+              changed_json="[]"
+              payload="$(jq -nc --arg mode "$mode" --argjson changed "$changed_json" '{mode: $mode, changed_tests: $changed}')"
+          fi
           echo "payload=${payload}" >> "$GITHUB_OUTPUT"
           echo "mode=${mode} changed_tests=${changed_json}"
 

--- a/.github/workflows/maintenance-build-debian.yml
+++ b/.github/workflows/maintenance-build-debian.yml
@@ -59,10 +59,26 @@ jobs:
           changed_json="[]"
           if [[ "$EVENT" == "push" && ! "$BEFORE" =~ ^0+$ ]]; then
               api_err="$(mktemp)"
-              if changed_json="$(gh api "repos/${REPO}/compare/${BEFORE}...${AFTER}" \
-                  --jq '[.files[].filename | select(startswith("tests/") and endswith(".conf"))]' \
+              if compare_json="$(gh api "repos/${REPO}/compare/${BEFORE}...${AFTER}" \
+                  --jq '{total: (.files | length), changed: [.files[].filename | select(startswith("tests/") and endswith(".conf"))]}' \
                   2>"${api_err}")"; then
-                  mode="changed"
+                  # GitHub's compare endpoint hard-caps .files at 300 entries,
+                  # only on the first page - files beyond that aren't
+                  # retrievable at all, so pagination cannot recover them, and
+                  # the response carries no truncation flag. A merge that
+                  # large means any tests/*.conf past the cutoff is invisible
+                  # here, so a "changed" result built from a possibly-
+                  # truncated list could run less than the merge touched -
+                  # fall back to running everything instead of trusting it.
+                  total_files="$(jq -r '.total' <<< "${compare_json}")"
+                  if [[ "${total_files}" -ge 300 ]]; then
+                      echo "::warning::compare returned ${total_files} files (>= GitHub's 300-file cap, possibly truncated) - falling back to mode=all"
+                      mode="all"
+                      changed_json="[]"
+                  else
+                      mode="changed"
+                      changed_json="$(jq -c '.changed' <<< "${compare_json}")"
+                  fi
               else
                   echo "::warning::gh api compare failed, falling back to mode=all: $(cat "${api_err}")"
                   mode="all"

--- a/.github/workflows/maintenance-unit-tests.yml
+++ b/.github/workflows/maintenance-unit-tests.yml
@@ -111,15 +111,34 @@ jobs:
 
           # repository_dispatch is the post-merge trigger fired by
           # maintenance-build-debian after a push to main. It carries a
-          # client_payload: CP_MODE="changed" with a space-separated CP_CHANGED
-          # list runs exactly what the merge touched (a desktop PR -> its one
+          # client_payload: CP_MODE="changed" with a JSON array CP_CHANGED
+          # runs exactly what the merge touched (a desktop PR -> its one
           # desktop); CP_MODE="all" (a manual build, or a payload-less dispatch
           # fired by hand) runs the whole suite. Read via env, never inlined into
           # the script, so the payload can't inject shell.
-          dispatch_changed=""
+          #
+          # repository_dispatch can also be fired directly (bypassing the
+          # trusted producer workflow) with an arbitrary client_payload, so
+          # every entry is validated before it is ever used: must look like a
+          # bare tests/<name>.conf path (no traversal), and resolve to a real
+          # regular file actually under this checkout - anything else is
+          # dropped rather than reaching `source` below.
+          dispatch_changed=()
           if [[ "${{ github.event_name }}" == "repository_dispatch" ]]; then
               if [[ "${CP_MODE}" == "changed" ]]; then
-                  dispatch_changed="${CP_CHANGED}"
+                  entry=""
+                  while IFS= read -r entry; do
+                      [[ -n "${entry}" ]] || continue
+                      if [[ "${entry}" =~ ^tests/[^/]+\.conf$ ]] && [[ -f "${GITHUB_WORKSPACE}/${entry}" ]]; then
+                          resolved="$(realpath -e -- "${GITHUB_WORKSPACE}/${entry}")"
+                          case "${resolved}" in
+                              "${GITHUB_WORKSPACE}"/*) dispatch_changed+=("${entry}") ;;
+                              *) echo "::warning::ignoring dispatch changed_tests entry outside workspace: ${entry}" ;;
+                          esac
+                      else
+                          echo "::warning::ignoring invalid dispatch changed_tests entry: ${entry}"
+                      fi
+                  done < <(jq -r '.[]? // empty' <<< "${CP_CHANGED:-[]}" 2>/dev/null || true)
               else
                   run_all_tests=true
               fi
@@ -129,9 +148,8 @@ jobs:
               tests=($(grep -rwl tests/*.conf -e "ENABLED=true" | cut -d":" -f1))
           elif [[ "${{ github.event_name }}" == "repository_dispatch" ]]; then
               # Post-merge: run just the tests the merge changed (from the payload).
-              if [[ -n "$dispatch_changed" ]]; then
-                  read -r -a changed_tests <<< "$dispatch_changed"
-                  tests=($(grep -rwl -e "ENABLED=true" -- "${changed_tests[@]}" 2>/dev/null | cut -d":" -f1))
+              if [[ ${#dispatch_changed[@]} -gt 0 ]]; then
+                  tests=($(grep -rwl -e "ENABLED=true" -- "${dispatch_changed[@]}" 2>/dev/null | cut -d":" -f1))
               else
                   tests=()
               fi

--- a/.github/workflows/maintenance-unit-tests.yml
+++ b/.github/workflows/maintenance-unit-tests.yml
@@ -57,9 +57,12 @@ jobs:
       - name: "Make JSON ${{ steps.changed-files.outputs.all_changed_files }}"
         id: json
         env:
-          # Consumed as an env var rather than interpolated into the script
-          # body, so a file name can never be treated as shell.
+          # Consumed as env vars rather than interpolated into the script body,
+          # so a file name (or a dispatch payload) can never be treated as shell.
           CHANGED_TESTS: "${{ steps.changed-files.outputs.all_changed_files }}"
+          # repository_dispatch payload from maintenance-build-debian.
+          CP_MODE: ${{ github.event.client_payload.mode }}
+          CP_CHANGED: ${{ github.event.client_payload.changed_tests }}
         run: |
 
           # Run each enabled test case against every arch its TESTARCH
@@ -106,8 +109,32 @@ jobs:
               run_all_tests=true
           fi
 
+          # repository_dispatch is the post-merge trigger fired by
+          # maintenance-build-debian after a push to main. It carries a
+          # client_payload: CP_MODE="changed" with a space-separated CP_CHANGED
+          # list runs exactly what the merge touched (a desktop PR -> its one
+          # desktop); CP_MODE="all" (a manual build, or a payload-less dispatch
+          # fired by hand) runs the whole suite. Read via env, never inlined into
+          # the script, so the payload can't inject shell.
+          dispatch_changed=""
+          if [[ "${{ github.event_name }}" == "repository_dispatch" ]]; then
+              if [[ "${CP_MODE}" == "changed" ]]; then
+                  dispatch_changed="${CP_CHANGED}"
+              else
+                  run_all_tests=true
+              fi
+          fi
+
           if [[ "$run_all_tests" == "true" ]]; then
               tests=($(grep -rwl tests/*.conf -e "ENABLED=true" | cut -d":" -f1))
+          elif [[ "${{ github.event_name }}" == "repository_dispatch" ]]; then
+              # Post-merge: run just the tests the merge changed (from the payload).
+              if [[ -n "$dispatch_changed" ]]; then
+                  read -r -a changed_tests <<< "$dispatch_changed"
+                  tests=($(grep -rwl -e "ENABLED=true" -- "${changed_tests[@]}" 2>/dev/null | cut -d":" -f1))
+              else
+                  tests=()
+              fi
           else
               # Take the list from tj-actions/changed-files above: it already
               # resolved the PR base and fetched whatever history that needed.


### PR DESCRIPTION
## Problem

The post-merge unit-test run — `repository_dispatch` **"Unit tests"**, fired by `maintenance-build-debian` after a push to `main` — tested **nothing**. `run_all_tests` only covered `schedule` and `workflow_dispatch`, so a `repository_dispatch` fell through to the changed-files branch, where `git diff origin/main...HEAD` is empty (it *is* `main`) → empty matrix → **zero tests**. (Seen in [run 33233302945](https://github.com/armbian/configng/actions/runs/33233302945): *"the loop iterates an empty set"*.)

## Fix

Make the dispatch carry what changed:

- **`maintenance-build-debian.yml`** — on a push to `main`, ask the API which `tests/*.conf` the pushed range (`before...after`) touched, and pass them as `client_payload`:
  ```json
  { "mode": "changed", "changed_tests": "tests/LXQT01.conf ..." }
  ```
  A manual build (`workflow_dispatch`) or a first push with an all-zero before-sha signals `mode: "all"`.
- **`maintenance-unit-tests.yml`** — on `repository_dispatch`, run exactly those tests (filtered for `ENABLED=true`). `mode=all`, or a payload-less hand-fired dispatch, runs the full suite.

Net behaviour:

| Trigger | Runs |
|---|---|
| PR (`pull_request`) | only changed tests, none when no test changed *(unchanged)* |
| **push→main merge** (this PR) | **only the test(s) the merge changed** — a desktop PR → its one desktop |
| merge that changed no test | nothing |
| nightly `schedule` | everything |
| manual build (`workflow_dispatch`) | everything |

## Notes

- Payload is read via env (`CP_MODE`/`CP_CHANGED`), never interpolated into the shell body (no script-injection surface).
- Verified the decision logic under bash for all cases (one changed → one, multiple → those, disabled filtered out, empty → none, `all` → full suite).

## Testing

Workflow-only change; both files parse as YAML and pass editorconfig. It exercises for real on the next push to `main` (and can be dry-run via `workflow_dispatch` on `maintenance-build-debian`, which sends `mode=all`).