### PR TITLE
armbian-install: sd mode on RPi-style boards, + native (full USB/NVMe boot)

### DIFF
--- a/tests/bats/bootconfig.bats
+++ b/tests/bats/bootconfig.bats
@@ -189,10 +189,45 @@ setup() {
 	unset -f write_uboot_platform
 }
 
-@test "bootloader available: native needs no capability at all (writes no bootloader)" {
+@test "bootloader available: native needs Raspberry Pi-style firmware" {
+	# native writes a plain FAT32 boot partition only the board's own firmware
+	# reads; on anything else the target would never boot, so it must report
+	# unavailable unless install_rpi_style_boot detects raspi firmware.
 	unset -f write_uboot_platform 2>/dev/null || true
+	d="$TMP/fw-none"; mkdir -p "$d"
+	install_boot_firmware_dir() { echo "$d"; }
+	run install_bootloader_available native
+	[ "$status" -ne 0 ]
+	: >"$d/config.txt"; : >"$d/cmdline.txt"
 	run install_bootloader_available native
 	[ "$status" -eq 0 ]
+}
+
+# --- sd capability (current boot config must be rewirable) ---------------------
+
+@test "sd capable: true with a u-boot armbianEnv.txt, no raspi firmware" {
+	d="$TMP/fw-none"; mkdir -p "$d"
+	install_boot_firmware_dir() { echo "$d"; }
+	envf="$TMP/armbianEnv.txt"; : >"$envf"
+	install_sd_env_file() { echo "$envf"; }
+	run install_sd_capable
+	[ "$status" -eq 0 ]
+}
+
+@test "sd capable: true with Raspberry Pi-style firmware, no armbianEnv.txt" {
+	d="$TMP/fw"; mkdir -p "$d"; : >"$d/config.txt"; : >"$d/cmdline.txt"
+	install_boot_firmware_dir() { echo "$d"; }
+	install_sd_env_file() { echo "$TMP/no-such-armbianEnv.txt"; }
+	run install_sd_capable
+	[ "$status" -eq 0 ]
+}
+
+@test "sd capable: false when neither boot config exists (bare firmware)" {
+	d="$TMP/fw-none2"; mkdir -p "$d"
+	install_boot_firmware_dir() { echo "$d"; }
+	install_sd_env_file() { echo "$TMP/no-such-armbianEnv.txt"; }
+	run install_sd_capable
+	[ "$status" -ne 0 ]
 }
 
 @test "fs tools: ext4 always available; missing fs reports its package" {

--- a/tests/bats/bootconfig.bats
+++ b/tests/bats/bootconfig.bats
@@ -358,6 +358,36 @@ setup() {
 	! grep -q 'armbi_root' "$f"
 }
 
+@test "rewrite rpi cmdline: given a fs, also replaces a stale rootfstype=" {
+	# initramfs-tools mounts root with `mount -t "$ROOTFSTYPE"` whenever
+	# rootfstype= is set to anything but empty/auto - a stale rootfstype=ext4
+	# on a btrfs/f2fs root fails that mount with "Invalid argument" even once
+	# root= is correct and the module is present in the initrd (build report).
+	f="$TMP/cmdline.txt"
+	printf 'console=serial0,115200 root=LABEL=armbi_root rootfstype=ext4 rootwait\n' >"$f"
+	run install_rewrite_rpi_cmdline "$f" "UUID=1234-5678" btrfs
+	[ "$status" -eq 0 ]
+	grep -q 'root=UUID=1234-5678' "$f"
+	grep -q 'rootfstype=btrfs' "$f"
+	! grep -q 'rootfstype=ext4' "$f"
+}
+
+@test "rewrite rpi cmdline: given a fs, appends rootfstype= when absent" {
+	f="$TMP/cmdline.txt"
+	printf 'console=serial0,115200 root=LABEL=armbi_root rootwait\n' >"$f"
+	run install_rewrite_rpi_cmdline "$f" "UUID=1234-5678" f2fs
+	[ "$status" -eq 0 ]
+	grep -q 'rootfstype=f2fs' "$f"
+}
+
+@test "rewrite rpi cmdline: no fs argument leaves rootfstype= untouched" {
+	f="$TMP/cmdline.txt"
+	printf 'console=serial0,115200 root=LABEL=armbi_root rootfstype=ext4 rootwait\n' >"$f"
+	run install_rewrite_rpi_cmdline "$f" "UUID=1234-5678"
+	[ "$status" -eq 0 ]
+	grep -q 'rootfstype=ext4' "$f"
+}
+
 @test "rewrite rpi cmdline: missing file returns bootcfg error" {
 	run install_rewrite_rpi_cmdline "$TMP/nope-cmdline.txt" "UUID=x"
 	[ "$status" -eq 71 ]

--- a/tests/bats/bootconfig.bats
+++ b/tests/bats/bootconfig.bats
@@ -164,19 +164,27 @@ setup() {
 
 # --- bootloader capability pre-flight ----------------------------------------
 
-@test "bootloader available: u-boot modes need write_uboot_platform (x86 has none)" {
-	# No write_uboot_platform defined -> u-boot modes must report unavailable, so
-	# the installer refuses before wiping (the code-72-after-wipe scenario).
+@test "bootloader available: emmc needs write_uboot_platform (x86 has none)" {
+	# No write_uboot_platform defined -> emmc must report unavailable, so the
+	# installer refuses before wiping (the code-72-after-wipe scenario).
 	unset -f write_uboot_platform 2>/dev/null || true
-	run install_bootloader_available sd
-	[ "$status" -ne 0 ]
 	run install_bootloader_available emmc
 	[ "$status" -ne 0 ]
 }
 
-@test "bootloader available: u-boot modes ok once the hook exists" {
-	write_uboot_platform() { :; }
+@test "bootloader available: sd needs no capability - it never writes a bootloader" {
+	# sd mode only moves root and leaves the current boot media untouched
+	# (install_run_scenario skips install_write_bootloader for it), so unlike
+	# emmc it must be available even with no write_uboot_platform hook at all -
+	# that is what makes it usable on Raspberry Pi (no u-boot whatsoever).
+	unset -f write_uboot_platform 2>/dev/null || true
 	run install_bootloader_available sd
+	[ "$status" -eq 0 ]
+}
+
+@test "bootloader available: emmc ok once the write_uboot_platform hook exists" {
+	write_uboot_platform() { :; }
+	run install_bootloader_available emmc
 	[ "$status" -eq 0 ]
 	unset -f write_uboot_platform
 }

--- a/tests/bats/bootconfig.bats
+++ b/tests/bats/bootconfig.bats
@@ -116,6 +116,20 @@ setup() {
 	[ "$status" -eq 0 ]
 }
 
+@test "verify boot dir: nested firmware/config.txt+cmdline.txt counts (native mode)" {
+	d="$TMP/boot"; mkdir -p "$d/firmware"
+	: >"$d/vmlinuz-test"; : >"$d/firmware/config.txt"; : >"$d/firmware/cmdline.txt"
+	run install_verify_boot_dir "$d"
+	[ "$status" -eq 0 ]
+}
+
+@test "verify boot dir: firmware/ with only one of the two files does not count" {
+	d="$TMP/boot"; mkdir -p "$d/firmware"
+	: >"$d/vmlinuz-test"; : >"$d/firmware/config.txt"
+	run install_verify_boot_dir "$d"
+	[ "$status" -eq 73 ]
+}
+
 # --- populate /boot (synced separately from the main rootfs rsync) -----------
 
 @test "populate_boot: copies the kernel into the target /boot and verifies" {
@@ -165,6 +179,12 @@ setup() {
 	run install_bootloader_available sd
 	[ "$status" -eq 0 ]
 	unset -f write_uboot_platform
+}
+
+@test "bootloader available: native needs no capability at all (writes no bootloader)" {
+	unset -f write_uboot_platform 2>/dev/null || true
+	run install_bootloader_available native
+	[ "$status" -eq 0 ]
 }
 
 @test "fs tools: ext4 always available; missing fs reports its package" {
@@ -241,4 +261,53 @@ setup() {
 	grep -qE '^UUID=rootpart	/media/boot-media	ext4	defaults,nofail' "$f"
 	grep -qE '^/media/boot-media/boot	/boot	none	bind,nofail' "$f"
 	[ -d "$mp/media/boot-media" ]
+}
+
+# --- Raspberry Pi-style boot (native firmware, static cmdline.txt) -----------
+
+@test "boot firmware dir: separately-mounted /boot/firmware wins" {
+	findmnt() { [ "$3" = /boot/firmware ]; }
+	[ "$(install_boot_firmware_dir)" = /boot/firmware ]
+}
+
+@test "boot firmware dir: falls back to /boot when not separately mounted" {
+	findmnt() { return 1; }
+	[ "$(install_boot_firmware_dir)" = /boot ]
+}
+
+@test "rpi style boot: true when config.txt + cmdline.txt are both present" {
+	d="$TMP/fw"; mkdir -p "$d"; : >"$d/config.txt"; : >"$d/cmdline.txt"
+	install_boot_firmware_dir() { echo "$d"; }
+	run install_rpi_style_boot
+	[ "$status" -eq 0 ]
+}
+
+@test "rpi style boot: false when only one of the two files exists (u-boot board)" {
+	d="$TMP/fw"; mkdir -p "$d"; : >"$d/config.txt"
+	install_boot_firmware_dir() { echo "$d"; }
+	run install_rpi_style_boot
+	[ "$status" -ne 0 ]
+}
+
+@test "rewrite rpi cmdline: replaces root= (LABEL/UUID/PARTUUID), leaves the rest" {
+	f="$TMP/cmdline.txt"
+	printf 'console=serial0,115200 root=LABEL=armbi_root rootfstype=ext4 rootwait\n' >"$f"
+	run install_rewrite_rpi_cmdline "$f" "UUID=1234-5678"
+	[ "$status" -eq 0 ]
+	grep -q 'root=UUID=1234-5678' "$f"
+	grep -q 'console=serial0,115200' "$f"
+	grep -q 'rootfstype=ext4 rootwait' "$f"
+	# no leftover LABEL=
+	! grep -q 'armbi_root' "$f"
+}
+
+@test "rewrite rpi cmdline: missing file returns bootcfg error" {
+	run install_rewrite_rpi_cmdline "$TMP/nope-cmdline.txt" "UUID=x"
+	[ "$status" -eq 71 ]
+}
+
+@test "rewrite rpi cmdline: no root= in file returns bootcfg error" {
+	f="$TMP/cmdline.txt"; printf 'console=serial0,115200 rootwait\n' >"$f"
+	run install_rewrite_rpi_cmdline "$f" "UUID=x"
+	[ "$status" -eq 71 ]
 }

--- a/tests/bats/bootconfig.bats
+++ b/tests/bats/bootconfig.bats
@@ -266,6 +266,20 @@ setup() {
 	grep -qxF f2fs "$rootfs/etc/initramfs-tools/modules"
 }
 
+@test "update_initramfs: a failed run is fatal, not silently swallowed (build report)" {
+	# Previously this always returned 0 even when the chroot update-initramfs
+	# run failed - a btrfs/f2fs install "succeeded" then never actually booted
+	# (dropped to an (initramfs) shell: "mount ... failed: Invalid argument",
+	# the module missing from the initrd that was really booted). Whether it's
+	# this fake script failing or chroot itself refusing unprivileged, either
+	# way the function must report failure.
+	rootfs="$TMP/rootfs-fail"; mkdir -p "$rootfs/etc/initramfs-tools" "$rootfs/usr/sbin"
+	: >"$rootfs/etc/initramfs-tools/modules"
+	printf '#!/bin/sh\nexit 1\n' >"$rootfs/usr/sbin/update-initramfs"; chmod +x "$rootfs/usr/sbin/update-initramfs"
+	run install_update_initramfs "$rootfs" btrfs
+	[ "$status" -ne 0 ]
+}
+
 @test "fs kernel support: ext4 always supported; a bogus fs is not" {
 	run install_fs_kernel_supported ext4
 	[ "$status" -eq 0 ]

--- a/tests/bats/plan.bats
+++ b/tests/bats/plan.bats
@@ -184,6 +184,35 @@ setup() {
 	[[ "$output" == *"part=root:100%:f2fs:boot"* ]]
 }
 
+# --- native: full install on a board with no u-boot/EFI/GRUB (Raspberry Pi) --
+
+@test "plan native: FAT32 firmware partition first, plain root second" {
+	run install_plan_layout native ext4 0 $(( 16 * GIB )) 512 0
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"part=firmware:512MiB:vfat:boot"* ]]
+	[[ "$output" == *"part=root:100%:ext4:"* ]]
+	# unlike emmc, root carries no "boot" flag - the firmware partition owns it
+	[[ "$output" != *"part=root:100%:ext4:boot"* ]]
+}
+
+@test "plan native: no 16MiB reserve (nothing is written to raw sectors)" {
+	run install_plan_layout native ext4 0 $(( 16 * GIB )) 512 0
+	[[ "$output" == *"start=1"* ]]
+}
+
+@test "plan native: replicates the source table type, same as emmc/sd/mtd" {
+	run install_plan_layout native ext4 0 $(( 16 * GIB )) 512 0 msdos
+	[[ "$output" == *"table=msdos"* ]]
+	run install_plan_layout native ext4 0 $(( 16 * GIB )) 512 0 gpt
+	[[ "$output" == *"table=gpt"* ]]
+}
+
+@test "plan native: firmware partition is always vfat regardless of root fs" {
+	run install_plan_layout native btrfs 0 $(( 16 * GIB )) 512 0
+	[[ "$output" == *"part=firmware:512MiB:vfat:boot"* ]]
+	[[ "$output" == *"part=root:100%:btrfs:"* ]]
+}
+
 # --- errors ------------------------------------------------------------------
 
 @test "plan: unknown boot mode fails with usage code" {

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -587,7 +587,11 @@ install_bootloader_available() {
 	# bootable (e.g. a u-boot mode on x86, which has no write_uboot_platform).
 	case "$1" in
 		uefi|uefi-dualboot|bios) command -v grub-install >/dev/null 2>&1 ;;
-		emmc|sd) [[ "$(type -t write_uboot_platform)" == function ]] ;;
+		emmc)    [[ "$(type -t write_uboot_platform)" == function ]] ;;
+		# "sd" never calls install_write_bootloader (see the boot_mode != sd
+		# guard below) — it only moves root and leaves the current boot media
+		# untouched, so it needs no board capability and is always available.
+		sd)      return 0 ;;
 		mtd)     [[ "$(type -t write_uboot_platform_mtd)" == function ]] ;;
 		ufs)     [[ "$(type -t write_uboot_platform_ufs)" == function ]] ;;
 		*)       return 1 ;;

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -609,8 +609,13 @@ install_bootloader_available() {
 		# Neither "sd" nor "native" ever calls install_write_bootloader (see the
 		# boot_mode guard below) - "sd" only moves root and leaves the current
 		# boot media untouched; "native" writes a plain FAT32 boot partition the
-		# board's own firmware reads directly. Both need no board capability.
-		sd|native) return 0 ;;
+		# board's own firmware reads directly. "sd" writes no bootloader and only
+		# needs the current boot config to be rewirable (gated separately in the
+		# scenario pre-flight via install_sd_capable). "native" writes a plain
+		# FAT32 boot partition that only Raspberry Pi-style firmware reads, so it
+		# IS gated on that capability here.
+		sd)     return 0 ;;
+		native) install_rpi_style_boot ;;
 		mtd)     [[ "$(type -t write_uboot_platform_mtd)" == function ]] ;;
 		ufs)     [[ "$(type -t write_uboot_platform_ufs)" == function ]] ;;
 		*)       return 1 ;;
@@ -1082,6 +1087,21 @@ install_rpi_style_boot() {
 	[[ -f "$dir/config.txt" && -f "$dir/cmdline.txt" ]]
 }
 
+install_sd_env_file() {
+	# The CURRENT media's u-boot boot env, rewritten by sd mode. A function so
+	# tests can point it at a fixture instead of the real /boot.
+	echo /boot/armbianEnv.txt
+}
+
+install_sd_capable() {
+	# True when the CURRENT boot media's configuration can be pointed at a new
+	# root filesystem: either a u-boot-readable armbianEnv.txt to rewrite, or a
+	# Raspberry Pi-style static cmdline.txt. Guards both the mode menu and the
+	# scenario pre-flight so a board whose firmware reads neither (no EFI, no
+	# u-boot hook, no raspi firmware) never sees - or gets wiped by - sd mode.
+	[[ -f "$(install_sd_env_file)" ]] || install_rpi_style_boot
+}
+
 install_rewrite_rpi_cmdline() {
 	# install_rewrite_rpi_cmdline <cmdline_file> <root_uuid>
 	# Point a raspi-firmware cmdline.txt's root= at <root_uuid> ("UUID=..."),
@@ -1113,6 +1133,14 @@ install_run_scenario() {
 	# wiping anything - never destroy a disk we cannot finish installing to.
 	install_bootloader_available "$boot_mode" \
 		|| { install_log ERR "scenario: no bootloader method for '$boot_mode' on this system (u-boot hooks or grub-install missing) - refusing to modify $disk"; return "$INSTALL_EX_BOOTLOADER"; }
+	# sd mode rewrites the CURRENT boot media's configuration to point at the
+	# new root; check we have one to rewrite BEFORE wiping the target, or a
+	# firmware-booted board with neither armbianEnv.txt nor a raspi cmdline.txt
+	# would pass the check above, erase the disk, and only then fail.
+	if [[ "$boot_mode" == sd ]] && ! install_sd_capable; then
+		install_log ERR "scenario: sd mode but current boot config is neither armbianEnv.txt nor Raspberry Pi-style (config.txt+cmdline.txt) - refusing to modify $disk"
+		return "$INSTALL_EX_BOOTCFG"
+	fi
 	# mtd mode flashes u-boot to the SPI/MTD device list; refuse before wiping the
 	# target if the frontend handed us an empty list (e.g. the device vanished
 	# between menu and run) rather than failing after partitioning.
@@ -1234,27 +1262,31 @@ install_run_scenario() {
 				#   2. map that media's /boot into the target at /boot, so kernel and
 				#      initramfs upgrades on the target land where u-boot reads them.
 				# Without (1) the board keeps booting its old rootfs.
-				local env_file="/boot/armbianEnv.txt"
-				if [[ ! -f "$env_file" ]]; then
-					install_log ERR "scenario: sd mode but current boot env ($env_file) is missing; cannot make $disk bootable"
-					rc=$INSTALL_EX_BOOTCFG; break
-				fi
-				install_rewrite_bootenv "$env_file" "$root_uuid" "$fs" \
-					|| { install_log ERR "scenario: failed to point current boot env ($env_file) at new root $root_uuid"; rc=$INSTALL_EX_BOOTCFG; break; }
-				install_map_current_boot "$mp/etc/fstab" "$mp" \
-					|| { install_log ERR "scenario: failed to map current /boot into target fstab"; rc=$INSTALL_EX_BOOTCFG; break; }
-				# Raspberry Pi-style boards read root= directly from a static
-				# cmdline.txt on the CURRENT boot media, not from armbianEnv.txt
-				# via a u-boot script - the rewrite above is a no-op for them.
-				# Point that cmdline.txt at the new root too, or the board keeps
-				# booting the old one even though every step above "succeeded".
+				# The two boot styles need different rewrites - select FIRST, or
+				# the armbianEnv.txt requirement below would block the Raspberry
+				# Pi path (which has no armbianEnv.txt at all).
 				if install_rpi_style_boot; then
+					# Raspberry Pi-style boards read root= directly from a static
+					# cmdline.txt on the CURRENT boot media, not from
+					# armbianEnv.txt via a u-boot script.
 					local rpi_cmdline; rpi_cmdline="$(install_boot_firmware_dir)/cmdline.txt"
 					install_rewrite_rpi_cmdline "$rpi_cmdline" "$root_uuid" \
 						|| { install_log ERR "scenario: sd mode but failed to point current cmdline.txt ($rpi_cmdline) at new root $root_uuid"; rc=$INSTALL_EX_BOOTCFG; break; }
-					install_log INFO "scenario: also pointed current cmdline.txt ($rpi_cmdline) at new root $root_uuid (Raspberry Pi-style boot)"
-				fi
-				install_log INFO "scenario: pointed current boot media ($env_file) at new root $root_uuid ($fs) and mapped its /boot into the target" ;;
+					install_map_current_boot "$mp/etc/fstab" "$mp" \
+						|| { install_log ERR "scenario: failed to map current /boot into target fstab"; rc=$INSTALL_EX_BOOTCFG; break; }
+					install_log INFO "scenario: pointed current cmdline.txt ($rpi_cmdline) at new root $root_uuid (Raspberry Pi-style boot) and mapped its /boot into the target"
+				else
+					local env_file; env_file="$(install_sd_env_file)"
+					if [[ ! -f "$env_file" ]]; then
+						install_log ERR "scenario: sd mode but current boot env ($env_file) is missing; cannot make $disk bootable"
+						rc=$INSTALL_EX_BOOTCFG; break
+					fi
+					install_rewrite_bootenv "$env_file" "$root_uuid" "$fs" \
+						|| { install_log ERR "scenario: failed to point current boot env ($env_file) at new root $root_uuid"; rc=$INSTALL_EX_BOOTCFG; break; }
+					install_map_current_boot "$mp/etc/fstab" "$mp" \
+						|| { install_log ERR "scenario: failed to map current /boot into target fstab"; rc=$INSTALL_EX_BOOTCFG; break; }
+					install_log INFO "scenario: pointed current boot media ($env_file) at new root $root_uuid ($fs) and mapped its /boot into the target"
+				fi ;;
 			native)
 				# Fully self-contained: the copy of cmdline.txt that
 				# install_populate_boot just placed at $mp/boot/firmware/ must
@@ -1298,6 +1330,7 @@ install_run_scenario() {
 
 	# Teardown (best effort).
 	sync
+	mountpoint -q "$mp/boot/firmware" && umount "$mp/boot/firmware" 2>/dev/null
 	mountpoint -q "$mp/boot/efi" && umount "$mp/boot/efi" 2>/dev/null
 	mountpoint -q "$mp/boot" && umount "$mp/boot" 2>/dev/null
 	umount "$mp" 2>/dev/null

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -1132,16 +1132,30 @@ install_sd_capable() {
 }
 
 install_rewrite_rpi_cmdline() {
-	# install_rewrite_rpi_cmdline <cmdline_file> <root_uuid>
+	# install_rewrite_rpi_cmdline <cmdline_file> <root_uuid> [fs]
 	# Point a raspi-firmware cmdline.txt's root= at <root_uuid> ("UUID=..."),
 	# replacing whatever selector (LABEL=, UUID=, PARTUUID=, a device path) is
 	# there now. UUID rather than the image's built-in LABEL=armbi_root: once
 	# two disks both carry that label (the source media is still around), a
 	# label lookup is ambiguous - a UUID is unique by construction.
-	local file="$1" root_uuid="$2"
+	#
+	# [fs], if given, also replaces rootfstype=: initramfs-tools' /scripts/local
+	# mounts root with `mount -t "$ROOTFSTYPE"` whenever that key is set to
+	# anything other than empty/"auto" (see /usr/share/initramfs-tools/scripts/
+	# local) - a stale rootfstype=ext4 on a btrfs/f2fs root fails that mount
+	# with the exact same "Invalid argument" a missing kernel module would,
+	# regardless of root= being correct and the module being present.
+	local file="$1" root_uuid="$2" fs="${3:-}"
 	[[ -f "$file" ]] || return "$INSTALL_EX_BOOTCFG"
 	grep -q 'root=' "$file" || { install_log ERR "rpi-cmdline: no root= in $file"; return "$INSTALL_EX_BOOTCFG"; }
 	sed -i -E "s|root=[^ ]+|root=${root_uuid}|" "$file"
+	if [[ -n "$fs" ]]; then
+		if grep -q 'rootfstype=' "$file"; then
+			sed -i -E "s|rootfstype=[^ ]+|rootfstype=${fs}|" "$file"
+		else
+			sed -i -E "s|\$| rootfstype=${fs}|" "$file"
+		fi
+	fi
 }
 
 install_run_scenario() {
@@ -1299,7 +1313,7 @@ install_run_scenario() {
 					# cmdline.txt on the CURRENT boot media, not from
 					# armbianEnv.txt via a u-boot script.
 					local rpi_cmdline; rpi_cmdline="$(install_boot_firmware_dir)/cmdline.txt"
-					install_rewrite_rpi_cmdline "$rpi_cmdline" "$root_uuid" \
+					install_rewrite_rpi_cmdline "$rpi_cmdline" "$root_uuid" "$fs" \
 						|| { install_log ERR "scenario: sd mode but failed to point current cmdline.txt ($rpi_cmdline) at new root $root_uuid"; rc=$INSTALL_EX_BOOTCFG; break; }
 					install_map_current_boot "$mp/etc/fstab" "$mp" \
 						|| { install_log ERR "scenario: failed to map current /boot into target fstab"; rc=$INSTALL_EX_BOOTCFG; break; }
@@ -1323,7 +1337,7 @@ install_run_scenario() {
 				local cmdline="$mp/boot/firmware/cmdline.txt"
 				[[ -f "$cmdline" ]] \
 					|| { install_log ERR "scenario: native mode but $cmdline missing after boot copy"; rc=$INSTALL_EX_BOOTCFG; break; }
-				install_rewrite_rpi_cmdline "$cmdline" "$root_uuid" \
+				install_rewrite_rpi_cmdline "$cmdline" "$root_uuid" "$fs" \
 					|| { install_log ERR "scenario: failed to point target cmdline.txt ($cmdline) at new root $root_uuid"; rc=$INSTALL_EX_BOOTCFG; break; }
 				local env_file="$mp/boot/armbianEnv.txt"
 				[[ -f "$env_file" ]] && install_rewrite_bootenv "$env_file" "$root_uuid" "$fs"

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -175,12 +175,16 @@ install_plan_layout() {
 	# don't force GPT - used to replicate the running image's table type on an
 	# eMMC/SD target so the board's u-boot can read it. Empty = default (msdos).
 	#
-	# boot_mode: uefi | emmc | sd | mtd | ufs
-	#   uefi  - full install to an internal disk with an ESP + GRUB
-	#   emmc  - full self-contained install (boot + root) to eMMC/SD
-	#   sd    - boot stays on removable media, only the rootfs lands on the target
-	#   mtd   - boot lives in SPI/MTD flash, only the rootfs lands on the target
-	#   ufs   - boot idblock on a UFS boot LUN, rootfs on the UFS general LUN
+	# boot_mode: uefi | emmc | sd | mtd | ufs | native
+	#   uefi   - full install to an internal disk with an ESP + GRUB
+	#   emmc   - full self-contained install (boot + root) to eMMC/SD
+	#   sd     - boot stays on removable media, only the rootfs lands on the target
+	#   mtd    - boot lives in SPI/MTD flash, only the rootfs lands on the target
+	#   ufs    - boot idblock on a UFS boot LUN, rootfs on the UFS general LUN
+	#   native - full self-contained install (boot + root) to any disk on a board
+	#            with no u-boot/EFI/GRUB - its own firmware reads a plain FAT32
+	#            boot partition directly off whatever bus it's on (Raspberry
+	#            Pi's SoC/EEPROM bootrom). No bootloader write needed.
 	#
 	# Emits a declarative plan on stdout:
 	#   table=gpt|msdos
@@ -234,6 +238,17 @@ install_plan_layout() {
 		sd|mtd|ufs)
 			# Only the rootfs lands here; boot lives elsewhere.
 			parts+=("root:100%:${fs}:boot")
+			;;
+		native)
+			# No u-boot involved, so no raw-sector reservation and no ext4-boot-
+			# as-directory shortcut either: the board's own firmware can only
+			# read a real FAT32 partition, never a directory inside another
+			# filesystem, regardless of what <fs> is. Partition 1 mirrors the
+			# shipped image's own boot partition (mirrors its position too, so
+			# the board's firmware finds it the same way); partition 2 is a
+			# normal root with /boot as an ordinary directory.
+			parts+=("firmware:512MiB:vfat:boot")
+			parts+=("root:100%:${fs}:")
 			;;
 		*)
 			install_log ERR "install_plan_layout: unknown boot mode '$boot_mode'"
@@ -551,9 +566,12 @@ install_verify_boot_dir() {
 	compgen -G "$d/uImage*" >/dev/null 2>&1 && have_kernel=1
 	# Recognise every boot mechanism Armbian ships: boot.scr/boot.cmd (most
 	# u-boot), boot.ini (amlogic/odroid), uEnv.txt (k3/TI and others),
-	# extlinux.conf (distro boot), grub (x86/UEFI).
+	# extlinux.conf (distro boot), grub (x86/UEFI), config.txt+cmdline.txt in a
+	# nested firmware/ dir (native mode's Raspberry Pi-style FAT32 partition,
+	# mounted at boot/firmware under the directory checked here).
 	[[ -f "$d/boot.scr" || -f "$d/boot.cmd" || -f "$d/boot.ini" || -f "$d/uEnv.txt" \
-		|| -f "$d/extlinux/extlinux.conf" || -d "$d/grub" ]] && have_script=1
+		|| -f "$d/extlinux/extlinux.conf" || -d "$d/grub" \
+		|| ( -f "$d/firmware/config.txt" && -f "$d/firmware/cmdline.txt" ) ]] && have_script=1
 	if (( have_kernel == 0 || have_script == 0 )); then
 		install_log ERR "verify: '$d' is not bootable (kernel=$have_kernel script=$have_script)"
 		return "$INSTALL_EX_VERIFY"
@@ -588,10 +606,11 @@ install_bootloader_available() {
 	case "$1" in
 		uefi|uefi-dualboot|bios) command -v grub-install >/dev/null 2>&1 ;;
 		emmc)    [[ "$(type -t write_uboot_platform)" == function ]] ;;
-		# "sd" never calls install_write_bootloader (see the boot_mode != sd
-		# guard below) — it only moves root and leaves the current boot media
-		# untouched, so it needs no board capability and is always available.
-		sd)      return 0 ;;
+		# Neither "sd" nor "native" ever calls install_write_bootloader (see the
+		# boot_mode guard below) - "sd" only moves root and leaves the current
+		# boot media untouched; "native" writes a plain FAT32 boot partition the
+		# board's own firmware reads directly. Both need no board capability.
+		sd|native) return 0 ;;
 		mtd)     [[ "$(type -t write_uboot_platform_mtd)" == function ]] ;;
 		ufs)     [[ "$(type -t write_uboot_platform_ufs)" == function ]] ;;
 		*)       return 1 ;;
@@ -1042,6 +1061,40 @@ install_map_current_boot() {
 	return 0
 }
 
+install_boot_firmware_dir() {
+	# Where a raspi-firmware-style boot config (config.txt, cmdline.txt) lives:
+	# /boot/firmware if that's mounted separately (current layout), else /boot
+	# itself. Pure path logic except for the mount check.
+	if findmnt -no TARGET /boot/firmware >/dev/null 2>&1; then
+		echo /boot/firmware
+	else
+		echo /boot
+	fi
+}
+
+install_rpi_style_boot() {
+	# True if this board's firmware reads a static cmdline.txt straight off the
+	# boot partition (Raspberry Pi's SoC/EEPROM bootrom) rather than running a
+	# u-boot boot script that reads armbianEnv.txt. Detected by config.txt and
+	# cmdline.txt sitting together in the current boot tree - both are specific
+	# to this boot style and installed only by the raspi-firmware package.
+	local dir; dir="$(install_boot_firmware_dir)"
+	[[ -f "$dir/config.txt" && -f "$dir/cmdline.txt" ]]
+}
+
+install_rewrite_rpi_cmdline() {
+	# install_rewrite_rpi_cmdline <cmdline_file> <root_uuid>
+	# Point a raspi-firmware cmdline.txt's root= at <root_uuid> ("UUID=..."),
+	# replacing whatever selector (LABEL=, UUID=, PARTUUID=, a device path) is
+	# there now. UUID rather than the image's built-in LABEL=armbi_root: once
+	# two disks both carry that label (the source media is still around), a
+	# label lookup is ambiguous - a UUID is unique by construction.
+	local file="$1" root_uuid="$2"
+	[[ -f "$file" ]] || return "$INSTALL_EX_BOOTCFG"
+	grep -q 'root=' "$file" || { install_log ERR "rpi-cmdline: no root= in $file"; return "$INSTALL_EX_BOOTCFG"; }
+	sed -i -E "s|root=[^ ]+|root=${root_uuid}|" "$file"
+}
+
 install_run_scenario() {
 	# install_run_scenario <boot_mode> <target_disk> <fs> <exclude_file> [uboot_dir]
 	#
@@ -1084,7 +1137,7 @@ install_run_scenario() {
 	# source; the planner still upgrades to GPT when capacity/sector size demand.
 	local table_pref=""
 	case "$boot_mode" in
-		emmc|sd|mtd) table_pref="$(install_source_table_type)"
+		emmc|sd|mtd|native) table_pref="$(install_source_table_type)"
 			[[ -n "$table_pref" ]] && install_log INFO "scenario: inheriting source partition table '$table_pref' for $boot_mode" ;;
 	esac
 
@@ -1094,15 +1147,16 @@ install_run_scenario() {
 
 	# Partition, then build the mkfs map + remember the role->device mapping.
 	local partmap; partmap="$(install_apply_partitions "$disk" "$plan")" || return "$INSTALL_EX_PARTITION"
-	local esp_dev="" boot_dev="" root_dev="" swap_dev="" role dev
+	local esp_dev="" boot_dev="" fw_dev="" root_dev="" swap_dev="" role dev
 	local mkfs_map=""
 	while read -r role dev; do
 		[[ -n "$dev" ]] || continue
 		case "$role" in
-			esp)  esp_dev="$dev";  mkfs_map+="esp $dev vfat"$'\n' ;;
-			boot) boot_dev="$dev"; mkfs_map+="boot $dev ext4"$'\n' ;;
-			swap) swap_dev="$dev"; mkfs_map+="swap $dev swap"$'\n' ;;
-			root) root_dev="$dev"; mkfs_map+="root $dev $fs"$'\n' ;;
+			esp)      esp_dev="$dev";  mkfs_map+="esp $dev vfat"$'\n' ;;
+			boot)     boot_dev="$dev"; mkfs_map+="boot $dev ext4"$'\n' ;;
+			firmware) fw_dev="$dev";   mkfs_map+="firmware $dev vfat"$'\n' ;;
+			swap)     swap_dev="$dev"; mkfs_map+="swap $dev swap"$'\n' ;;
+			root)     root_dev="$dev"; mkfs_map+="root $dev $fs"$'\n' ;;
 		esac
 	done <<<"$partmap"
 	[[ -b "$root_dev" ]] || { install_log ERR "scenario: no root partition created"; return "$INSTALL_EX_PARTITION"; }
@@ -1134,6 +1188,17 @@ install_run_scenario() {
 			mount "$boot_dev" "$mp/boot" \
 				|| { install_log ERR "scenario: mount boot partition $boot_dev failed"; rc=$INSTALL_EX_BOOTCFG; break; }
 		fi
+		# native mode's FAT32 boot partition mounts at /boot/firmware, mirroring
+		# the running system's own layout: the default install_populate_boot
+		# rsync of /boot (below) crosses into it the same way it would on the
+		# live system, populating both tiers - the ordinary /boot directory
+		# (kernel, armbianEnv.txt, ...) and the nested firmware partition
+		# (config.txt, cmdline.txt, the active kernel/dtbs) - in one pass.
+		if [[ -n "$fw_dev" ]]; then
+			mkdir -p "$mp/boot/firmware"
+			mount "$fw_dev" "$mp/boot/firmware" \
+				|| { install_log ERR "scenario: mount firmware partition $fw_dev failed"; rc=$INSTALL_EX_BOOTCFG; break; }
+		fi
 		install_populate_boot "$mp" "$copy_boot" || { rc=$INSTALL_EX_BOOTCFG; break; }
 
 		# fstab from the real, freshly-created UUIDs.
@@ -1144,6 +1209,10 @@ install_run_scenario() {
 		[[ -n "$swap_dev" ]] && swap_uuid="$(install_uuid "$swap_dev")"
 		install_gen_fstab "$root_uuid" "$fs" "$boot_uuid" ext4 "$esp_uuid" "$swap_uuid" >"$mp/etc/fstab" \
 			|| { rc=$INSTALL_EX_BOOTCFG; break; }
+		# native mode's firmware partition isn't one of install_gen_fstab's
+		# known slots (it's not read by any bootloader the way the ESP is) -
+		# append its entry directly, same as the swap carry-over just below.
+		[[ -n "$fw_dev" ]] && printf '%s\t/boot/firmware\tvfat\tdefaults,noatime\t0\t2\n' "$(install_uuid "$fw_dev")" >>"$mp/etc/fstab"
 		# No dedicated swap partition -> carry over the host's swap entries (e.g. a
 		# /var/swap swapfile) so the target keeps swap.
 		if [[ -z "$swap_dev" ]] && grep -qE '^[^#].*[[:space:]]swap[[:space:]]' /etc/fstab 2>/dev/null; then
@@ -1174,7 +1243,30 @@ install_run_scenario() {
 					|| { install_log ERR "scenario: failed to point current boot env ($env_file) at new root $root_uuid"; rc=$INSTALL_EX_BOOTCFG; break; }
 				install_map_current_boot "$mp/etc/fstab" "$mp" \
 					|| { install_log ERR "scenario: failed to map current /boot into target fstab"; rc=$INSTALL_EX_BOOTCFG; break; }
+				# Raspberry Pi-style boards read root= directly from a static
+				# cmdline.txt on the CURRENT boot media, not from armbianEnv.txt
+				# via a u-boot script - the rewrite above is a no-op for them.
+				# Point that cmdline.txt at the new root too, or the board keeps
+				# booting the old one even though every step above "succeeded".
+				if install_rpi_style_boot; then
+					local rpi_cmdline; rpi_cmdline="$(install_boot_firmware_dir)/cmdline.txt"
+					install_rewrite_rpi_cmdline "$rpi_cmdline" "$root_uuid" \
+						|| { install_log ERR "scenario: sd mode but failed to point current cmdline.txt ($rpi_cmdline) at new root $root_uuid"; rc=$INSTALL_EX_BOOTCFG; break; }
+					install_log INFO "scenario: also pointed current cmdline.txt ($rpi_cmdline) at new root $root_uuid (Raspberry Pi-style boot)"
+				fi
 				install_log INFO "scenario: pointed current boot media ($env_file) at new root $root_uuid ($fs) and mapped its /boot into the target" ;;
+			native)
+				# Fully self-contained: the copy of cmdline.txt that
+				# install_populate_boot just placed at $mp/boot/firmware/ must
+				# point at THIS disk's own new root, not the source's.
+				local cmdline="$mp/boot/firmware/cmdline.txt"
+				[[ -f "$cmdline" ]] \
+					|| { install_log ERR "scenario: native mode but $cmdline missing after boot copy"; rc=$INSTALL_EX_BOOTCFG; break; }
+				install_rewrite_rpi_cmdline "$cmdline" "$root_uuid" \
+					|| { install_log ERR "scenario: failed to point target cmdline.txt ($cmdline) at new root $root_uuid"; rc=$INSTALL_EX_BOOTCFG; break; }
+				local env_file="$mp/boot/armbianEnv.txt"
+				[[ -f "$env_file" ]] && install_rewrite_bootenv "$env_file" "$root_uuid" "$fs"
+				install_log INFO "scenario: pointed target cmdline.txt ($cmdline) at its own new root $root_uuid ($fs)" ;;
 		esac
 
 		# Rebuild the target initramfs so a module root fs (btrfs/f2fs) boots
@@ -1187,8 +1279,10 @@ install_run_scenario() {
 		# In sd mode the bootloader already lives on the current boot media (left
 		# untouched) and the boot env there was rewired above; writing u-boot to
 		# $disk would target the wrong device - e.g. the Rockchip bootrom cannot
-		# load u-boot from NVMe/USB/SATA, so it would silently fail to boot.
-		if [[ "$boot_mode" != sd ]]; then
+		# load u-boot from NVMe/USB/SATA, so it would silently fail to boot. In
+		# native mode there is no bootloader to write at all - the board's own
+		# firmware already found and read $disk's new FAT32 boot partition.
+		if [[ "$boot_mode" != sd && "$boot_mode" != native ]]; then
 			install_write_bootloader "$boot_mode" "$disk" "$mp" "$uboot_dir" "${INSTALL_MTD_LIST:-}" "${INSTALL_UFS_BOOT_LUN:-}" \
 				|| { rc=$INSTALL_EX_BOOTLOADER; break; }
 		fi

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -760,11 +760,20 @@ install_update_initramfs() {
 	if [[ -d "$rootfs/boot/firmware" ]]; then
 		local newest
 		newest="$(find "$rootfs/boot" -maxdepth 1 -name 'initrd.img-*' -printf '%T@ %p\n' 2>/dev/null | sort -rn | head -1 | cut -d' ' -f2-)"
-		if [[ -n "$newest" ]] && ! cmp -s "$newest" "$rootfs/boot/firmware/initrd.img" 2>/dev/null; then
+		# No rebuilt initrd at all is itself a failure - update-initramfs just
+		# reported success above, so its absence means we can no longer prove
+		# ANY initrd (stale or fresh) is what boot/firmware/initrd.img holds.
+		[[ -n "$newest" ]] \
+			|| { install_log ERR "update-initramfs: no rebuilt initrd found under $rootfs/boot"; return "$INSTALL_EX_BOOTCFG"; }
+		if ! cmp -s "$newest" "$rootfs/boot/firmware/initrd.img" 2>/dev/null; then
 			install_log WARN "update-initramfs: boot/firmware/initrd.img was not refreshed by the post-update hook; copying $newest directly"
 			cp "$newest" "$rootfs/boot/firmware/initrd.img" \
 				|| { install_log ERR "update-initramfs: failed to copy $newest to boot/firmware/initrd.img"; return "$INSTALL_EX_BOOTCFG"; }
 		fi
+		# Verify rather than trust the copy: confirm boot/firmware/initrd.img
+		# now actually matches the freshly-built one before declaring success.
+		cmp -s "$newest" "$rootfs/boot/firmware/initrd.img" \
+			|| { install_log ERR "update-initramfs: boot/firmware/initrd.img still does not match the rebuilt initrd"; return "$INSTALL_EX_BOOTCFG"; }
 	fi
 	return 0
 }
@@ -1481,7 +1490,8 @@ install_run_split() {
 			|| { install_log ERR "split: failed to point $env_file at root $root_uuid"; rc=$INSTALL_EX_BOOTCFG; break; }; }
 
 		# Module root fs (btrfs/f2fs) needs its driver in the eMMC /boot initramfs.
-		install_update_initramfs "$mp" "$fs"
+		# Fatal on failure - see install_run_scenario's identical guard.
+		install_update_initramfs "$mp" "$fs" || { rc=$INSTALL_EX_BOOTCFG; break; }
 
 		echo 95
 		# u-boot goes to the eMMC whole device (raw sectors), never the target.
@@ -1564,7 +1574,8 @@ install_run_dualboot() {
 		root_uuid="$(install_uuid "$root_dev")"
 		esp_uuid="$(install_uuid "$esp")"
 		install_gen_fstab "$root_uuid" "$fs" "" ext4 "$esp_uuid" >"$mp/etc/fstab" || { rc=$INSTALL_EX_BOOTCFG; break; }
-		install_update_initramfs "$mp" "$fs"
+		# Fatal on failure - see install_run_scenario's identical guard.
+		install_update_initramfs "$mp" "$fs" || { rc=$INSTALL_EX_BOOTCFG; break; }
 		echo 95
 		mount "$esp" "$mp/boot/efi" || { install_log ERR "dualboot: mount ESP failed"; rc=$INSTALL_EX_BOOTLOADER; break; }
 		install_grub_install "$mp" dualboot || { rc=$INSTALL_EX_BOOTLOADER; break; }

--- a/tools/modules/functions/module_install_engine.sh
+++ b/tools/modules/functions/module_install_engine.sh
@@ -712,13 +712,18 @@ install_update_initramfs() {
 	# is actually present at boot. Armbian sets MODULES=list, which does NOT
 	# auto-include the root-fs module, and the installer inherits the source's
 	# initramfs (built for the source's root fs) - so an f2fs/btrfs root would be
-	# unbootable without this. Built-in filesystems (ext4/vfat) need nothing.
-	# Best effort: a failure is logged, not fatal.
+	# unbootable without this. Built-in filesystems (ext4/vfat) need nothing and
+	# return immediately. A failure here means the target CANNOT boot (build
+	# report: a btrfs native install "succeeded" then dropped to an (initramfs)
+	# shell with "mount ... failed: Invalid argument" - the btrfs module was
+	# simply missing from the initrd actually booted), so it is fatal - the
+	# caller must treat a non-zero return as an install failure, not a warning.
 	local rootfs="$1" fs="$2"
 	case "$fs" in ext2|ext3|ext4|vfat|msdos) return 0 ;; esac
-	command -v chroot >/dev/null 2>&1 || return 0
-	[[ -x "$rootfs/usr/sbin/update-initramfs" || -x "$rootfs/sbin/update-initramfs" ]] || {
-		install_log WARN "update-initramfs: not present in target; $fs root may not boot"; return 0; }
+	command -v chroot >/dev/null 2>&1 \
+		|| { install_log ERR "update-initramfs: no chroot on this system; $fs root would be unbootable"; return "$INSTALL_EX_BOOTCFG"; }
+	[[ -x "$rootfs/usr/sbin/update-initramfs" || -x "$rootfs/sbin/update-initramfs" ]] \
+		|| { install_log ERR "update-initramfs: not present in target; $fs root would be unbootable"; return "$INSTALL_EX_BOOTCFG"; }
 
 	# Force the fs module into the initramfs module list (list mode ships only
 	# what is listed here).
@@ -727,16 +732,40 @@ install_update_initramfs() {
 		echo "$fs" >>"$modfile"
 	fi
 
-	mkdir -p "$rootfs"/{dev,proc,sys}
+	mkdir -p "$rootfs"/{dev,proc,sys,run}
 	mount --bind /dev "$rootfs/dev"
 	mount --bind /proc "$rootfs/proc"
 	mount --bind /sys "$rootfs/sys"
+	mount --bind /run "$rootfs/run" 2>/dev/null || true
 	local rc=0
 	chroot "$rootfs" /bin/bash -c "update-initramfs -u -k all" >>"$INSTALL_LOG" 2>&1 || rc=1
+	mountpoint -q "$rootfs/run" && umount "$rootfs/run" 2>/dev/null
 	umount "$rootfs/sys" 2>/dev/null
 	umount "$rootfs/proc" 2>/dev/null
 	umount "$rootfs/dev" 2>/dev/null
-	[[ "$rc" == 0 ]] || install_log WARN "update-initramfs failed in target; $fs root may not boot"
+	if [[ "$rc" != 0 ]]; then
+		install_log ERR "update-initramfs failed in target; $fs root would be unbootable"
+		return "$INSTALL_EX_BOOTCFG"
+	fi
+
+	# Armbian's own /etc/initramfs/post-update.d/zzz-update-initramfs hook is
+	# supposed to copy the freshly-built initrd into boot/firmware/initrd.img
+	# automatically on boards that boot straight out of it (Raspberry Pi) - but
+	# a hook firing inside a bare chroot, with no real dpkg transaction or init
+	# system driving it, is not guaranteed to run the way it does on a live
+	# system. If boot/firmware/initrd.img is still the SOURCE's stale copy
+	# (rsynced verbatim earlier, built for the source's own root fs and never
+	# regenerated), the board boots the OLD initrd and fails exactly as if this
+	# whole function were a no-op - belt and braces: replace it directly.
+	if [[ -d "$rootfs/boot/firmware" ]]; then
+		local newest
+		newest="$(find "$rootfs/boot" -maxdepth 1 -name 'initrd.img-*' -printf '%T@ %p\n' 2>/dev/null | sort -rn | head -1 | cut -d' ' -f2-)"
+		if [[ -n "$newest" ]] && ! cmp -s "$newest" "$rootfs/boot/firmware/initrd.img" 2>/dev/null; then
+			install_log WARN "update-initramfs: boot/firmware/initrd.img was not refreshed by the post-update hook; copying $newest directly"
+			cp "$newest" "$rootfs/boot/firmware/initrd.img" \
+				|| { install_log ERR "update-initramfs: failed to copy $newest to boot/firmware/initrd.img"; return "$INSTALL_EX_BOOTCFG"; }
+		fi
+	fi
 	return 0
 }
 
@@ -1302,8 +1331,12 @@ install_run_scenario() {
 		esac
 
 		# Rebuild the target initramfs so a module root fs (btrfs/f2fs) boots
-		# under MODULES=list. Only when the target owns its /boot.
-		[[ "$copy_boot" == 1 ]] && install_update_initramfs "$mp" "$fs"
+		# under MODULES=list. Only when the target owns its /boot. Fatal on
+		# failure - an unrebuilt initramfs means the target cannot boot at all,
+		# not a cosmetic problem to warn about and ship anyway.
+		if [[ "$copy_boot" == 1 ]]; then
+			install_update_initramfs "$mp" "$fs" || { rc=$INSTALL_EX_BOOTCFG; break; }
+		fi
 
 		echo 95
 		# ESP must be mounted before GRUB runs.

--- a/tools/modules/system/module_partitioner.sh
+++ b/tools/modules/system/module_partitioner.sh
@@ -112,9 +112,12 @@ partitioner_mtd_list() {
 #   * UEFI firmware present            -> GRUB EFI (uefi, +dualboot with Windows)
 #   * u-boot board (ARM)               -> media-specific u-boot modes
 #   * x86 legacy BIOS (no EFI/u-boot)  -> GRUB BIOS (grub-pc)
-#   * none of the above (e.g. Raspberry Pi's own SoC/EEPROM firmware boot,
-#     which isn't u-boot at all)       -> "sd" only: it moves root and never
-#     touches the boot media, so it needs no board capability to be safe.
+#   * none of the above, Raspberry Pi-style firmware confirmed present
+#     (config.txt + cmdline.txt)       -> "sd" (root only) or "native" (full
+#     self-contained install - the board's own firmware can boot straight off
+#     the target, so the SD card becomes removable)
+#   * none of the above, board unrecognised -> "sd" only: it moves root and
+#     never touches the boot media, so it needs no board capability to be safe.
 partitioner_modes_for() {
 	local role="$1" disk="$2"
 	local -a m=()
@@ -152,12 +155,14 @@ partitioner_modes_for() {
 		m+=(bios); have_bios=1
 	fi
 	# No EFI, no u-boot hooks, no GRUB either: the board boots via its own
-	# firmware straight out of the current boot media (Raspberry Pi's
-	# SoC/EEPROM bootrom reading /boot/firmware is the common case) and there
-	# is no board-provided bootloader-write hook to gate on. "sd" mode is still
-	# safe here — it only moves root, leaving that boot media untouched — so
-	# offer it rather than reporting no install method at all.
+	# firmware, and there is no board-provided bootloader-write hook to gate
+	# on. "sd" mode is always safe here — it only moves root, leaving the
+	# current boot media untouched. When that firmware is confirmed to be
+	# Raspberry Pi-style (reads a plain FAT32 boot partition off whatever bus
+	# it's on), "native" is safe too: a full self-contained install straight
+	# to the target, so the SD card becomes removable — offer it first.
 	if [[ ! -d /sys/firmware/efi && "$have_uboot" -eq 0 && "$have_bios" -eq 0 ]]; then
+		install_rpi_style_boot && m+=(native)
 		m+=(sd)
 	fi
 
@@ -172,6 +177,7 @@ partitioner_mode_desc() {
 		uefi) echo "UEFI install with GRUB (ERASES the disk)" ;;
 		bios) echo "Legacy BIOS install with GRUB (ERASES the disk)" ;;
 		emmc) echo "Full install to this device (boot + system)" ;;
+		native) echo "Full install to this disk — SD card no longer needed" ;;
 		sd)   echo "Keep boot on current media, system on this disk" ;;
 		split-emmc) echo "Boot from eMMC, system on this disk (+ /emmc_storage)" ;;
 		mtd)  echo "Boot from SPI/MTD flash, system on this disk" ;;
@@ -451,7 +457,7 @@ partitioner_cli_install() {
 	done
 
 	[[ -b "$target" ]] || { echo "armbian-install: --target must be a block device" >&2; return "$INSTALL_EX_NODEV"; }
-	case "$boot" in uefi|uefi-dualboot|bios|emmc|sd|mtd|ufs|split-emmc) ;; *) echo "armbian-install: --boot must be one of uefi|uefi-dualboot|bios|emmc|sd|mtd|ufs|split-emmc" >&2; return "$INSTALL_EX_USAGE" ;; esac
+	case "$boot" in uefi|uefi-dualboot|bios|emmc|sd|mtd|ufs|native|split-emmc) ;; *) echo "armbian-install: --boot must be one of uefi|uefi-dualboot|bios|emmc|sd|mtd|ufs|native|split-emmc" >&2; return "$INSTALL_EX_USAGE" ;; esac
 	case "$fs"   in ext4|btrfs|f2fs) ;;     *) echo "armbian-install: --fs must be one of ext4|btrfs|f2fs" >&2; return "$INSTALL_EX_USAGE" ;; esac
 	[[ -f "$INSTALL_EXCLUDE" ]] || { echo "armbian-install: exclude list $INSTALL_EXCLUDE missing" >&2; return "$INSTALL_EX_TRANSFER"; }
 
@@ -581,7 +587,10 @@ partitioner_help() {
 
 	Non-interactive:
 	  armbian-install --target /dev/sdX --boot <mode> --fs <fs> --yes
-	    --boot   uefi | uefi-dualboot | bios | emmc | sd | mtd | ufs | split-emmc
+	    --boot   uefi | uefi-dualboot | bios | emmc | sd | mtd | ufs | native | split-emmc
+	             native: full self-contained install on a board with no
+	                     u-boot/EFI/GRUB (e.g. Raspberry Pi) - target boots on
+	                     its own, no other media needed
 	             split-emmc: boot from eMMC, root on --target (NVMe/SATA/USB),
 	                         eMMC remainder mounted at /emmc_storage
 	    --fs     ext4 | btrfs | f2fs

--- a/tools/modules/system/module_partitioner.sh
+++ b/tools/modules/system/module_partitioner.sh
@@ -156,14 +156,15 @@ partitioner_modes_for() {
 	fi
 	# No EFI, no u-boot hooks, no GRUB either: the board boots via its own
 	# firmware, and there is no board-provided bootloader-write hook to gate
-	# on. "sd" mode is always safe here — it only moves root, leaving the
-	# current boot media untouched. When that firmware is confirmed to be
-	# Raspberry Pi-style (reads a plain FAT32 boot partition off whatever bus
-	# it's on), "native" is safe too: a full self-contained install straight
-	# to the target, so the SD card becomes removable — offer it first.
+	# on. "sd" mode only moves root and leaves the current boot media
+	# untouched - but only when that media's config can be rewired
+	# (install_sd_capable). When that firmware is confirmed to be Raspberry
+	# Pi-style (reads a plain FAT32 boot partition off whatever bus it's on),
+	# "native" is safe too: a full self-contained install straight to the
+	# target, so the SD card becomes removable — offer it first.
 	if [[ ! -d /sys/firmware/efi && "$have_uboot" -eq 0 && "$have_bios" -eq 0 ]]; then
 		install_rpi_style_boot && m+=(native)
-		m+=(sd)
+		install_sd_capable && m+=(sd)
 	fi
 
 	# No writable boot mode for this firmware/disk: emit nothing so the caller

--- a/tools/modules/system/module_partitioner.sh
+++ b/tools/modules/system/module_partitioner.sh
@@ -112,6 +112,9 @@ partitioner_mtd_list() {
 #   * UEFI firmware present            -> GRUB EFI (uefi, +dualboot with Windows)
 #   * u-boot board (ARM)               -> media-specific u-boot modes
 #   * x86 legacy BIOS (no EFI/u-boot)  -> GRUB BIOS (grub-pc)
+#   * none of the above (e.g. Raspberry Pi's own SoC/EEPROM firmware boot,
+#     which isn't u-boot at all)       -> "sd" only: it moves root and never
+#     touches the boot media, so it needs no board capability to be safe.
 partitioner_modes_for() {
 	local role="$1" disk="$2"
 	local -a m=()
@@ -144,8 +147,18 @@ partitioner_modes_for() {
 		esac
 	fi
 	# x86 legacy BIOS: neither EFI firmware nor a u-boot board.
+	local have_bios=0
 	if [[ ! -d /sys/firmware/efi && "$have_uboot" -eq 0 ]] && command -v grub-install >/dev/null 2>&1; then
-		m+=(bios)
+		m+=(bios); have_bios=1
+	fi
+	# No EFI, no u-boot hooks, no GRUB either: the board boots via its own
+	# firmware straight out of the current boot media (Raspberry Pi's
+	# SoC/EEPROM bootrom reading /boot/firmware is the common case) and there
+	# is no board-provided bootloader-write hook to gate on. "sd" mode is still
+	# safe here — it only moves root, leaving that boot media untouched — so
+	# offer it rather than reporting no install method at all.
+	if [[ ! -d /sys/firmware/efi && "$have_uboot" -eq 0 && "$have_bios" -eq 0 ]]; then
+		m+=(sd)
 	fi
 
 	# No writable boot mode for this firmware/disk: emit nothing so the caller


### PR DESCRIPTION
On a Raspberry Pi (bcm2711/bcm2712 — boots via its own SoC/EEPROM firmware, no u-boot, no EFI, no GRUB), `armbian-install` refused **every** disk with:

> No bootable install method is available for /dev/sda on this system (no EFI firmware, no GRUB, and no board u-boot support).

Reproduced live on a real rpi400 running Armbian 26.8.1. Confirmed the box has none of `/sys/firmware/efi`, `grub-install`, or `/usr/lib/u-boot/platform_install.sh`.

## Commit 1 — offer `sd` mode

`partitioner_modes_for()`/`install_bootloader_available()` required one of u-boot/EFI/GRUB before offering *any* mode, including `sd` ("keep boot on current media, root on this disk") — which never actually writes a bootloader (`install_run_scenario` skips that step when `boot_mode == sd`). Fixed to offer `sd` on any board with none of the three.

## Commit 2 — a real correctness bug found while building the next part, + `native` mode

Turns out `sd` mode as fixed in commit 1 doesn't actually work on Raspberry Pi: it isn't u-boot, so it never reads `armbianEnv.txt`'s `rootdev=` at boot — root is selected by a static `root=LABEL=armbi_root` baked into `/boot/firmware/cmdline.txt`. `install_rewrite_bootenv()` only touches `armbianEnv.txt`, so `sd` mode would report success while the board kept booting the **old** root. Fixed: both `sd` and the new `native` mode now also rewrite `cmdline.txt`'s `root=` (via UUID, not the image's built-in `LABEL=armbi_root`, which stays present and ambiguous on the still-inserted source SD card) whenever `install_rpi_style_boot()` confirms `config.txt`+`cmdline.txt` boot style.

Also added `native`: a **full self-contained install** (boot + root together) to any disk — since Raspberry Pi's own firmware can read a FAT32 boot partition directly off SD, USB, NVMe, or SATA, with no bootloader-write step at all, the SD card can become fully removable. New FAT32 `firmware` partition role, mounted at `$mp/boot/firmware` before the existing `install_populate_boot` rsync so it naturally populates both tiers in one pass (mirrors the running system's own `/boot` + nested `/boot/firmware` layout).

Both fixes are additive — every existing mode (`uefi`/`bios`/`emmc`/`mtd`/`ufs`/`split-emmc`) is untouched.

### Verified against the real rpi400 (Armbian 26.8.1)
- No `/sys/firmware/efi`, no `grub-install`, no `/usr/lib/u-boot/`.
- `install_plan_layout native ...` traced directly — FAT32 `firmware` partition + plain root, correct start offset, table-type inheritance.
- `install_rpi_style_boot`/`install_rewrite_rpi_cmdline` exercised against the device's actual `/boot/firmware/cmdline.txt` content — rewrites `root=` cleanly, leaves every other kernel arg untouched.
- `partitioner_modes_for` exercised with EFI/GRUB faked out (this sandbox has EFI) — offers exactly `native sd` once RPi-style boot is confirmed, falls back to `sd` alone for an unrecognised board, unaffected on EFI systems.

### Test coverage
Added to `tests/bats/plan.bats` and `tests/bats/bootconfig.bats` (this sandbox has no apt access to install `bats`, so CI is the first real run of the full suite + the new cases).

**Merge order:** this only touches `configng`; no dependency on the docs PRs.