### PR TITLE
Draw dialog borders with Unicode box characters

### DIFF
--- a/bin/armbian-config
+++ b/bin/armbian-config
@@ -46,7 +46,7 @@ _parse_debug_flag() {
 _parse_debug_flag "$@"
 set -- "${_debug_argv[@]}"
 
-[[ $EUID != 0 ]] && exec sudo --preserve-env=DEBUG,DEBUG_LOG "$0" "$@"
+[[ $EUID != 0 ]] && exec sudo --preserve-env=DEBUG,DEBUG_LOG,NCURSES_NO_UTF8_ACS "$0" "$@"
 #
 # Get the script directory
 script_dir="$(dirname "$0")"

--- a/tools/modules/functions/module_env_init.sh
+++ b/tools/modules/functions/module_env_init.sh
@@ -24,6 +24,11 @@ function set_runtime_variables() {
 		fi
 	fi
 
+	# Draw dialog borders with Unicode box characters rather than the VT100 alternate charset:
+	# PuTTY and other emulators that report TERM=xterm but ignore that charset switch in UTF-8 mode show letters.
+	# A pre-set value wins, so a genuine non-UTF-8 terminal can opt out with NCURSES_NO_UTF8_ACS=0.
+	export NCURSES_NO_UTF8_ACS="${NCURSES_NO_UTF8_ACS:-1}"
+
 	# Check if udevadm is available
 	if ! [[ -x "$(command -v udevadm)" ]]; then
 		missing_dependencies+=("udev")


### PR DESCRIPTION
# Description

dialog (ncurses) draws its borders via the VT100 alternate charset (`ESC(0` + letters). Terminals that report `TERM=xterm` but ignore that switch in UTF-8 mode show the borders as letters. `NCURSES_NO_UTF8_ACS=1` makes ncurses emit U+2500 box-drawing characters directly; outside UTF-8 locales ncurses ignores the variable.

Same fix for the build framework: armbian/build#10660.

# Implementation Details

- One `export NCURSES_NO_UTF8_ACS=1` next to the `DIALOG` selection in `set_runtime_variables`.
- whiptail (newt) already writes Unicode on its own and is unaffected.
- A pre-set value wins (`${NCURSES_NO_UTF8_ACS:-1}`): a genuine non-UTF-8 terminal opts out with `NCURSES_NO_UTF8_ACS=0`, since `bin/armbian-config` forces `LC_ALL=C.UTF-8` and the locale check in ncurses cannot help there.
- `bin/armbian-config` preserves the variable across its sudo re-exec, so the opt-out works for non-root users too.
- No new external dependencies.

# Documentation Summary

No metadata or generated documentation affected.

# Testing Procedure

Expected to fix: PuTTY with default settings (UTF-8 + TERM=xterm, "Enable VT100 line drawing even in UTF-8 mode" off), mosh, Chrome Secure Shell (hterm). Basis: their terminfo entries carry `U8#1` in ncurses terminfo.src.

Expected no change: xterm, GNOME Terminal and other VTE terminals, Konsole, kitty, Alacritty, WezTerm, foot, iTerm2, macOS Terminal.app, Windows Terminal, tmux, Linux console, GNU screen. Non-UTF-8 locales: unchanged.

- Armbian (ncurses 6.4) over ssh: the main menu goes from `ESC(0` + letters to U+2500 borders.
- Serial console (helios64, ttyS2): serial-getty sets `TERM=linux`, whose terminfo carries `U8#1`, so the borders were already Unicode there; with the variable the bytes on the wire are the same. No change.

Before / after (PuTTY behaviour emulated by dropping `ESC(0`/`ESC(B` from the output stream):

| before | after |
|---|---|
| ![before](https://github.com/user-attachments/assets/ddb4c48b-83fc-471f-979d-caccfc5e250f) | ![after](https://github.com/user-attachments/assets/3034ad07-8980-4028-a199-75b858a3c8c5) |

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
