### PR TITLE
desktops/xmonad: run the session under GNOME Flashback, add autostart

### DIFF
--- a/tools/modules/desktops/postinst/xmonad.sh
+++ b/tools/modules/desktops/postinst/xmonad.sh
@@ -6,6 +6,31 @@ if [ -d /etc/armbian/lightdm ]; then cp -R /etc/armbian/lightdm /etc/; fi
 # Disable Pulseaudio timer scheduling which does not work with sndhdmi driver
 if [ -f /etc/pulse/default.pa ]; then sed "s/load-module module-udev-detect$/& tsched=0/g" -i  /etc/pulse/default.pa; fi
 
-# set wallpapper to armbian
-
-
+# xmonad has no session autostart of its own, so the wallpaper, the status
+# bar and the tray helpers are started from ~/.xprofile, which both the plain
+# and the GNOME Flashback session read.
+#
+# Written from here rather than shipped in desktops/skel/: that directory is
+# copied into /etc/skel wholesale for whichever desktop is installing
+# (module_desktop_branding.sh), so a .xprofile placed there would start xmobar
+# and friends under XFCE, GNOME and KDE too. The guard below is the second
+# half of that -- it keeps the commands inert if some other desktop is
+# installed alongside xmonad and inherits this file anyway.
+#
+# DESKTOP_SESSION is the .desktop basename: 'xmonad' or
+# 'gnome-flashback-xmonad'. Matching on it rather than XDG_CURRENT_DESKTOP,
+# which the flashback session sets to GNOME-Flashback:GNOME and so cannot be
+# told apart from gnome-flashback-metacity.
+mkdir -p /etc/skel
+cat > /etc/skel/.xprofile <<- 'XPROFILEEOF'
+	#!/bin/sh
+	case "${DESKTOP_SESSION:-}" in
+	*xmonad*)
+		[ -x /usr/bin/feh ] && feh --bg-scale /usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-3840x2160.jpg &
+		[ -x /usr/bin/xmobar ] && xmobar &
+		[ -x /usr/bin/nm-applet ] && nm-applet &
+		[ -x /usr/bin/dunst ] && dunst &
+		;;
+	esac
+XPROFILEEOF
+chmod 644 /etc/skel/.xprofile

--- a/tools/modules/desktops/yaml/xmonad.yaml
+++ b/tools/modules/desktops/yaml/xmonad.yaml
@@ -13,6 +13,18 @@ tiers:
       - xserver-xorg
       - xterm
       - dbus-x11
+      # The xmonad package ships two sessions: xmonad.desktop, which runs
+      # the window manager bare, and gnome-flashback-xmonad.desktop, which
+      # runs it inside a GNOME Flashback session. Only the second gets a
+      # session dbus, polkit agent and session management, and it needs
+      # gnome-session-flashback present to start at all.
+      - gnome-session-flashback
+      # startx / xinit, for starting a session without the display manager
+      - xinit
+      # X has no cursor theme of its own, so without one the pointer falls
+      # back to the black X and stays that way outside GTK windows
+      - dmz-cursor-theme
+      - fonts-ubuntu
       - dmenu
       - dunst
       - feh


### PR DESCRIPTION
Redo of #809 against the current desktop layout. That PR could not be rebased — all three files it changed were moved and rewritten by the YAML rework, which is why it sits at `CONFLICTING`:

| #809 touched | now |
|---|---|
| `include/branding/postinst/xmonad.sh` | `modules/desktops/postinst/xmonad.sh` |
| `include/branding/skel/.xprofile` | (see below — deliberately not in skel) |
| `modules/system/module_desktop_packages.sh` | `modules/desktops/yaml/xmonad.yaml` |

## Session

The **xmonad package itself** ships two sessions — verified from the .deb:

```
/usr/share/xsessions/xmonad.desktop                  Exec=xmonad-session
/usr/share/xsessions/gnome-flashback-xmonad.desktop  Exec=gnome-flashback-xmonad
                                                     TryExec=gnome-flashback
```

The flashback one is what gets a session dbus, polkit agent and session management, but its `TryExec` is `gnome-flashback`, which was not installed — so it could never start. Adding `gnome-session-flashback` is what makes that session usable. (`gnome-session-flashback` itself ships only `gnome-flashback-metacity.desktop`.)

Also added: `xinit`, `dmz-cursor-theme` (without a cursor theme the pointer stays the black X outside GTK windows), `fonts-ubuntu`.

**`xterm` stays.** #809 replaced it with `xinit`, but no xmonad config is shipped in this repo, so the stock keybinding still launches `xterm` — dropping it leaves Mod+Shift+Enter dead. `terminator` from `common.yaml` does not change that.

## Autostart, without leaking into other desktops

`.xprofile` is written by the **postinst**, not shipped in `desktops/skel/`. That directory is copied wholesale into `/etc/skel` for whichever desktop is installing (`module_desktop_branding.sh:48`), so a `.xprofile` there would start `xmobar`, `nm-applet` and `dunst` under XFCE, GNOME and KDE too — the concern raised on #809. Writing it from the xmonad postinst scopes it to xmonad installs.

The file also guards on `DESKTOP_SESSION`, for the case where another desktop is installed alongside xmonad and inherits it anyway. Matching on `DESKTOP_SESSION` rather than `XDG_CURRENT_DESKTOP`, because the flashback session sets the latter to `GNOME-Flashback:GNOME` and so cannot be told apart from `gnome-flashback-metacity`:

| `DESKTOP_SESSION` | |
|---|---|
| `xmonad` | runs |
| `gnome-flashback-xmonad` | runs |
| `gnome-flashback-metacity` | inert |
| `xfce` / `gnome` / unset | inert |

## Dropped from #809: the NetworkManager change

`unmanaged-devices=type:ethernet` is **not** carried over. `_module_desktops_configure_networking` already flips netplan to the NetworkManager renderer for *every* device on desktop install, and its own comment warns that leaving two backends in place makes them "race to claim each interface at boot". Telling NM to additionally ignore ethernet would leave it claimed by neither.

## :warning: Follow-up needed in armbian/build

Autologin still selects the **bare** session, so the flashback session added here will not be picked automatically. `armbian-firstlogin` (in `armbian/build`, not this repo) does:

```bash
[[ -x $(command -v xmonad) ]] && sed -i "s/user-session.*/user-session=xmonad/" ...
```

`xmonad.desktop` does still exist, so nothing breaks — it just keeps landing in the session without dbus/polkit. Making the flashback session the default needs `user-session=gnome-flashback-xmonad` there, with a fallback when that .desktop is absent. Separate repo, separate PR; happy to open it.

## Verification

- All four packages exist across xmonad's **full declared matrix** — 7 releases × up to 5 arches, 28 combinations including `armhf`, `riscv64`, `loong64` — checked with the repo's own `audit.py`. No gaps.
- `fonts-ubuntu` is correctly dropped on Debian releases by the existing `common.yaml` per-arch `packages_remove`, same as xfce/mate/kde. No new override needed.
- `parse_desktop_yaml.py` resolves the tier rc=0 on trixie/noble/resolute × arm64/riscv64.
- Session guard exercised against all six `DESKTOP_SESSION` values in the table above.
- `bash -n` and `shellcheck -s bash -S warning` clean on the postinst; YAML parses, no duplicates.

Closes #809 once merged.