### PR TITLE
firmware: refresh the apt index before the repository madison check

### DIFF
--- a/tools/modules/system/module_armbian_firmware.sh
+++ b/tools/modules/system/module_armbian_firmware.sh
@@ -494,10 +494,16 @@ function module_armbian_firmware() {
 			fi
 
 			# Point the sources at the requested repo (no-op if already there).
-			if [[ "$prev_host" != "$target_host" ]]; then
+			[[ "$prev_host" != "$target_host" ]] && \
 				sed -i "s|[a-zA-Z0-9.-]*\.armbian\.com|${target_host}|g" "$sources_file"
-				pkg_update
-			fi
+
+			# Refresh the index so the madison check below reflects the TARGET repo's
+			# current contents. Needed after an actual switch, but also on a no-op
+			# switch (already on the requested repo) where the ambient index may be
+			# stale or entirely absent — e.g. a freshly provisioned container with no
+			# apt lists yet, which otherwise makes madison find nothing and the switch
+			# wrongly report the repo as publishing no kernel.
+			pkg_update
 
 			# Predict the empty-repo case: verify the TARGET repo actually publishes
 			# a kernel for this board BEFORE committing to it. apt-cache show can't


### PR DESCRIPTION
## Problem

configng's **Stable repository** test fails with:

```
Error: the 'stable' repository (apt.armbian.com) publishes no linux-image-edge-arm64 — refusing the switch and reverting to apt.armbian.com; current kernel left in place.
```

The package **does** exist on apt.armbian.com (all releases/arches). The switch verifies it via `apt-cache madison` before committing — but the index is refreshed **only when the mirror host changes** ([`module_armbian_firmware.sh:497-500`](tools/modules/system/module_armbian_firmware.sh#L497-L500)). A `repository stable` call on a system already on apt.armbian.com is a **no-op switch**, so it skips `pkg_update` and `madison` queries whatever's cached. The `repository-update` test containers ship with **empty apt lists** and the harness runs the testcase without an `apt-get update`, so `madison` finds nothing → false "no kernel" abort.

## Fix

Run `pkg_update` **unconditionally** before the madison check so it always reflects the target repo's current contents (the `sed` still only runs on a real host change). Refreshing the index before asking "does the target repo publish this kernel" is also simply more correct — a no-op switch against a stale index could otherwise miss a package that was added/removed since the last update.

## Verified

In the arm64 `repository-update` container (with `/etc/armbian-release` present):

```
BEFORE update (current no-op behavior): madison linux-image-edge-arm64 -> NOT FOUND   (the reported error)
AFTER pkg_update (the fix):              linux-image-edge-arm64 | 26.8.3 | apt.armbian.com trixie/main arm64
```

## Related

Pairs with armbian/docker-armbian-build#42, which gives the containers a `/etc/armbian-release` (so `BRANCH`/`LINUXFAMILY` are set and the target is `linux-image-edge-arm64` rather than `linux-image--`). Both are needed for the repository tests to pass.