### PR TITLE
docs: update networking & FAQ links to the new lowercase docs paths

### DIFF
--- a/tools/include/markdown/BNS001-footer.md
+++ b/tools/include/markdown/BNS001-footer.md
@@ -30,4 +30,4 @@ Choose between:
 - The system will apply the configurations.
 - Your network connection should then be fully established.
 
-If you experience issues or prefer full control, follow the [manual networking setup guide](https://docs.armbian.com/User-Guide_Networking/).
+If you experience issues or prefer full control, follow the [manual networking setup guide](https://docs.armbian.com/user-guide/networking/).

--- a/tools/include/markdown/STD001-footer.md
+++ b/tools/include/markdown/STD001-footer.md
@@ -3,7 +3,7 @@ Best Practices
 1. **Back up your data** (system and configuration).  
 2. **Test on a spare device or SD card** before upgrading production systems.  
 3. **Read the official release notes** of your target distribution:  
-- [Armbian FAQ: Can I upgrade my userspace flavor?](/User-Guide_FAQ/#can-i-upgrade-my-userspace-flavor-like-bullseye-to-bookworm-or-jammy-to-noble)  
+- [Armbian FAQ: Can I upgrade my userspace flavor?](/user-guide/faq/#can-i-upgrade-my-userspace-flavor-like-bookworm-trixie-or-jammy-noble)  
 - [Debian upgrade notes](https://www.debian.org/releases/trixie/release-notes/upgrading.en.html)  
 - [Ubuntu release upgrade guide](https://documentation.ubuntu.com/server/how-to/software/upgrade-your-release/)  
 4. **Ensure you have console access** (serial, HDMI + keyboard, SSH).  


### PR DESCRIPTION
The documentation site renamed pages to lowercase, dashed paths (e.g. `User-Guide_Networking` → `user-guide/networking`). configng still emitted the old-style links, so the generated `docs/config/*.md` in armbian/documentation drifted and the `Automatic documentation update` PR ([documentation#1193](https://github.com/armbian/documentation/pull/1193)) kept trying to revert the docs to the stale URLs.

Fix the two footer includes to match the current docs:

| page | before | after |
|---|---|---|
| Network (BNS001) | `docs.armbian.com/User-Guide_Networking/` | `docs.armbian.com/user-guide/networking/` |
| Updates (STD001) | `/User-Guide_FAQ/#…bullseye-to-bookworm…` | `/user-guide/faq/#…bookworm-trixie…` |

The Updates anchor also now matches the FAQ heading's current slug. The **Storage** page in [documentation#1193](https://github.com/armbian/documentation/pull/1193) needs no change here — `config.jobs.json` already carries the long "(eMMC/NVMe/SATA/USB/UFS, or Windows dual-boot)" description; that diff was just generated from an older snapshot.

Once merged, the next `pull-from-armbian-config` regen produces the correct links, so documentation#1193 can be closed (superseded) rather than merged.

---
Heads-up (out of scope here): `tools/modules/system/module_memory.sh` still points `["module_memory,doc_link"]` at `docs.armbian.com/User-Guide_Fine-Tuning/`, which no longer exists as a page. Happy to fix that in a follow-up once we settle its correct target.