### PR TITLE
desktops/lxqt: drop resolute (panel.conf conffile conflict)

### DIFF
--- a/tools/modules/desktops/yaml/lxqt.yaml
+++ b/tools/modules/desktops/yaml/lxqt.yaml
@@ -115,10 +115,17 @@ releases:
       - pkexec
       - libu2f-udev
 
-  resolute:
-    # Ubuntu 26.04 LTS.
-    architectures: [arm64, amd64]
-    packages:
-      - polkitd
-      - pkexec
-      - libfido2-1
+  # resolute (Ubuntu 26.04 LTS) is intentionally omitted so it is reported
+  # unavailable for LXQt and never enters the build matrix. Its lxqt-panel
+  # (2.3.2-0ubuntu1) and lxqt-branding-debian (0.14.0.7, pulled in as a
+  # Recommends of lxqt-core) both ship /etc/xdg/lxqt/panel.conf with no
+  # Replaces/Conflicts, so dpkg aborts the unpack and lxqt-core can't install
+  # (upstream Ubuntu packaging bug, not ours). Re-add the block below once the
+  # archive resolves the conffile conflict - see tests/LXQT01.conf.
+  #resolute:
+  #  # Ubuntu 26.04 LTS.
+  #  architectures: [arm64, amd64]
+  #  packages:
+  #    - polkitd
+  #    - pkexec
+  #    - libfido2-1


### PR DESCRIPTION
### Symptom

The resolute LXQt rootfs builds fail in armbian/ci "Build All Artifacts"
([run 33248993102](https://github.com/armbian/ci/actions/runs/33248993102) —
`rootfs-amd64-resolute-lxqt-desktop-{minimal,mid,full}`).

### Cause

```
dpkg: error processing archive .../lxqt-panel_2.3.2-0ubuntu1_amd64.deb (--unpack):
 trying to overwrite '/etc/xdg/lxqt/panel.conf', which is also in package lxqt-branding-debian (0.14.0.7)
...
lxqt-core : Depends: lxqt-panel but it is not going to be installed
Error: lxqt package install failed
```

On resolute (Ubuntu 26.04), **`lxqt-panel` (2.3.2-0ubuntu1)** and
**`lxqt-branding-debian` (0.14.0.7** — pulled in as a *Recommends* of
`lxqt-core`) **both ship `/etc/xdg/lxqt/panel.conf`** with no
`Replaces`/`Conflicts`, so dpkg aborts the `lxqt-panel` unpack → `lxqt-core`'s
dependency is unmet → the build dies. It's an upstream Ubuntu packaging bug,
not ours (jammy/bookworm/noble/trixie are unaffected).

### Fix

A desktop is offered for a `(release, arch)` only when the release is a key in
the YAML's `releases:` block —
`parse_desktop_yaml.py`: `is_available = arch in supported_archs and release in releases`.
So the `resolute:` block alone was putting resolute-lxqt into the build matrix.
**Comment it out** — resolute now reports `DESKTOP_AVAILABLE="no"` for lxqt and
drops out of the matrix. This matches **`tests/LXQT01.conf`**, which already
excludes resolute for exactly this reason. Re-add the block once the archive
resolves the conffile conflict.

### Verified (parse_desktop_yaml.py)

```
lxqt resolute/amd64 -> no      lxqt resolute/arm64 -> no
lxqt trixie/{amd64,arm64} -> yes   lxqt noble/{amd64,arm64} -> yes
xfce resolute/amd64 -> yes     (only lxqt affected)
```

YAML still parses.