### PR TITLE
tests: cover ZFS install on trixie, noble and resolute

### DIFF
--- a/tests/zfs.conf
+++ b/tests/zfs.conf
@@ -1,0 +1,11 @@
+ENABLED=true
+RELEASE="trixie:noble:resolute"
+TESTARCH="arm64,amd64"
+TESTNAME="ZFS install"
+
+testcase() {(
+	./bin/armbian-config --api module_zfs remove
+	./bin/armbian-config --api module_zfs install
+	./bin/armbian-config --api module_zfs status
+	./bin/armbian-config --api module_zfs remove
+)}


### PR DESCRIPTION
`module_zfs` had no unit test. Adds `tests/zfs.conf` in the same shape as the other module tests (`unbound.conf` etc.): remove, install, status, remove.

```sh
ENABLED=true
RELEASE="trixie:noble:resolute"
TESTARCH="arm64,amd64"
TESTNAME="ZFS install"
```

`TESTARCH` follows the module's own declaration — `["module_zfs,arch"]="x86-64 arm64"` — so no armhf or riscv64.

## :warning: Heads-up before merging: this is likely to fail on noble and resolute

I ran the module in the actual test images (`ghcr.io/armbian/repository-update:<release>-amd64`) before opening this:

| Release | `module_zfs install` | Why |
|---|---|---|
| trixie | **rc=0** | no matching kernel headers available, so DKMS *skips* the build: `WARNING: No kernel headers were found, skipping module build` |
| noble | **rc=1** | headers *are* installable, so DKMS really builds — and the build fails |
| resolute | **rc=1** | same |

The noble failure in full:

```
Error! Bad return status for module build on kernel: 6.8.0-138-generic (x86_64)
dpkg: error processing package zfs-dkms (--configure):
 installed zfs-dkms package post-installation script subprocess returned error exit status 10
```

So on trixie the test passes for the wrong reason (nothing is compiled), and on noble/resolute it fails because zfs-dkms is built against the **container host's** kernel rather than an Armbian one.

That may be genuinely worth catching — or it may mean ZFS can't be meaningfully unit-tested in a container and the test should be trixie-only, or gated. Since CI will run it on this PR anyway, I've left all three releases in as requested; the result will show whether the CI runners' kernels behave the same as my local ones.

Related: `module_zfs kernel_max` returns `<not set>` inside the container, so the `ZFS001` menu condition (`linux-version compare "${KERNELID}" le "$(module_zfs kernel_max)"`) can't gate anything there either.