### PR TITLE
install engine: read the partition table without opening the disk for writing

### DIFF
--- a/tests/bats/integration_dualboot.bats
+++ b/tests/bats/integration_dualboot.bats
@@ -72,9 +72,8 @@ teardown() {
 		echo "# parted: $(parted -sm "$LOOP" print 2>&1 | tr '\n' '|')" >&3
 		echo "# blkid: p1=[$(blkid "${LOOP}p1" 2>&1)] p2=[$(blkid "${LOOP}p2" 2>&1)]" >&3
 		# Reproduce the function's auto-detect steps under the SAME pipefail so the
-		# log shows exactly where it bails (parted-gpt check vs. the lsblk parse).
-		parted -sm "$LOOP" print 2>/dev/null | grep -q '^/dev/.*:gpt:'
-		echo "# diag: parted|grep-q rc=$?" >&3
+		# log shows exactly where it bails (label-type check vs. the lsblk parse).
+		echo "# diag: lsblk PTTYPE=[$(lsblk -ndo PTTYPE "$LOOP" 2>/dev/null)]" >&3
 		local _j; _j="$(lsblk -b -po NAME,FSTYPE,PARTTYPENAME,SIZE --json "$LOOP" 2>/dev/null)"
 		echo "# diag: parts=[$(_install_windows_parts "$_j" | tr '\n' ' ')]" >&3
 	fi

--- a/tests/bats/integration_loopback.bats
+++ b/tests/bats/integration_loopback.bats
@@ -5,7 +5,7 @@
 # need root + losetup, so they run under sudo in CI and skip locally otherwise.
 #
 # They exercise the exact chain the installer uses, minus the rootfs rsync and
-# bootloader write, and assert with parted/blkid/lsblk that the on-disk result
+# bootloader write, and assert with sfdisk/blkid/lsblk that the on-disk result
 # matches the plan - proving the GPT/MBR/flag/blocksize fixes end to end.
 
 setup() {
@@ -16,6 +16,7 @@ setup() {
 	if [[ "$(id -u)" -ne 0 ]]; then skip "needs root for losetup"; fi
 	command -v losetup >/dev/null || skip "losetup not available"
 	command -v parted  >/dev/null || skip "parted not available"
+	command -v sfdisk  >/dev/null || skip "sfdisk not available"
 
 	IMG="$BATS_TEST_TMPDIR/disk.img"
 	truncate -s 8G "$IMG"
@@ -26,14 +27,18 @@ teardown() {
 	[[ -n "${LOOP:-}" ]] && losetup -d "$LOOP" 2>/dev/null || true
 }
 
+# Partition-table assertions read `sfdisk -d`, which opens the disk read-only.
+# parted opens it read-write even for `print`, and closing that handle makes udev
+# re-probe the disk; `[ -b ]` node checks right after a parted call flaked on that.
+_ptable() { sfdisk -d "$LOOP" 2>/dev/null; }
+
 @test "loopback: uefi plan yields GPT with an ESP-flagged first partition" {
 	local plan; plan="$(install_plan_layout uefi ext4 1 $((8*1024*1024*1024)) 512 0)"
 	run install_apply_partitions "$LOOP" "$plan"
 	[ "$status" -eq 0 ]
-	# parted reports the label type and the esp flag (force C locale - parted
-	# translates flag names, e.g. "boot" -> "zagon" under a Slovenian locale).
-	LC_ALL=C parted -sm "$LOOP" print | grep -q '^/dev/.*:gpt:'
-	LC_ALL=C parted -sm "$LOOP" print | head -3 | grep -q 'esp'
+	# Label type and the ESP partition type GUID, straight from the on-disk table.
+	_ptable | grep -q '^label: gpt'
+	_ptable | grep -q "^${LOOP}p1 : .*type=C12A7328-F81F-11D2-BA4B-00A0C93EC93B"
 	# Two partition nodes exist.
 	[ -b "${LOOP}p1" ]
 	[ -b "${LOOP}p2" ]
@@ -109,13 +114,13 @@ teardown() {
 	local plan; plan="$(install_plan_layout emmc ext4 0 $((8*1024*1024*1024)) 512 0)"
 	run install_apply_partitions "$LOOP" "$plan"
 	[ "$status" -eq 0 ]
-	LC_ALL=C parted -sm "$LOOP" print | grep -q '^/dev/.*:msdos:'
-	LC_ALL=C parted -sm "$LOOP" print | grep -q 'boot'
+	_ptable | grep -q '^label: dos'
+	_ptable | grep -q "^${LOOP}p1 : .*bootable"
 	[ -b "${LOOP}p1" ]
 	[ ! -b "${LOOP}p2" ]
-	# p1 must start at 16MiB so it clears the on-device u-boot region
+	# p1 must start at 16MiB (sector 32768) so it clears the on-device u-boot region
 	# (idbloader@32KiB + u-boot.itb@8MiB); starting at 1MiB corrupts boot.
-	LC_ALL=C parted -sm "$LOOP" unit MiB print | grep -qE '^1:16\.0MiB:'
+	_ptable | grep -qE "^${LOOP}p1 : start= *32768,"
 }
 
 @test "loopback: emmc-boot plan yields /boot + /emmc_storage, p1 at 16MiB" {
@@ -126,8 +131,9 @@ teardown() {
 	[[ "$output" == *"storage ${LOOP}p2"* ]]
 	[ -b "${LOOP}p1" ]
 	[ -b "${LOOP}p2" ]
-	# boot partition clears the u-boot region and is ~512MiB; storage fills the rest
-	LC_ALL=C parted -sm "$LOOP" unit MiB print | grep -qE '^1:16\.0MiB:528'
+	# boot partition clears the u-boot region (starts at sector 32768 = 16MiB) and is
+	# 512MiB (1048576 sectors); storage fills the rest
+	_ptable | grep -qE "^${LOOP}p1 : start= *32768, size= *1048576,"
 }
 
 @test "loopback: apply_partitions echoes role->device for each partition" {
@@ -159,8 +165,8 @@ root ${LOOP}p2 ext4"
 	local plan; plan="$(install_plan_layout bios ext4 0 $((8*1024*1024*1024)) 512 0)"
 	run install_apply_partitions "$LOOP" "$plan"
 	[ "$status" -eq 0 ]
-	LC_ALL=C parted -sm "$LOOP" print | grep -q '^/dev/.*:msdos:'
-	LC_ALL=C parted -sm "$LOOP" print | grep -q 'boot'
+	_ptable | grep -q '^label: dos'
+	_ptable | grep -q "^${LOOP}p1 : .*bootable"
 	[ -b "${LOOP}p1" ]
 	[ ! -b "${LOOP}p2" ]
 }
@@ -171,7 +177,7 @@ root ${LOOP}p2 ext4"
 	[[ "$plan" == *"table=gpt"* ]]
 	run install_apply_partitions "$LOOP" "$plan"
 	[ "$status" -eq 0 ]
-	LC_ALL=C parted -sm "$LOOP" print | grep -q 'bios_grub'
+	_ptable | grep -q "^${LOOP}p1 : .*type=21686148-6449-6E6F-744E-656564454649"
 	[[ "$output" == *"biosboot ${LOOP}p1"* ]]
 	[[ "$output" == *"root ${LOOP}p2"* ]]
 }
@@ -183,5 +189,5 @@ root ${LOOP}p2 ext4"
 	[[ "$plan" == *"table=gpt"* ]]
 	run install_apply_partitions "$LOOP" "$plan"
 	[ "$status" -eq 0 ]
-	LC_ALL=C parted -sm "$LOOP" print | grep -q '^/dev/.*:gpt:'
+	_ptable | grep -q '^label: gpt'
 }

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -796,14 +796,12 @@ install_detect_windows() {
 	local disk="$1" json="${2:-}"
 	if [[ -z "$json" ]]; then
 		[[ -b "$disk" ]] || return "$INSTALL_EX_NODEV"
-		# GPT is required for a UEFI Windows install. Capture parted's output and
-		# grep it separately rather than `parted | grep -q`: under `set -o pipefail`
-		# (which strict callers, and the bats suite, set) `grep -q` can exit on the
-		# first match while parted is still writing, leaving parted killed by
-		# SIGPIPE (141) and the pipeline failing on an otherwise valid GPT disk.
-		local ptbl
-		ptbl="$(parted -sm "$disk" print 2>/dev/null)" || true
-		grep -q '^/dev/.*:gpt:' <<<"$ptbl" || return "$INSTALL_EX_NODEV"
+		# GPT is required for a UEFI Windows install. Read the label type with lsblk,
+		# which opens the disk read-only. parted opens it read-write even for `print`,
+		# and closing a write handle fires udev's watch rule: the partitions get
+		# re-probed, and the lsblk below sees empty FSTYPE/PARTTYPENAME while that
+		# runs, so a valid Windows disk is refused.
+		[[ "$(lsblk -ndo PTTYPE "$disk" 2>/dev/null)" == "gpt" ]] || return "$INSTALL_EX_NODEV"
 		json="$(lsblk -b -po NAME,FSTYPE,PARTTYPENAME,SIZE --json "$disk" 2>/dev/null)"
 	fi
 


### PR DESCRIPTION
# Description

parted opens the disk read-write even for `print`. Closing that handle fires udev's watch rule (`60-block.rules`), udev re-probes the disk and its partitions, and anything that reads lsblk or checks partition nodes in that window sees empty FSTYPE/PARTTYPENAME or a missing node.

`install_detect_windows` did exactly that (`parted print` for the label type, then lsblk), so a valid Windows/UEFI disk was refused now and then: CI "dualboot: detect_windows finds the ESP and the NTFS volume" failed in 4 of the last 5 runs of the bats workflow. The loopback bats asserted on `parted print` followed by `[ -b ]` node checks and flaked the same way ("uefi plan", "emmc ext4 plan").

# Implementation Details

- `install_detect_windows`: label type via `lsblk -ndo PTTYPE` (read-only), as `install_source_table_type` already does.
- `integration_loopback.bats`: assertions via `sfdisk -d` (opens read-only): label, ESP / bios_grub type GUIDs, `bootable`, start and size in sectors. Skips without sfdisk.
- `integration_dualboot.bats`: the failure diagnostics mirror the new check.
- No new external dependencies (sfdisk is util-linux).

# Documentation Summary

No metadata or generated documentation affected.

# Testing Procedure

Armbian 7.2, bats 1.14, both suites under root on loop devices:

| suite | before | after |
|---|---|---|
| detect_windows alone | 3 of 6 runs failed | 0 of 10 |
| loopback + dualboot | 2 of 6 runs failed | 0 of 8 |

`strace`: `parted -sm print` opens the disk `O_RDWR`; `sfdisk -d` and `lsblk` open `O_RDONLY` and produce no udev events (`udevadm monitor`).

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ensured that my changes do not introduce new warnings or errors
- [x] No new external dependencies are included
- [x] Changes have been tested and verified
