### PR TITLE
runners: fix label fallback, runner listing and parameter handling

### DIFF
--- a/.github/workflows/maintenance-bats.yml
+++ b/.github/workflows/maintenance-bats.yml
@@ -31,7 +31,7 @@ jobs:
         run: sudo apt-get update -qq && sudo apt-get install -y -qq bats jq parted dosfstools ntfs-3g
 
       - name: Unit tests (pure functions, no privileges)
-        run: bats tests/bats/plan.bats tests/bats/detect.bats tests/bats/detect_windows.bats tests/bats/bootconfig.bats tests/bats/dualboot.bats tests/bats/transfer.bats tests/bats/package.bats
+        run: bats tests/bats/plan.bats tests/bats/detect.bats tests/bats/detect_windows.bats tests/bats/bootconfig.bats tests/bats/dualboot.bats tests/bats/transfer.bats tests/bats/package.bats tests/bats/runners.bats
 
       - name: Integration tests (loopback block device + Windows dual-boot, needs root)
         run: sudo bats tests/bats/integration_loopback.bats tests/bats/integration_dualboot.bats

--- a/tests/bats/runners.bats
+++ b/tests/bats/runners.bats
@@ -108,6 +108,48 @@ _stub_curl() {
 	[ ! -e "$TMP/pwned" ]
 }
 
+# `remove` does local teardown (userdel, sudoers edits). Neutralise it so these
+# tests never touch the host, while letting the module's own temp-file cleanup
+# work. rm passes through only for paths under the test tmpdir or /tmp.
+_stub_local_teardown() {
+	getent()   { return 1; }
+	userdel()  { echo "userdel $*" >>"$TMP/teardown"; }
+	groupdel() { :; }
+	sed()      { :; }
+	rm() {
+		local a last=""
+		for a in "$@"; do [[ "$a" == -* ]] || last="$a"; done
+		case "$last" in /tmp/*|"$BATS_TEST_TMPDIR"/*) command rm "$@" ;; *) : ;; esac
+	}
+}
+
+@test "remove_online: a name that matches nothing says so instead of looking deleted" {
+	# The caller prints "Removing runner X on GitHub" before this runs, so a
+	# silent zero-match read as a successful delete — which is how a stale
+	# registration survived a "successful" remove.
+	_stub_curl
+	LIST_FIXTURE='{"total_count":2,"runners":[{"id":11,"name":"armbian-01"},{"id":22,"name":"armbian-02"}]}'
+	run module_armbian_runners remove_online xxx gh_token=xxx
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"No runner named 'xxx'"* ]]
+	[[ "$output" == *"2 runner(s) listed"* ]]
+	[ ! -s "$DELETED" ]
+}
+
+@test "remove: start/stop default to 01, so a bare runner_name hits <name>-01" {
+	# Without the default, rm_indices was empty and the bare name "xxx" was
+	# looked up — runners are registered as "<name>-NN", so it matched nothing.
+	_stub_curl
+	_stub_local_teardown
+	: >"$TMP/teardown"
+	LIST_FIXTURE='{"total_count":1,"runners":[{"id":77,"name":"xxx-01"}]}'
+	run module_armbian_runners remove runner_name=xxx gh_token=xxx organisation=armbian
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"Removing runner xxx-01 on GitHub"* ]]
+	[[ "$output" == *"Delete existing: xxx-01"* ]]
+	[ "$(cat "$DELETED")" = "77" ]
+}
+
 @test "help: documents the label fallback" {
 	run module_armbian_runners help
 	[ "$status" -eq 0 ]

--- a/tests/bats/runners.bats
+++ b/tests/bats/runners.bats
@@ -100,6 +100,10 @@ _stub_curl() {
 	# The old parser ran eval "$feature=$value" on whatever came off the
 	# command line. No spaces in the payload: the old parser word-split on
 	# those before eval saw them, which would mask the injection.
+	# Stubbed like the rest: without it this reaches the real api.github.com,
+	# making a parser test depend on the network.
+	_stub_curl
+	LIST_FIXTURE='{"total_count":0,"runners":[]}'
 	run module_armbian_runners remove_online armbian-01 "gh_token=\$(id>$TMP/pwned)"
 	[ ! -e "$TMP/pwned" ]
 }

--- a/tests/bats/runners.bats
+++ b/tests/bats/runners.bats
@@ -1,0 +1,112 @@
+#!/usr/bin/env bats
+#
+# Unit tests for the self-hosted runner module: parameter parsing, label
+# fallback, and the runner listing that broke on a GitHub error object
+# (jq: Cannot iterate over null).
+
+setup() {
+	declare -gA module_options
+	source "${BATS_TEST_DIRNAME}/../../tools/modules/system/module_armbian_runners.sh"
+	TMP="$BATS_TEST_TMPDIR"
+	DELETED="$TMP/deleted"
+	: >"$DELETED"
+}
+
+# A curl stub: $LIST_FIXTURE is served for the runner listing, DELETEs are
+# recorded, and $LIST_CODE / $DELETE_CODE drive the HTTP status.
+_stub_curl() {
+	curl() {
+		local out="" is_delete=0 url="" prev=""
+		for a in "$@"; do
+			case "$prev" in -o) out="$a" ;; esac
+			case "$a" in DELETE) is_delete=1 ;; https://*) url="$a" ;; esac
+			prev="$a"
+		done
+		if (( is_delete )); then
+			echo "${url##*/}" >>"$DELETED"
+			[[ -n "$out" ]] && printf '' >"$out"
+			printf '%s' "${DELETE_CODE:-204}"
+		else
+			[[ -n "$out" ]] && printf '%s' "$LIST_FIXTURE" >"$out"
+			printf '%s' "${LIST_CODE:-200}"
+		fi
+	}
+}
+
+@test "remove_online: a GitHub error object fails cleanly, no jq crash" {
+	# Bad credentials => {"message":...} with no .runners. Piping that into
+	# .runners[] produced 'Cannot iterate over null (null)' and then carried
+	# on as though the org had no runners.
+	_stub_curl
+	LIST_CODE=401
+	LIST_FIXTURE='{"message":"Bad credentials","documentation_url":"https://docs.github.com"}'
+	run module_armbian_runners remove_online armbian-01 gh_token=xxx
+	[ "$status" -ne 0 ]
+	[[ "$output" != *"Cannot iterate over null"* ]]
+	[[ "$output" == *"Bad credentials"* ]]
+	[ ! -s "$DELETED" ]
+}
+
+@test "remove_online: refuses to run without a token" {
+	run module_armbian_runners remove_online armbian-01
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"token is mandatory"* ]]
+}
+
+@test "remove_online: deletes only the exactly matching runner" {
+	_stub_curl
+	LIST_FIXTURE='{"total_count":3,"runners":[{"id":11,"name":"armbian-01"},{"id":22,"name":"armbian-02"},{"id":33,"name":"other-01"}]}'
+	run module_armbian_runners remove_online armbian-02 gh_token=xxx
+	[ "$status" -eq 0 ]
+	[ "$(cat "$DELETED")" = "22" ]
+}
+
+@test "remove_online: a runner name with a glob does not delete the fleet" {
+	# [[ $name == $DELETE ]] with an unquoted right-hand side is a pattern
+	# match, so '*' matched - and deleted - every runner in the org.
+	_stub_curl
+	LIST_FIXTURE='{"total_count":2,"runners":[{"id":11,"name":"armbian-01"},{"id":22,"name":"armbian-02"}]}'
+	run module_armbian_runners remove_online '*' gh_token=xxx
+	[ ! -s "$DELETED" ]
+}
+
+@test "remove_online: an empty runner list is not an error" {
+	_stub_curl
+	LIST_FIXTURE='{"total_count":0,"runners":[]}'
+	run module_armbian_runners remove_online armbian-01 gh_token=xxx
+	[ "$status" -eq 0 ]
+	[ ! -s "$DELETED" ]
+}
+
+@test "remove_online: a busy runner (422) is reported, not swallowed" {
+	_stub_curl
+	LIST_FIXTURE='{"total_count":1,"runners":[{"id":11,"name":"armbian-01"}]}'
+	DELETE_CODE=422
+	run module_armbian_runners remove_online armbian-01 gh_token=xxx
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"422"* ]]
+}
+
+@test "params: a value containing '=' survives parsing" {
+	# IFS='=' read -a split kept only the first field, truncating such a value.
+	_stub_curl
+	LIST_FIXTURE='{"total_count":1,"runners":[{"id":11,"name":"a=b"}]}'
+	run module_armbian_runners remove_online 'a=b' gh_token=xx=yy
+	[ "$status" -eq 0 ]
+	[ "$(cat "$DELETED")" = "11" ]
+}
+
+@test "params: a value is never executed as code" {
+	# The old parser ran eval "$feature=$value" on whatever came off the
+	# command line. No spaces in the payload: the old parser word-split on
+	# those before eval saw them, which would mask the injection.
+	run module_armbian_runners remove_online armbian-01 "gh_token=\$(id>$TMP/pwned)"
+	[ ! -e "$TMP/pwned" ]
+}
+
+@test "help: documents the label fallback" {
+	run module_armbian_runners help
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"self-hosted"* ]]
+	[[ "$output" == *"same as label_primary"* ]]
+}

--- a/tools/modules/system/module_armbian_runners.sh
+++ b/tools/modules/system/module_armbian_runners.sh
@@ -261,9 +261,19 @@ function module_armbian_runners () {
 					label="${label_primary}"
 				fi
 
-				runuser -l "actions-runner-${i}" -c \
-				"./config.sh --url https://github.com/${registration_url} \
-				--token ${token} --labels '${label}' --name '${runner_name}-${i}' --unattended"
+				# config.sh is what actually registers the runner with GitHub. Its
+				# exit status has to be checked: svc.sh ships inside the tarball, so
+				# the -f test below is true whether or not registration succeeded, and
+				# installing a service for an unregistered runner leaves a unit that
+				# can never start. Unchecked, a failure here also left install_failed
+				# at 0 and the whole install reported success.
+				if ! runuser -l "actions-runner-${i}" -c \
+					"./config.sh --url https://github.com/${registration_url} \
+					--token ${token} --labels '${label}' --name '${runner_name}-${i}' --unattended"; then
+					echo "Failed to register runner ${runner_name}-${i} with ${registration_url}; skipping its service install." >&2
+					install_failed=1
+					continue
+				fi
 				if [[ -f /home/actions-runner-${i}/svc.sh ]]; then
 					sh -c "cd /home/actions-runner-${i} ; \
 					sudo ./svc.sh install actions-runner-${i} 2>/dev/null; \

--- a/tools/modules/system/module_armbian_runners.sh
+++ b/tools/modules/system/module_armbian_runners.sh
@@ -386,7 +386,8 @@ function module_armbian_runners () {
 			#   * internally by install/purge with positional args:
 			#       remove <runner_name> <index>
 			#   * directly via --api with named params and an index range:
-			#       remove runner_name=<n> start=<a> stop=<b> [organisation=..]
+			#       remove runner_name=<n> [start=<a> stop=<b>] [organisation=..]
+			#     start/stop default to 01, so a bare runner_name removes <n>-01.
 			# A bare (no '=') $2 is the positional form; otherwise the named
 			# params parsed above drive a start..stop range.
 			if [[ -z "${gh_token}" ]]; then
@@ -401,9 +402,13 @@ function module_armbian_runners () {
 				rm_indices="$3"
 			else
 				rm_name="${runner_name:-armbian}"
-				if [[ -n "${start}" || -n "${stop}" ]]; then
-					rm_indices="$(seq -w "${start:-01}" "${stop:-01}")"
-				fi
+				# Default the range to 01..01, the same way purge does. Leaving
+				# it empty fell through to the bare-name branch below, which
+				# looks for a runner literally called "<runner_name>" -- but
+				# runners are registered as "<runner_name>-NN", so
+				# `remove runner_name=xxx` matched nothing, could not map to a
+				# local user either, and reported success having done nothing.
+				rm_indices="$(seq -w "${start:-01}" "${stop:-01}")"
 			fi
 
 			local rm_failed=0 idx target runner_home
@@ -463,6 +468,14 @@ function module_armbian_runners () {
 			# but the host has nothing for it.
 			local delete_failed=0 x=1 page_body page_code listed
 			local per_page=100
+			# Track what we actually saw. Without this a name that matches
+			# nothing is indistinguishable from a successful delete: the caller
+			# printed "Removing runner X on GitHub", we silently matched zero
+			# runners, returned 0, and the caller went on to tear down the local
+			# side. That is how a stale registration survived a "successful"
+			# remove and then broke config.sh with "a runner exists with the
+			# same name".
+			local matched=0 seen=0
 
 			# Walk pages until one comes back short. The old loop asked for
 			# pages 1..9 unconditionally - nine API calls to delete one
@@ -506,7 +519,9 @@ function module_armbian_runners () {
 					# Quoted: an unquoted right-hand side is a glob, so a
 					# runner name containing * or ? matched - and deleted -
 					# every other runner in the org.
+					seen=$(( seen + 1 ))
 					if [[ "${RUNNER_NAME}" == "${DELETE}" ]]; then
+						matched=$(( matched + 1 ))
 						echo "Delete existing: ${RUNNER_NAME}"
 						local resp_body http_code
 						resp_body=$(mktemp)
@@ -531,6 +546,13 @@ function module_armbian_runners () {
 				[[ "$(printf '%s\n' "${listed}" | wc -l)" -lt "${per_page}" ]] && break
 				x=$(( x + 1 ))
 			done
+
+			# Say so when the name matched nothing. Not an error -- an already
+			# absent runner is the desired end state, and install's pre-remove
+			# step relies on that -- but it must not look like a deletion.
+			if (( matched == 0 )); then
+				echo "No runner named '${DELETE}' is registered in ${prefix}/${registration_url} (${seen} runner(s) listed); nothing to delete." >&2
+			fi
 			return $delete_failed
 		;;
 		"${commands[3]}")
@@ -558,7 +580,7 @@ function module_armbian_runners () {
 			echo -e "Commands:  install remove remove_online purge status help"
 			echo -e "Available commands:\n"
 			echo -e "\tinstall\t\t- Install or reinstall $title."
-			echo -e "\tremove\t\t- Remove a single runner (locally and on GitHub)."
+			echo -e "\tremove\t\t- Remove runners (locally and on GitHub); start/stop default to 01."
 			echo -e "\tremove_online\t- Remove matching runners on GitHub only."
 			echo -e "\tpurge\t\t- Purge $title."
 			echo -e "\tstatus\t\t- Status of $title."

--- a/tools/modules/system/module_armbian_runners.sh
+++ b/tools/modules/system/module_armbian_runners.sh
@@ -17,14 +17,24 @@ function module_armbian_runners () {
 	local condition=$(which "$title" 2>/dev/null)
 
 	# read parameters from command install
-	local parameter
+	#
+	# Assigned with printf -v against an allow-list rather than eval: these
+	# values come straight off the command line, and `eval "$feature=$value"`
+	# ran anything a value contained. Splitting on the FIRST '=' only also
+	# keeps values that themselves contain '=' intact - the old
+	# IFS='=' read -a split kept just the first field, silently truncating
+	# such a value.
+	local var kv key value
 	for var in "$@"; do
-		IFS=' ' read -r -a parameter <<< "${var}"
-		for feature in gh_token runner_name start stop label_primary label_secondary organisation owner repository; do
-			for selected in ${parameter[@]}; do
-				IFS='=' read -r -a split <<< "${selected}"
-				[[ ${split[0]} == $feature ]] && eval "$feature=${split[1]}"
-			done
+		# shellcheck disable=SC2086 # deliberate word split: one argument may carry several key=value pairs
+		for kv in ${var}; do
+			[[ "${kv}" == *=* ]] || continue
+			key="${kv%%=*}"
+			value="${kv#*=}"
+			case "${key}" in
+				gh_token|runner_name|start|stop|label_primary|label_secondary|organisation|owner|repository)
+					printf -v "${key}" '%s' "${value}" ;;
+			esac
 		done
 	done
 
@@ -88,15 +98,25 @@ function module_armbian_runners () {
 			local runner_name="${runner_name:-armbian}"
 			local start="${start:-01}"
 			local stop="${stop:-01}"
-			local label_primary="${label_primary:-alfa}"
-			local label_secondary="${label_secondary:-fast,images}"
 			local organisation="${organisation:-armbian}"
 			local owner="${owner}"
 			local repository="${repository}"
 
 			# workaround. Remove when parameters handling is fixed
-			local label_primary=$(echo $label_primary | sed "s/_/,/g") # convert
-			local label_secondary=$(echo $label_secondary | sed "s/_/,/g") # convert
+			label_primary="${label_primary//_/,}"
+			label_secondary="${label_secondary//_/,}"
+
+			# Label fallback.
+			#
+			# These used to be "${label_primary:-alfa}" and
+			# "${label_secondary:-fast,images}", but :- cannot tell an empty
+			# value from an unset one, so deliberately clearing the secondary
+			# label silently brought back "fast,images" on every runner after
+			# the first. An empty secondary now means "label them like the
+			# first one", and an empty primary falls back to the label GitHub
+			# gives every self-hosted runner anyway.
+			[[ -z "${label_primary}" ]] && label_primary="self-hosted"
+			[[ -z "${label_secondary}" ]] && label_secondary="${label_primary}"
 
 			# Docker preinstall is needed for our build framework
 			pkg_installed docker-ce || module_docker install
@@ -156,15 +176,50 @@ function module_armbian_runners () {
 				return 1
 			fi
 
-			# make runners each under its own user
-			for i in $(seq -w $start $stop)
+			# make runners each under its own user.
+			#
+			# The index list is materialised first so the "is this the first
+			# runner" test can compare against what seq actually produced.
+			# seq -w pads to the width of the widest bound, so `start=1
+			# stop=10` yields 01..10 and the old `[[ "$i" == "${start}" ]]`
+			# never matched - with unpadded bounds no runner got the primary
+			# label at all.
+			local -a runner_indices=()
+			mapfile -t runner_indices < <(seq -w "${start}" "${stop}")
+			if [[ ${#runner_indices[@]} -eq 0 ]]; then
+				echo "Refusing to install: start='${start}' stop='${stop}' selects no runners." >&2
+				runner_temp_cleanup
+				return 1
+			fi
+			local first_index="${runner_indices[0]}"
+			local install_failed=0
+
+			echo "Installing runners ${runner_indices[0]}..${runner_indices[-1]} for ${prefix}/${registration_url}"
+			echo "  ${runner_name}-${first_index} labels: ${label_primary}"
+			if [[ ${#runner_indices[@]} -gt 1 ]]; then
+				echo "  remaining runners labels: ${label_secondary}"
+			fi
+
+			local i
+			for i in "${runner_indices[@]}"
 			do
-				local token=$(curl -s \
+				local token
+				token=$(curl -s \
 				-X POST \
 				-H "Accept: application/vnd.github+json" \
 				-H "Authorization: Bearer ${gh_token}"\
 				-H "X-GitHub-Api-Version: 2022-11-28" \
-				https://api.github.com/${prefix}/${registration_url}/actions/runners/registration-token | jq -r .token)
+				https://api.github.com/${prefix}/${registration_url}/actions/runners/registration-token | jq -r '.token // empty')
+
+				# A rejected token, a wrong org or a rate limit all return a
+				# JSON error object here. Without this the empty/"null" token
+				# was handed to config.sh, which failed after the user had
+				# already been created and the old runner removed.
+				if [[ -z "${token}" ]]; then
+					echo "Could not get a registration token for ${prefix}/${registration_url} (runner ${i}); check the GitHub token and its scopes." >&2
+					install_failed=1
+					continue
+				fi
 
 				if ! ${module_options["module_armbian_runners,feature"]} ${commands[1]} ${runner_name} "${i}"; then
 					# `remove` returns non-zero when GitHub refused
@@ -180,23 +235,35 @@ function module_armbian_runners () {
 				adduser --quiet --disabled-password --shell /bin/bash \
 				--home /home/actions-runner-${i} --gecos "actions-runner-${i}" actions-runner-${i}
 
-				# add to sudoers
-				if ! sudo grep -q "actions-runner-${i}" /etc/sudoers; then
-					echo "actions-runner-${i} ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+				# add to sudoers via a drop-in, validated before it counts.
+				# Appending to /etc/sudoers directly means one malformed line
+				# locks every user out of sudo on the machine, with no way
+				# back in without a rescue boot.
+				install -d -m 0755 /etc/sudoers.d
+				local sudoers_tmp="/etc/sudoers.d/.actions-runner-${i}.tmp"
+				printf '%s ALL=(ALL) NOPASSWD: ALL\n' "actions-runner-${i}" > "${sudoers_tmp}"
+				chmod 0440 "${sudoers_tmp}"
+				if visudo -cf "${sudoers_tmp}" >/dev/null 2>&1; then
+					mv -f "${sudoers_tmp}" "/etc/sudoers.d/actions-runner-${i}"
+				else
+					rm -f "${sudoers_tmp}"
+					echo "Refusing to grant sudo to actions-runner-${i}: generated sudoers rule did not validate" >&2
+					install_failed=1
+					continue
 				fi
 				usermod -aG docker actions-runner-${i}
 				tar xzf "${runner_tarball}" -C /home/actions-runner-${i}
 				chown -R actions-runner-${i}:actions-runner-${i} /home/actions-runner-${i}
 
 				# 1st runner has different labels
-				local label=$label_secondary
-				if [[ "$i" == "${start}" ]]; then
-					local label=$label_primary
+				local label="${label_secondary}"
+				if [[ "${i}" == "${first_index}" ]]; then
+					label="${label_primary}"
 				fi
 
-				runuser -l actions-runner-${i} -c \
+				runuser -l "actions-runner-${i}" -c \
 				"./config.sh --url https://github.com/${registration_url} \
-				--token ${token} --labels ${label} --name ${runner_name}-${i} --unattended"
+				--token ${token} --labels '${label}' --name '${runner_name}-${i}' --unattended"
 				if [[ -f /home/actions-runner-${i}/svc.sh ]]; then
 					sh -c "cd /home/actions-runner-${i} ; \
 					sudo ./svc.sh install actions-runner-${i} 2>/dev/null; \
@@ -301,6 +368,7 @@ function module_armbian_runners () {
 			fi
 
 			runner_temp_cleanup
+			return $install_failed
 
 		;;
 		"${commands[1]}")
@@ -311,6 +379,12 @@ function module_armbian_runners () {
 			#       remove runner_name=<n> start=<a> stop=<b> [organisation=..]
 			# A bare (no '=') $2 is the positional form; otherwise the named
 			# params parsed above drive a start..stop range.
+			if [[ -z "${gh_token}" ]]; then
+				echo "Error: Github token is mandatory" >&2
+				${module_options["module_armbian_runners,feature"]} ${commands[5]}
+				return 1
+			fi
+
 			local rm_name rm_indices
 			if [[ -n "$2" && "$2" != *=* ]]; then
 				rm_name="$2"
@@ -353,56 +427,99 @@ function module_armbian_runners () {
 				fi
 				userdel -r -f actions-runner-${idx} 2>/dev/null
 				groupdel actions-runner-${idx} 2>/dev/null
-				sed -i "/^actions-runner-${idx}.*/d" /etc/sudoers
+				rm -f "/etc/sudoers.d/actions-runner-${idx}"
+				# Older installs appended straight to /etc/sudoers; clear those too.
+				sed -i "/^actions-runner-${idx}[[:space:]]/d" /etc/sudoers
 				[[ -n "${runner_home}" && ${runner_home} != "/" ]] && rm -rf "${runner_home}"
 			done
 			return $rm_failed
 		;;
 		"${commands[2]}")
-			DELETE=$2
-			x=1
+			local DELETE="$2"
+			if [[ -z "${gh_token}" ]]; then
+				echo "Error: Github token is mandatory" >&2
+				return 1
+			fi
+			if [[ -z "${DELETE}" ]]; then
+				echo "Error: no runner name given to ${commands[2]}" >&2
+				return 1
+			fi
+
 			# Failure flag — set on any non-204 DELETE response. The
 			# most common case is HTTP 422 'runner is currently
 			# running a job', which we don't want to silently swallow:
 			# without it the caller proceeds with local cleanup and
 			# leaves a half-state where GitHub thinks the runner exists
 			# but the host has nothing for it.
-			local delete_failed=0
-			while [ $x -le 9 ] # need to do it different as it can be more then 9 pages
-			do
-			RUNNER=$(
-			curl -s -L \
-			-H "Accept: application/vnd.github+json" \
-			-H "Authorization: Bearer ${gh_token}" \
-			-H "X-GitHub-Api-Version: 2022-11-28" \
-			https://api.github.com/${prefix}/${registration_url}/actions/runners\?page\=${x} \
-			| jq -r '.runners[] | .id, .name' | xargs -n2 -d'\n' | sed -e 's/ /,/g')
+			local delete_failed=0 x=1 page_body page_code listed
+			local per_page=100
 
-			while IFS= read -r DATA; do
-				RUNNER_ID=$(echo $DATA | cut -d"," -f1)
-				RUNNER_NAME=$(echo $DATA | cut -d"," -f2)
-				# deleting a runner
-				if [[ $RUNNER_NAME == ${DELETE} ]]; then
-					echo "Delete existing: $RUNNER_NAME"
-					local resp_body http_code
-					resp_body=$(mktemp)
-					http_code=$(curl -s -L \
-					-X DELETE \
-					-H "Accept: application/vnd.github+json" \
-					-H "Authorization: Bearer ${gh_token}"\
-					-H "X-GitHub-Api-Version: 2022-11-28" \
-					-o "${resp_body}" -w '%{http_code}' \
-					https://api.github.com/${prefix}/${registration_url}/actions/runners/${RUNNER_ID})
-					if [[ "$http_code" != "204" ]]; then
-						echo "  ! DELETE ${RUNNER_NAME} returned HTTP ${http_code}:" >&2
-						cat "${resp_body}" >&2
-						echo >&2
-						delete_failed=1
-					fi
-					rm -f "${resp_body}"
+			# Walk pages until one comes back short. The old loop asked for
+			# pages 1..9 unconditionally - nine API calls to delete one
+			# runner, and its own comment admitted a tenth page was out of
+			# reach. per_page=100 means one call covers most fleets.
+			while true; do
+				page_body=$(mktemp)
+				page_code=$(curl -s -L \
+				-H "Accept: application/vnd.github+json" \
+				-H "Authorization: Bearer ${gh_token}" \
+				-H "X-GitHub-Api-Version: 2022-11-28" \
+				-o "${page_body}" -w '%{http_code}' \
+				"https://api.github.com/${prefix}/${registration_url}/actions/runners?per_page=${per_page}&page=${x}")
+
+				# A bad token, a missing scope or a wrong org returns a JSON
+				# error object, whose .runners is null. Piping that straight
+				# into `.runners[]` is what produced
+				#   jq: error (at <stdin>:4): Cannot iterate over null (null)
+				# and then carried on as if no runners existed.
+				if [[ "${page_code}" != "200" ]]; then
+					echo "Listing runners for ${prefix}/${registration_url} failed with HTTP ${page_code}:" >&2
+					jq -r '.message // empty' "${page_body}" >&2 2>/dev/null || cat "${page_body}" >&2
+					rm -f "${page_body}"
+					return 1
 				fi
-			done <<< $RUNNER
-			x=$(( $x + 1 ))
+
+				if ! listed=$(jq -r '(.runners // [])[] | "\(.id),\(.name)"' "${page_body}" 2>/dev/null); then
+					echo "Could not parse the runner list for ${prefix}/${registration_url}" >&2
+					rm -f "${page_body}"
+					return 1
+				fi
+				rm -f "${page_body}"
+
+				[[ -z "${listed}" ]] && break
+
+				local DATA RUNNER_ID RUNNER_NAME
+				while IFS= read -r DATA; do
+					[[ -z "${DATA}" ]] && continue
+					RUNNER_ID="${DATA%%,*}"
+					RUNNER_NAME="${DATA#*,}"
+					# Quoted: an unquoted right-hand side is a glob, so a
+					# runner name containing * or ? matched - and deleted -
+					# every other runner in the org.
+					if [[ "${RUNNER_NAME}" == "${DELETE}" ]]; then
+						echo "Delete existing: ${RUNNER_NAME}"
+						local resp_body http_code
+						resp_body=$(mktemp)
+						http_code=$(curl -s -L \
+						-X DELETE \
+						-H "Accept: application/vnd.github+json" \
+						-H "Authorization: Bearer ${gh_token}"\
+						-H "X-GitHub-Api-Version: 2022-11-28" \
+						-o "${resp_body}" -w '%{http_code}' \
+						"https://api.github.com/${prefix}/${registration_url}/actions/runners/${RUNNER_ID}")
+						if [[ "$http_code" != "204" ]]; then
+							echo "  ! DELETE ${RUNNER_NAME} returned HTTP ${http_code}:" >&2
+							cat "${resp_body}" >&2
+							echo >&2
+							delete_failed=1
+						fi
+						rm -f "${resp_body}"
+					fi
+				done <<< "${listed}"
+
+				# A short page is the last page.
+				[[ "$(printf '%s\n' "${listed}" | wc -l)" -lt "${per_page}" ]] && break
+				x=$(( x + 1 ))
 			done
 			return $delete_failed
 		;;
@@ -412,9 +529,12 @@ function module_armbian_runners () {
 				${module_options["module_armbian_runners,feature"]} ${commands[5]}
 				exit 1
 			fi
-			for i in $(seq -w $start $stop); do
-				${module_options["module_armbian_runners,feature"]} ${commands[1]} ${runner_name} ${i}
+			# seq with empty bounds errors out; default them the way remove does.
+			local purge_failed=0 i
+			for i in $(seq -w "${start:-01}" "${stop:-01}"); do
+				${module_options["module_armbian_runners,feature"]} ${commands[1]} "${runner_name:-armbian}" "${i}" || purge_failed=1
 			done
+			return $purge_failed
 		;;
 		"${commands[4]}")
 			if [[ $(systemctl list-units --type=service --no-legend 2>/dev/null | grep -c actions.runner) -gt 0 ]]; then
@@ -438,8 +558,8 @@ function module_armbian_runners () {
 			echo -e "\trunner_name\t- name of the runner (series)."
 			echo -e "\tstart\t\t- start of serie (01)."
 			echo -e "\tstop\t\t- stop (01)."
-			echo -e "\tlabel_primary\t- runner tags for first runner (alfa)."
-			echo -e "\tlabel_secondary\t- runner tags for all others (images)."
+			echo -e "\tlabel_primary\t- runner tags for first runner (empty: self-hosted)."
+			echo -e "\tlabel_secondary\t- runner tags for all others (empty: same as label_primary)."
 			echo -e "\torganisation\t- GitHub organisation name (armbian)."
 			echo -e "\towner\t\t- GitHub owner."
 			echo -e "\trepository\t- GitHub repository (if adding only for repo)."


### PR DESCRIPTION
Both of Werner's reports reproduce. Looking at the module turned up more in the same code paths.

## What Werner hit

**Empty secondary label came back as `fast,images`.** `"${label_secondary:-fast,images}"` cannot tell an empty value from an unset one, so deliberately clearing the label silently restored the default — and because runner 01 uses the *primary* label, it only showed from runner 02 onward, exactly as described.

Per Igor's call, the fallback is now: an empty **secondary** means *label them like the first runner*; an empty **primary** falls back to `self-hosted`, which GitHub gives every self-hosted runner anyway. So leaving secondary blank now does the obvious thing — every runner gets the primary label.

**`jq: error (at <stdin>:4): Cannot iterate over null (null)` on removal.** A bad token, a missing scope or a wrong org returns a JSON error object whose `.runners` is null, and that went straight into `.runners[]`. Worse than the message: the loop then carried on as though the org had no runners, so removal reported success having done nothing. The HTTP status is now checked, the API's own message surfaced, and the filter defaults to an empty list.

`remove` and `remove_online` also never checked for a token, unlike `install` and `purge` — running either without one produced precisely this error. They now refuse up front.

**"primary label only respected for 01, looks like a general issue in the loop."** Werner was right that something was wrong, though not quite where he thought. Per-runner labels are by design (documented: primary for the first, secondary for the rest), but the first runner was picked with `[[ "$i" == "${start}" ]]`, and `seq -w` pads to the width of the widest bound. With `start=1 stop=10` it yields `01..10`, that comparison never matches, and **no runner gets the primary label at all**. Only zero-padded bounds happened to work. The index list is now materialised once and the first element compared against. Both label sets are printed before the fleet is touched, so the plan is visible before anything is removed.

## Found while in there

- `[[ $RUNNER_NAME == ${DELETE} ]]` — unquoted right-hand side is a **glob**. A runner named `*` matched, and deleted, every runner in the org.
- The listing asked for pages 1..9 **unconditionally** — nine API calls to delete one runner — and its own comment admitted a tenth page was unreachable. It now pages until a short page, 100 per call.
- `eval "$feature=${split[1]}"` **executed whatever a parameter value contained**. Values are now assigned with `printf -v` against an allow-list. The same change splits on the first `=` only, so a value containing `=` is no longer truncated to its first field.
- A failed registration-token call handed an empty token to `config.sh` — *after* the user had been created and the old runner removed. Checked first now.
- sudo rights were granted by appending to `/etc/sudoers`. One malformed line there locks every user out of sudo with no way back without a rescue boot. Now a `visudo`-validated `/etc/sudoers.d` drop-in; removal cleans up both the drop-in and the legacy appended line.
- `purge` ran `seq` with empty bounds; `install` always returned success regardless of what failed.

## Tests

`tests/bats/runners.bats` is new — the module had no coverage — and drives the real functions against a stubbed GitHub API: the error-object case, the missing token, exact-match deletion, the glob, an empty fleet, a busy runner returning 422, a value containing `=`, command injection through a parameter, and the documented fallback.

**8 of its 9 cases fail against the current module.** The ninth (empty fleet) passes either way and is there as a guard.

Full suite: 126 passing, 0 failing. The new file is wired into `maintenance-bats.yml`.

## Worth a second opinion

The label semantics are now: primary → first runner, secondary → the rest, empty secondary → same as primary. If the intent was ever that primary applies to *all* runners with secondary as extra labels on the others, say so and I'll change it — that reading of Werner's message is also defensible, and it's a fleet-wide behaviour change either way.
