### PR TITLE
TUI: Help describes the tool, top-level leaf entries work, shorter Storage entry

### DIFF
--- a/tools/json/config.help.json
+++ b/tools/json/config.help.json
@@ -3,29 +3,12 @@
         {
             "id": "Help",
             "description": "About this tool",
-            "sub": [
-                {
-                    "id": "HLP001",
-                    "description": "Contribute",
-                    "command": [
-                        "show_message <<< $(about_armbian_configng)"
-                    ],
-                    "status": "Stable",
-                    "author": "@armbian",
-                    "help": "Contribute features and improvements to the armbian-config utility"
-                },
-                {
-                    "id": "HLP002",
-                    "description": "List of Config function(WIP)",
-                    "command": [
-                        "show_message <<< see_use"
-                    ],
-                    "status": "Disabled",
-                    "author": "@armbian",
-                    "help": "List of Config function(WIP)"
-                }
+            "help": "What armbian-config is, what each menu covers, and where to get help.",
+            "command": [
+                "show_message <<< $(about_armbian_configng)"
             ],
-            "help": "View information about this tool, documentation links, and guidance to help understand and manage system features."
+            "status": "Stable",
+            "author": "@armbian"
         }
     ]
 }

--- a/tools/json/config.system.json
+++ b/tools/json/config.system.json
@@ -1026,7 +1026,7 @@
                     "sub": [
                         {
                             "id": "STO001",
-                            "description": "Install the running system to internal media (eMMC/NVMe/SATA/USB/UFS, or Windows dual-boot)",
+                            "description": "Install the running system to internal media",
                             "short": "Install",
                             "module": "module_partitioner",
                             "command": [
@@ -1035,7 +1035,7 @@
                             "status": "Preview",
                             "author": "@igorpecovnik",
                             "condition": "",
-                            "help": "Clones your current live OS installation - Keeps your settings, configuration, installed."
+                            "help": "Clones the running OS to eMMC, NVMe, SATA, USB or UFS, keeping your settings, configuration and installed packages."
                         },
                         {
                             "id": "FLASH1",

--- a/tools/modules/functions/module_dialog_ui.sh
+++ b/tools/modules/functions/module_dialog_ui.sh
@@ -159,7 +159,17 @@ generate_top_menu() {
 		if [ $exitstatus = 0 ]; then
 			[ -z "$OPTION" ] && break
 			[[ -n "$debug" ]] && echo "$OPTION"
-			generate_menu "$OPTION"
+			# A top-level entry may be a leaf (no 'sub'), in which case it runs
+			# its command directly instead of opening an empty submenu. Same
+			# test generate_menu uses for its own children.
+			local submenu_count=$(jq -r --arg id "$OPTION" '.menu[] | .. | objects | select(.id==$id) | .sub? | length' "$json_file")
+			submenu_count=${submenu_count:-0}
+			[[ "$submenu_count" == "null" ]] && submenu_count=0
+			if [ "$submenu_count" -gt 0 ]; then
+				generate_menu "$OPTION"
+			else
+				execute_command "$OPTION"
+			fi
 		fi
 	done
 }
@@ -254,7 +264,7 @@ function execute_command() {
 		.about?' "$json_file")
 
 	# If a about exists, display it and wait for user confirmation
-	if [[ "$about" != "null" && $INPUTMODE != "cmd" ]]; then
+	if [[ -n "$about" && "$about" != "null" && $INPUTMODE != "cmd" ]]; then
 		get_user_continue "\n\n$about\n\nWould you like to continue?" process_input
 	fi
 

--- a/tools/modules/runtime/config.runtime.sh
+++ b/tools/modules/runtime/config.runtime.sh
@@ -84,6 +84,14 @@ else
 	update_submenu_data "Network" "N08" "IPV4"
 fi
 
+# Dual-booting alongside Windows is only possible on UEFI firmware, which is
+# also exactly what module_partitioner tests before offering the uefi-dualboot
+# mode. Mention it in the entry only where it can actually happen, rather than
+# advertising it on every board.
+if [ -d /sys/firmware/efi ]; then
+	update_sub_submenu_data "System" "Storage" "STO001" "Windows dual-boot"
+fi
+
 
 #
 # Sub sub menu updates

--- a/tools/modules/system/about_armbian_configng.sh
+++ b/tools/modules/system/about_armbian_configng.sh
@@ -10,20 +10,26 @@ module_options+=(
 #
 # @description Show general information about this tool
 #
+# Sized to fit an 80x24 terminal without scrolling: dialog msgbox is
+# auto-sized, and it clips rather than scrolls, so keep this at or under
+# 15 lines and 70 columns.
+#
 function about_armbian_configng() {
 
 	echo "Armbian Config: The Next Generation"
 	echo ""
-	echo "How to make this tool even better?"
+	echo "Configures an installed Armbian system: kernel and firmware, storage,"
+	echo "network, users and services, plus optional third-party software."
 	echo ""
-	echo "- propose new features or software titles"
-	echo "  https://github.com/armbian/configng/issues/new?template=feature-reqests.yml"
+	echo "  System         kernel, firmware, storage, users, services"
+	echo "  Network        wired, wireless, hotspot, DNS, addressing"
+	echo "  Localisation   locale, timezone, keyboard, hostname"
+	echo "  Software       install and remove curated applications"
 	echo ""
-	echo "- report bugs"
-	echo "  https://github.com/armbian/configng/issues/new?template=bug-reports.yml"
+	echo "Every entry is scriptable:  armbian-config --api <module> <command>"
 	echo ""
-	echo "- support developers with a small donation"
-	echo "  https://github.com/sponsors/armbian"
-	echo ""
+	echo "Docs    https://docs.armbian.com/armbian-config/"
+	echo "Issues  https://github.com/armbian/configng/issues"
+	echo "Donate  https://github.com/sponsors/armbian"
 
 }


### PR DESCRIPTION
Three TUI changes: Help now says what the tool is and shows it in one keystroke, top-level leaf entries work, and the Storage install entry fits on screen.

## 1. Help shows the tool description directly

Help opened a submenu containing a single entry, `HLP001 Contribute`, in an otherwise empty list — two keystrokes for one screen, and nothing anywhere saying what `armbian-config` actually is.

Help is now a leaf: no `sub`, command attached directly. Choosing it shows:

```
Armbian Config: The Next Generation

Configures an installed Armbian system: kernel and firmware, storage,
network, users and services, plus optional third-party software.

  System         kernel, firmware, storage, users, services
  Network        wired, wireless, hotspot, DNS, addressing
  Localisation   locale, timezone, keyboard, hostname
  Software       install and remove curated applications

Every entry is scriptable:  armbian-config --api <module> <command>

Docs    https://docs.armbian.com/armbian-config/
Issues  https://github.com/armbian/configng/issues
Donate  https://github.com/sponsors/armbian
```

The contribute links that were the whole of HLP001 are kept, as two lines instead of a screen.

Sized to fit 80x24 without scrolling, which matters: `show_message` calls `dialog_msgbox` with height and width `0` — auto-size — and dialog **clips rather than scrolls**. This is 15 lines and 69 columns, so 22x75 with box chrome. The text it replaces ran to 77 columns, already too wide for an 80-column terminal.

## 2. Top-level menu entries can be leaves

Making Help a leaf exposed a gap: `generate_top_menu` called `generate_menu` unconditionally. Only the nested dispatcher inside `generate_menu` tested `.sub? | length` and fell through to `execute_command`. A top-level entry without `sub` therefore opened an *empty* submenu. `generate_top_menu` now runs the same test.

That empty submenu also surfaced an older bug worth fixing on its own. For an id matching nothing,

```
jq '.menu[] | .. | objects | select(.id == $id) | .about?'
```

prints **nothing at all**, not the string `"null"`. The guard only compared against `"null"`, so an empty result passed it and raised a confirmation dialog with an empty body — a `Warning / Would you like to continue?` box containing no text. The guard now also requires the value to be non-empty, so any id lookup miss stays silent.

## 3. Storage install entry: shorter, and honest about Windows

It read, at 91 characters:

> Install the running system to internal media (eMMC/NVMe/SATA/USB/UFS, or Windows dual-boot)

which the menu truncated mid-word, and it advertised Windows dual-boot on every board including those that can never do it.

| | |
|---|---|
| non-UEFI | `Install the running system to internal media` (44) |
| UEFI | `Install the running system to internal media (Windows dual-boot)` (64) |

The Windows part is appended at runtime only when `/sys/firmware/efi` exists — the same test `module_partitioner` already applies before offering its `uefi-dualboot` mode, so the entry promises dual-boot exactly where the installer can deliver it. It is the firmware directory rather than the architecture, so it covers every UEFI image, not only x86.

The media list moves to the help line at the bottom of the menu, where there is room:

> Clones the running OS to eMMC, NVMe, SATA, USB or UFS, keeping your settings, configuration and installed packages.

## Verification

- dispatch checked against the generated menu: System/Network/Localisation/Software report 6/4/4/16 children and open submenus; Help reports 0 and runs its command; an unknown id no longer trips the confirmation prompt
- both Storage branches exercised — UEFI on a UEFI host, non-UEFI by running the runtime with the firmware path redirected so the guard evaluates false
- `bash -n` on every touched module, JSON parses, `tools/config-assemble.sh -p` runs clean

Only sources are committed; `/lib/` and `/docs/` are gitignored build output.
